### PR TITLE
Give builtin ADTs a TypeDecl

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.245"
+let supported_charon_version = "0.1.246"

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -449,41 +449,6 @@ let match_literal (pl : literal) (l : Values.literal) : bool =
   | LChar pv, VChar v -> Uchar.of_char pv = v
   | _ -> false
 
-let generic_args_match_params (params : T.generic_params)
-    (args : T.generic_args) : bool =
-  let pr, pt, pc, ptr = TypesUtils.generic_params_lengths params in
-  let ar, at, ac, atr = TypesUtils.generic_args_lengths args in
-  pr = ar && pt = at && pc = ac && ptr = atr
-
-(* Instantiate the provided generics with the given binder, if any. *)
-let instantiate_name_generics (binder : T.generic_args T.binder)
-    (g : T.generic_args) : T.generic_args =
-  if binder.binder_params = TypesUtils.empty_generic_params then begin
-    (* HACK: Monomorphization doesn't handle late-bound regions properly, so we
-       append them here manually. *)
-    let regions_count, types_count, const_generics_count, trait_refs_count =
-      TypesUtils.generic_args_lengths g
-    in
-    (* We additionally append the regions from `g` to the monomorphized args, so that we can match against them. *)
-    assert (types_count = 0 && const_generics_count = 0 && trait_refs_count = 0);
-    {
-      binder.binder_value with
-      (* Late-bound regions are appended after the monomorphized ones. *)
-      regions = binder.binder_value.regions @ g.regions;
-    }
-  end
-  else if g = TypesUtils.empty_generic_args then
-    (* The caller did not provide generics for the instantiated item, we keep that so. *)
-    g
-  else begin
-    if not (generic_args_match_params binder.binder_params g) then
-      failwith
-        "(partially) monomorphized generic parameters do not match the \
-         supplied generic arguments";
-    Substitute.apply_args_to_binder g
-      Substitute.st_substitute_visitor#visit_generic_args binder
-  end
-
 let rec match_name_with_generics (ctx : ctx) (c : match_config)
     ?(m : maps = mk_empty_maps ()) (p : pattern) (n : T.name)
     (g : T.generic_args) : bool =
@@ -494,7 +459,7 @@ let rec match_name_with_generics (ctx : ctx) (c : match_config)
   let n, g =
     match List.rev n with
     | PeInstantiated binder :: rest_rev ->
-        let g = instantiate_name_generics binder g in
+        let g = Substitute.instantiate_name_generics binder g in
         (List.rev rest_rev, g)
     | _ -> (n, g)
   in
@@ -513,6 +478,8 @@ let rec match_name_with_generics (ctx : ctx) (c : match_config)
       && match_generic_args ctx c m pg g
   | [ PIdent (pid, pd, pg) ], [ PeTarget target ] ->
       pid = target && pd = 0 && match_generic_args ctx c m pg g
+  | [ PIdent ("str", 0, pg) ], [ PeBuiltin PeStr ] ->
+      match_generic_args ctx c m pg g
   | [ PImpl pty ], [ PeImpl impl ] -> (
       (* We can get there when matching a prefix of the name with a pattern *)
       (* We have to distinguish two cases:
@@ -556,26 +523,24 @@ and match_name (ctx : ctx) (c : match_config) (p : pattern) (n : T.name) : bool
     =
   match_name_with_generics ctx c p n TypesUtils.empty_generic_args
 
-and match_pattern_with_type_id (ctx : ctx) (c : match_config) (m : maps)
-    (pid : pattern) (id : T.type_id) (generics : T.generic_args) : bool =
-  match id with
-  | TAdtId id ->
-      (* Lookup the type decl and match the name *)
+and match_pattern_with_type_decl_id (ctx : ctx) (c : match_config) (m : maps)
+    (pid : pattern) (id : T.type_decl_id) (builtin : T.builtin_ty option)
+    (generics : T.generic_args) : bool =
+  match (builtin, pid) with
+  | None, _ ->
       let d = T.TypeDeclId.Map.find id ctx.crate.type_decls in
       match_name_with_generics ctx c ~m pid d.item_meta.name generics
-  | TBuiltin TTuple -> false
-  | TBuiltin id -> (
-      match (id, pid) with
-      | ( TBox,
-          ( [ PIdent ("Box", _, pgenerics) ]
-          | [
-              PIdent ("alloc", _, []);
-              PIdent ("boxed", _, []);
-              PIdent ("Box", _, pgenerics);
-            ] ) ) -> match_generic_args ctx c m pgenerics generics
-      | TStr, [ PIdent ("str", _, []) ] ->
-          generics = TypesUtils.empty_generic_args
-      | _ -> false)
+  | Some TTuple, _ -> false
+  | ( Some TBox,
+      ( [ PIdent ("Box", _, pgenerics) ]
+      | [
+          PIdent ("alloc", _, []);
+          PIdent ("boxed", _, []);
+          PIdent ("Box", _, pgenerics);
+        ] ) ) -> match_generic_args ctx c m pgenerics generics
+  | Some TStr, [ PIdent ("str", _, []) ] ->
+      generics = TypesUtils.empty_generic_args
+  | Some _, _ -> false
 
 and match_pattern_with_literal_type (pty : pattern) (ty : T.literal_type) : bool
     =
@@ -589,7 +554,8 @@ and match_expr_with_ty (ctx : ctx) (c : match_config) (m : maps) (pty : expr)
     (ty : T.ty) : bool =
   match (pty, ty) with
   | EComp pid, TAdt tref ->
-      match_pattern_with_type_id ctx c m pid tref.id tref.generics
+      match_pattern_with_type_decl_id ctx c m pid tref.id tref.builtin
+        tref.generics
   | EComp pid, TLiteral lit -> match_pattern_with_literal_type pid lit
   | EPrimAdt (pid, pgenerics), ty -> begin
       match (pid, ty) with
@@ -613,9 +579,9 @@ and match_expr_with_ty (ctx : ctx) (c : match_config) (m : maps) (pty : expr)
             }
           in
           match_generic_args ctx c m pgenerics generics
-      | TTuple, TAdt tref ->
-          tref.id = TBuiltin TTuple
-          && match_generic_args ctx c m pgenerics tref.generics
+      | TTuple, TAdt ({ builtin = Some TTuple; _ } as tref) ->
+          match_generic_args ctx c m pgenerics
+            (Substitute.type_decl_ref_generics ctx.crate.type_decls tref)
       | _ -> false
     end
   | ERef (pr, pty, prk), TRef (r, ty, rk) ->
@@ -966,7 +932,7 @@ and name_with_generics_to_pattern_aux (ctx : ctx) (c : to_pat_config)
   let n, generics =
     match List.rev n with
     | PeInstantiated binder :: rest_rev ->
-        (List.rev rest_rev, instantiate_name_generics binder generics)
+        (List.rev rest_rev, Substitute.instantiate_name_generics binder generics)
     | _ -> (n, generics)
   in
   let generics = generic_args_to_pattern ctx c m generics in
@@ -991,6 +957,13 @@ and path_elem_with_generic_args_to_pattern (ctx : ctx) (c : to_pat_config)
       (* In pattern generation, we skip monomorphized elements since patterns
          are meant to match the logical structure, not the instantiation details *)
       []
+  | PeBuiltin PeStr -> begin
+      match generics with
+      | None -> [ PIdent ("str", 0, []) ]
+      | Some args -> [ PIdent ("str", 0, args) ]
+    end
+  | PeBuiltin (PeTuple _) ->
+      failwith "Can't convert the name of a tuple to a pattern"
 
 and impl_elem_to_pattern (ctx : ctx) (c : to_pat_config) (impl : T.impl_elem) :
     pattern_elem =
@@ -1013,19 +986,25 @@ and ty_to_pattern_aux (ctx : ctx) (c : to_pat_config) (m : constraints)
     (ty : T.ty) : expr =
   match ty with
   | TAdt tref -> (
-      match tref.id with
-      | TAdtId id ->
+      match tref.builtin with
+      | None ->
           (* Lookup the declaration *)
-          let d = T.TypeDeclId.Map.find id ctx.crate.type_decls in
+          let d = T.TypeDeclId.Map.find tref.id ctx.crate.type_decls in
           EComp
             (name_with_generics_to_pattern_aux ctx c m d.item_meta.name
                tref.generics)
-      | TBuiltin id -> (
-          let generics = generic_args_to_pattern ctx c m tref.generics in
-          match id with
-          | TTuple -> EPrimAdt (TTuple, generics)
-          | TBox -> EComp [ PIdent ("Box", 0, generics) ]
-          | TStr -> EComp [ PIdent ("str", 0, generics) ]))
+      | Some TTuple ->
+          let args =
+            Substitute.type_decl_ref_generics ctx.crate.type_decls tref
+          in
+          EPrimAdt (TTuple, generic_args_to_pattern ctx c m args)
+      | Some TBox ->
+          EComp
+            [ PIdent ("Box", 0, generic_args_to_pattern ctx c m tref.generics) ]
+      | Some TStr ->
+          EComp
+            [ PIdent ("str", 0, generic_args_to_pattern ctx c m tref.generics) ]
+      )
   | TVar v -> EVar (type_var_to_pattern m v)
   | TLiteral lit -> literal_type_to_pattern c lit
   | TRef (r, ty, rk) ->

--- a/charon-ml/src/Print.ml
+++ b/charon-ml/src/Print.ml
@@ -124,9 +124,6 @@ let region_binder_to_string value_to_string env rb =
           Format.pp_print_string fmt (value_to_string env value))
         env fmt rb)
 
-let type_id_to_string env id =
-  PrintFmt.pp_to_string (fun fmt -> PrintFmt.pp_type_id env fmt id)
-
 let type_decl_id_to_string env def_id =
   PrintFmt.pp_to_string (fun fmt -> PrintFmt.pp_type_decl_id env fmt def_id)
 

--- a/charon-ml/src/PrintFmt.ml
+++ b/charon-ml/src/PrintFmt.ml
@@ -383,33 +383,15 @@ let abi_prefix (abi : abi) : string =
   | AbiRust -> ""
   | _ -> "extern \"" ^ abi_name abi ^ "\" "
 
-let rec pp_type_id (env : fmt_env) (fmt : Format.formatter) (id : type_id) :
-    unit =
-  match id with
-  | TAdtId id -> pp_type_decl_id env fmt id
-  | TBuiltin aty -> (
-      match aty with
-      | TTuple -> ()
-      | TBox -> pp_string fmt "alloc::boxed::Box"
-      | TStr -> pp_string fmt "str")
-
-and pp_type_decl_id env fmt def_id =
+let rec pp_type_decl_id env fmt def_id =
   match find_short_name env (IdType def_id) with
   | Some name -> pp_name env fmt name
   | None -> pp_string fmt (type_decl_id_to_pretty_string def_id)
 
 and pp_type_decl_ref (env : fmt_env) (fmt : Format.formatter)
     (tref : type_decl_ref) : unit =
-  match tref.id with
-  | TBuiltin TTuple ->
-      let params, _trait_refs = generic_args_to_strings env tref.generics in
-      let trailing_comma = if List.length params = 1 then "," else "" in
-      Format.fprintf fmt "(%a%s)"
-        (pp_sep_list ", " pp_string)
-        params trailing_comma
-  | id ->
-      Format.fprintf fmt "%a%a" (pp_type_id env) id (pp_generic_args env)
-        tref.generics
+  Format.fprintf fmt "%a%a" (pp_type_decl_id env) tref.id (pp_generic_args env)
+    tref.generics
 
 and pp_fun_decl_id (env : fmt_env) (fmt : Format.formatter) (id : FunDeclId.id)
     : unit =
@@ -476,32 +458,30 @@ and pp_unsizing_metadata (env : fmt_env) (fmt : Format.formatter)
 
 and pp_const_aggregate (env : fmt_env) (tref : type_decl_ref) opt_variant_id
     (fmt : Format.formatter) (fields : constant_expr list) : unit =
-  match tref.id with
-  | TBuiltin TTuple ->
-      let trailing_comma = if List.length fields = 1 then "," else "" in
-      Format.fprintf fmt "(%a%s)"
-        (pp_sep_list ", " (pp_constant_expr env))
-        fields trailing_comma
-  | TAdtId def_id ->
-      let fields =
-        match adt_field_names env def_id opt_variant_id with
-        | None ->
-            fields
-            |> List.mapi (fun i value ->
-                   (FieldId.to_string (FieldId.of_int i), value))
-        | Some field_names -> List.combine field_names fields
-      in
-      let pp_variant fmt =
-        match opt_variant_id with
-        | None -> pp_type_decl_id env fmt def_id
-        | Some variant_id -> pp_adt_variant env def_id fmt variant_id
-      in
-      Format.fprintf fmt "%t { %a }" pp_variant
-        (pp_sep_list ", " (fun fmt (field, value) ->
-             Format.fprintf fmt "%s: %a" field (pp_constant_expr env) value))
-        fields
-  | TBuiltin TBox -> raise (Failure "Unexpected Box constant aggregate")
-  | TBuiltin TStr -> raise (Failure "Unexpected str constant aggregate")
+  if tref.builtin = Some TTuple then
+    let trailing_comma = if List.length fields = 1 then "," else "" in
+    Format.fprintf fmt "(%a%s)"
+      (pp_sep_list ", " (pp_constant_expr env))
+      fields trailing_comma
+  else
+    let def_id = tref.id in
+    let fields =
+      match adt_field_names env def_id opt_variant_id with
+      | None ->
+          fields
+          |> List.mapi (fun i value ->
+                 (FieldId.to_string (FieldId.of_int i), value))
+      | Some field_names -> List.combine field_names fields
+    in
+    let pp_variant fmt =
+      match opt_variant_id with
+      | None -> pp_type_decl_id env fmt def_id
+      | Some variant_id -> pp_adt_variant env def_id fmt variant_id
+    in
+    Format.fprintf fmt "%t { %a }" pp_variant
+      (pp_sep_list ", " (fun fmt (field, value) ->
+           Format.fprintf fmt "%s: %a" field (pp_constant_expr env) value))
+      fields
 
 and pp_constant_expr (env : fmt_env) (fmt : Format.formatter)
     (cv : constant_expr) : unit =
@@ -594,6 +574,16 @@ and pp_fn_ptr (env : fmt_env) (fmt : Format.formatter) (ptr : fn_ptr) : unit =
 
 and pp_ty (env : fmt_env) (fmt : Format.formatter) (ty : ty) : unit =
   match ty with
+  | TAdt ({ builtin = Some TTuple; _ } as tref) ->
+      (* Print tuples as `(T1, T2, ...)` instead of `(_, _, ...)<T1, T2, ...>`. *)
+      let fields =
+        (Substitute.type_decl_ref_generics env.crate.type_decls tref).types
+      in
+      let trailing_comma = if List.length fields = 1 then "," else "" in
+      Format.fprintf fmt "(%a%s)"
+        (pp_sep_list ", " (pp_ty env))
+        fields trailing_comma
+  | TAdt { builtin = Some TStr; _ } -> pp_string fmt "str"
   | TAdt tref -> pp_type_decl_ref env fmt tref
   | TVar tv -> pp_string fmt (type_db_var_to_string env tv)
   | TNever -> pp_string fmt "!"
@@ -921,6 +911,15 @@ and pp_path_elem (env : fmt_env) (fmt : Format.formatter) (e : path_elem) : unit
       let explicits, _ = generic_args_to_strings env binder.binder_value in
       Format.fprintf fmt "<%a>" (pp_sep_list ", " pp_string) explicits
   | PeTarget target -> pp_string fmt target
+  (* Written the same way as the types themselves, trailing comma included, so
+     that a declaration and its uses don't look like different types. *)
+  | PeBuiltin (PeTuple n) ->
+      let trailing_comma = if n = 1 then "," else "" in
+      Format.fprintf fmt "(%a%s)"
+        (pp_sep_list ", " pp_string)
+        (List.init n (fun _ -> "_"))
+        trailing_comma
+  | PeBuiltin PeStr -> pp_string fmt "str"
 
 and pp_name (env : fmt_env) (fmt : Format.formatter) (n : name) : unit =
   let env = { env with generics = [] } in
@@ -1218,7 +1217,18 @@ let pp_item_intro (env : fmt_env) (indent : string) (keyword : string)
     match has_short_name env id with
     | Some short_name ->
         (name_to_string env short_name, "// Full name: " ^ full_name ^ "\n")
-    | None -> (full_name, "")
+    | None ->
+        let shortens =
+          List.exists
+            (function
+              | PeImpl (ImplElemTrait impl_id) ->
+                  Option.is_some (trait_impl_short_name env impl_id)
+              | _ -> false)
+            meta.name
+        in
+        if shortens then
+          (name_to_string env meta.name, "// Full name: " ^ full_name ^ "\n")
+        else (full_name, "")
   in
   let attributes =
     List.filter_map
@@ -1381,22 +1391,27 @@ let rec pp_projection_elem (env : fmt_env) (subplace : place)
       in
       Format.fprintf fmt "%s[%s..%s]" sub (operand_to_string env from) to_
   | Field (opt_variant_id, fid) -> (
-      match fst (ty_as_adt subplace.ty) with
-      | TBuiltin TTuple ->
-          Format.fprintf fmt "%s.%s" sub (FieldId.to_string fid)
-      | TAdtId adt_id -> (
-          let field_name =
-            match adt_field_to_string env adt_id opt_variant_id fid with
-            | Some field_name -> field_name
-            | None -> FieldId.to_string fid
-          in
-          match opt_variant_id with
-          | None -> Format.fprintf fmt "%s.%s" sub field_name
-          | Some variant_id ->
-              Format.fprintf fmt "(%s as variant %a).%s" sub
-                (pp_adt_variant env adt_id)
-                variant_id field_name)
-      | TBuiltin _ -> raise (Failure "Unreachable"))
+      (* The type of the sub-place tells us which declaration the field comes
+         from. *)
+      let adt = ty_as_opt_adt subplace.ty in
+      let field_name =
+        match
+          Option.bind adt (fun adt ->
+              adt_field_to_string env adt.id opt_variant_id fid)
+        with
+        | Some field_name -> field_name
+        | None -> FieldId.to_string fid
+      in
+      match (opt_variant_id, adt) with
+      | None, _ -> Format.fprintf fmt "%s.%s" sub field_name
+      | Some variant_id, Some adt ->
+          Format.fprintf fmt "(%s as variant %a).%s" sub
+            (pp_adt_variant env adt.id)
+            variant_id field_name
+      | Some variant_id, None ->
+          Format.fprintf fmt "(%s as variant %s).%s" sub
+            (variant_id_to_pretty_string variant_id)
+            field_name)
   | PtrMetadata -> Format.fprintf fmt "%s.metadata" sub
 
 and pp_place (env : fmt_env) (fmt : Format.formatter) (p : place) : unit =
@@ -1429,11 +1444,7 @@ and pp_nullop (env : fmt_env) (fmt : Format.formatter) (op : nullop) : unit =
   | SizeOf -> pp_string fmt "size_of"
   | AlignOf -> pp_string fmt "align_of"
   | OffsetOf (ty, opt_variant_id, field_id) ->
-      let def_id =
-        match ty.id with
-        | TAdtId def_id -> Some def_id
-        | _ -> None
-      in
+      let def_id = Some ty.id in
       let variant_name =
         match (def_id, opt_variant_id) with
         | Some def_id, Some variant_id -> (
@@ -1511,43 +1522,39 @@ and pp_aggregate (env : fmt_env) (agg : aggregate_kind) (fmt : Format.formatter)
     (fields : operand list) : unit =
   let fields = List.map (operand_to_string env) fields in
   match agg with
-  | AggregatedAdt (tref, opt_variant_id, opt_field_id) -> (
-      match tref.id with
-      | TBuiltin TTuple ->
-          let trailing_comma = if List.length fields = 1 then "," else "" in
-          Format.fprintf fmt "(%a%s)"
-            (pp_sep_list ", " pp_string)
-            fields trailing_comma
-      | TBuiltin TBox ->
-          Format.fprintf fmt "Box(%a)" (pp_sep_list ", " pp_string) fields
-      | TBuiltin TStr ->
-          Format.fprintf fmt "[%a]" (pp_sep_list ", " pp_string) fields
-      | TAdtId def_id ->
-          let pp_variant fmt =
-            match opt_variant_id with
-            | None -> pp_type_decl_id env fmt def_id
-            | Some variant_id -> pp_adt_variant env def_id fmt variant_id
-          in
-          let fields =
-            match adt_field_names env def_id opt_variant_id with
-            | None ->
-                fields
-                |> List.mapi (fun i value ->
-                       FieldId.to_string (FieldId.of_int i) ^ ": " ^ value)
-            | Some field_names ->
-                let field_names =
-                  match opt_field_id with
-                  | None -> field_names
-                  (* Only keep the selected field *)
-                  | Some field_id ->
-                      [ List.nth field_names (FieldId.to_int field_id) ]
-                in
-                let fields = List.combine field_names fields in
-                List.map (fun (field, value) -> field ^ ": " ^ value) fields
-          in
-          Format.fprintf fmt "%t { %a }" pp_variant
-            (pp_sep_list ", " pp_string)
-            fields)
+  | AggregatedAdt (tref, opt_variant_id, opt_field_id) ->
+      if tref.builtin = Some TTuple then
+        let trailing_comma = if List.length fields = 1 then "," else "" in
+        Format.fprintf fmt "(%a%s)"
+          (pp_sep_list ", " pp_string)
+          fields trailing_comma
+      else
+        let def_id = tref.id in
+        let pp_variant fmt =
+          match opt_variant_id with
+          | None -> pp_type_decl_id env fmt def_id
+          | Some variant_id -> pp_adt_variant env def_id fmt variant_id
+        in
+        let fields =
+          match adt_field_names env def_id opt_variant_id with
+          | None ->
+              fields
+              |> List.mapi (fun i value ->
+                     FieldId.to_string (FieldId.of_int i) ^ ": " ^ value)
+          | Some field_names ->
+              let field_names =
+                match opt_field_id with
+                | None -> field_names
+                (* Only keep the selected field *)
+                | Some field_id ->
+                    [ List.nth field_names (FieldId.to_int field_id) ]
+              in
+              let fields = List.combine field_names fields in
+              List.map (fun (field, value) -> field ^ ": " ^ value) fields
+        in
+        Format.fprintf fmt "%t { %a }" pp_variant
+          (pp_sep_list ", " pp_string)
+          fields
   | AggregatedArray (_ty, _cg) ->
       Format.fprintf fmt "[%a]" (pp_sep_list ", " pp_string) fields
   | AggregatedRawPtr (_, refk) ->
@@ -2094,7 +2101,7 @@ module Llbc = struct
             let p = place_to_string env place in
             let discr_type =
               match place.ty with
-              | TAdt { id = TAdtId type_id; _ } -> Some type_id
+              | TAdt tref -> Some tref.id
               | _ -> None
             in
             let indent1 = indent ^ indent_incr in

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -479,6 +479,53 @@ let apply_args_to_item_binder (tr_self : trait_ref_kind) (args : generic_args)
   in
   substitutor (subst_free_vars subst) binder.item_binder_value
 
+let generic_args_match_params (params : Types.generic_params)
+    (args : Types.generic_args) : bool =
+  let pr, pt, pc, ptr = TypesUtils.generic_params_lengths params in
+  let ar, at, ac, atr = TypesUtils.generic_args_lengths args in
+  pr = ar && pt = at && pc = ac && ptr = atr
+
+(* Instantiate the provided generics with the given binder, if any. *)
+let instantiate_name_generics (binder : Types.generic_args Types.binder)
+    (g : Types.generic_args) : Types.generic_args =
+  if binder.binder_params = TypesUtils.empty_generic_params then begin
+    (* HACK: Monomorphization doesn't handle late-bound regions properly, so we
+       append them here manually. *)
+    let regions_count, types_count, const_generics_count, trait_refs_count =
+      TypesUtils.generic_args_lengths g
+    in
+    (* We additionally append the regions from `g` to the monomorphized args, so that we can match against them. *)
+    assert (types_count = 0 && const_generics_count = 0 && trait_refs_count = 0);
+    {
+      binder.binder_value with
+      (* Late-bound regions are appended after the monomorphized ones. *)
+      regions = binder.binder_value.regions @ g.regions;
+    }
+  end
+  else if g = TypesUtils.empty_generic_args then
+    (* The caller did not provide generics for the instantiated item, we keep that so. *)
+    g
+  else begin
+    if not (generic_args_match_params binder.binder_params g) then
+      failwith
+        "(partially) monomorphized generic parameters do not match the \
+         supplied generic arguments";
+    apply_args_to_binder g st_substitute_visitor#visit_generic_args binder
+  end
+
+(** The arguments this type was declared with, i.e. the ones it had before
+    (partial) monomorphization: monomorphization moves the arguments of an item
+    into its name, so we look for them there. *)
+let type_decl_ref_generics (type_decls : type_decl TypeDeclId.Map.t)
+    (tref : type_decl_ref) : generic_args =
+  match TypeDeclId.Map.find_opt tref.id type_decls with
+  | Some decl -> (
+      match List.rev decl.item_meta.name with
+      | PeInstantiated binder :: _ ->
+          instantiate_name_generics binder tref.generics
+      | _ -> tref.generics)
+  | None -> tref.generics
+
 (** Merge two levels of binders into a single one that binds the concatenated
     params. Useful for consumers that don't want to have to handle method
     binders. *)

--- a/charon-ml/src/TypesUtils.ml
+++ b/charon-ml/src/TypesUtils.ml
@@ -74,7 +74,8 @@ let type_decl_is_enum (def : type_decl) : bool =
 
 (** The declaration of the unit type [()]. Tuples get one declaration per arity;
     charon reserves the very first id for the 0-tuple so that we can name it
-    without looking at the crate. *)
+    without looking at the crate. With [--no-gen-tuple-structs], this is instead
+    the (opaque) declaration of every tuple. *)
 let unit_type_decl_id : type_decl_id = TypeDeclId.of_int 0
 
 (** The unit type *)

--- a/charon-ml/src/TypesUtils.ml
+++ b/charon-ml/src/TypesUtils.ml
@@ -72,32 +72,41 @@ let type_decl_is_enum (def : type_decl) : bool =
   | Enum _ -> true
   | _ -> false
 
-(** Return [true] if a {!type:Charon.Types.ty} is actually [unit] *)
-let ty_is_unit (ty : ty) : bool =
-  match ty with
-  | TAdt
-      {
-        id = TBuiltin TTuple;
-        generics =
-          { regions = []; types = []; const_generics = []; trait_refs = _ };
-      } -> true
-  | _ -> false
+(** The declaration of the unit type [()]. Tuples get one declaration per arity;
+    charon reserves the very first id for the 0-tuple so that we can name it
+    without looking at the crate. *)
+let unit_type_decl_id : type_decl_id = TypeDeclId.of_int 0
 
-let ty_as_opt_adt (ty : ty) : (type_id * generic_args) option =
+(** The unit type *)
+let mk_unit_ty : ty =
+  TAdt
+    {
+      id = unit_type_decl_id;
+      generics =
+        { regions = []; types = []; const_generics = []; trait_refs = [] };
+      builtin = Some TTuple;
+    }
+
+(** Return [true] if a {!type:Charon.Types.ty} is actually [unit]. The 0-tuple
+    takes no arguments, so it is the same type before and after
+    monomorphization. *)
+let ty_is_unit (ty : ty) : bool = ty = mk_unit_ty
+
+let ty_as_opt_adt (ty : ty) : type_decl_ref option =
   match ty with
-  | TAdt tref -> Some (tref.id, tref.generics)
+  | TAdt tref -> Some tref
   | _ -> None
 
 let ty_is_adt (ty : ty) : bool = Option.is_some (ty_as_opt_adt ty)
 
-let ty_as_adt (ty : ty) : type_id * generic_args =
+let ty_as_adt (ty : ty) : type_decl_ref =
   match ty_as_opt_adt ty with
-  | Some (id, generics) -> (id, generics)
+  | Some tref -> tref
   | None -> raise (Failure "Unreachable")
 
 let ty_as_builtin_adt_opt (ty : ty) : (builtin_ty * generic_args) option =
   match ty with
-  | TAdt { id = TBuiltin id; generics } -> Some (id, generics)
+  | TAdt { builtin = Some id; generics; _ } -> Some (id, generics)
   | _ -> None
 
 let ty_is_builtin_adt (ty : ty) : bool =
@@ -139,12 +148,12 @@ let ty_as_ref (ty : ty) : region * ty * ref_kind =
 
 let ty_is_custom_adt (ty : ty) : bool =
   match ty with
-  | TAdt { id = TAdtId _; _ } -> true
+  | TAdt { builtin = None; _ } -> true
   | _ -> false
 
 let ty_as_custom_adt (ty : ty) : TypeDeclId.id * generic_args =
   match ty with
-  | TAdt { id = TAdtId id; generics } -> (id, generics)
+  | TAdt { id; generics; builtin = None } -> (id, generics)
   | _ -> raise (Failure "Unreachable")
 
 let ty_as_literal (ty : ty) : literal_type =
@@ -236,16 +245,12 @@ let generic_args_of_params span (generics : generic_params) : generic_args =
   in
   { regions; types; const_generics; trait_refs }
 
-(** The unit type *)
-let mk_unit_ty : ty =
-  TAdt { id = TBuiltin TTuple; generics = empty_generic_args }
-
 (** The usize type *)
 let mk_usize_ty : ty = TLiteral (TUInt Usize)
 
 let ty_as_opt_box (box_ty : ty) : ty option =
   match box_ty with
-  | TAdt { id = TBuiltin TBox; generics = { types = [ boxed_ty ]; _ } } ->
+  | TAdt { generics = { types = [ boxed_ty ]; _ }; builtin = Some TBox; _ } ->
       Some boxed_ty
   | _ -> None
 
@@ -267,9 +272,15 @@ let ty_get_ref (ty : ty) : region * ty * ref_kind =
 let mk_ref_ty (r : region) (ty : ty) (ref_kind : ref_kind) : ty =
   TRef (r, ty, ref_kind)
 
-(** Make a box type *)
-let mk_box_ty (ty : ty) : ty =
-  TAdt { id = TBuiltin TBox; generics = mk_generic_args_from_types [ ty ] }
+(** Make a box type. [Box] is declared like any other ADT, so the caller has to
+    supply the id of its declaration. *)
+let mk_box_ty (box_id : type_decl_id) (ty : ty) : ty =
+  TAdt
+    {
+      id = box_id;
+      generics = mk_generic_args_from_types [ ty ];
+      builtin = Some TBox;
+    }
 
 (* TODO: move region set manipulation to aeneas *)
 

--- a/charon-ml/src/generated/Generated_FullAst.ml
+++ b/charon-ml/src/generated/Generated_FullAst.ml
@@ -164,6 +164,14 @@ and cli_options = {
           normally created, including when indexing behind a raw pointer. *)
   treat_box_as_builtin : bool;
       (** Treat [Box<T>] as if it was a built-in type. *)
+  no_gen_tuple_structs : bool;
+      (** Don't generate a type declaration per tuple arity. Instead, every
+          tuple type refers to the single opaque declaration with id
+          [TypeDeclId::UNIT], and stores its field types in its generic
+          arguments. This is meant for consumers that build tuples of arbitrary
+          arity on the fly and don't care about their declaration. Note that
+          this makes tuple types ill-typed with respect to their declaration; it
+          is also incompatible with [--monomorphize]. *)
   raw_consts : bool;  (** Do not inline or evaluate constants. *)
   consts : const_handling option;
       (** How to handle constants and statics: whether they should be

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -2197,6 +2197,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           ("ops_to_function_calls", ops_to_function_calls);
           ("index_to_function_calls", index_to_function_calls);
           ("treat_box_as_builtin", treat_box_as_builtin);
+          ("no_gen_tuple_structs", no_gen_tuple_structs);
           ("raw_consts", raw_consts);
           ("consts", consts);
           ("unsized_strings", unsized_strings);
@@ -2263,6 +2264,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           bool_of_json ctx index_to_function_calls
         in
         let* treat_box_as_builtin = bool_of_json ctx treat_box_as_builtin in
+        let* no_gen_tuple_structs = bool_of_json ctx no_gen_tuple_structs in
         let* raw_consts = bool_of_json ctx raw_consts in
         let* consts = option_of_json const_handling_of_json ctx consts in
         let* unsized_strings = bool_of_json ctx unsized_strings in
@@ -2322,6 +2324,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
              ops_to_function_calls;
              index_to_function_calls;
              treat_box_as_builtin;
+             no_gen_tuple_structs;
              raw_consts;
              consts;
              unsized_strings;

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -369,6 +369,16 @@ and builtin_index_op_of_json (ctx : of_json_ctx) (js : json) :
         Ok ({ is_array; mutability; is_range } : builtin_index_op)
     | _ -> Error "")
 
+and builtin_path_elem_of_json (ctx : of_json_ctx) (js : json) :
+    (builtin_path_elem, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Tuple", _0) ] ->
+        let* _0 = int_of_json ctx _0 in
+        Ok (PeTuple _0)
+    | `String "Str" -> Ok PeStr
+    | _ -> Error "")
+
 and builtin_ty_of_json (ctx : of_json_ctx) (js : json) :
     (builtin_ty, string) result =
   combine_error_msgs js __FUNCTION__
@@ -990,6 +1000,9 @@ and path_elem_of_json (ctx : of_json_ctx) (js : json) :
     | `Assoc [ ("Target", _0) ] ->
         let* _0 = string_of_json ctx _0 in
         Ok (PeTarget _0)
+    | `Assoc [ ("Builtin", _0) ] ->
+        let* _0 = builtin_path_elem_of_json ctx _0 in
+        Ok (PeBuiltin _0)
     | _ -> Error "")
 
 and place_of_json (ctx : of_json_ctx) (js : json) : (place, string) result =
@@ -1475,21 +1488,11 @@ and type_decl_ref_of_json (ctx : of_json_ctx) (js : json) :
     (type_decl_ref, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("id", id); ("generics", generics) ] ->
-        let* id = type_id_of_json ctx id in
+    | `Assoc [ ("id", id); ("generics", generics); ("builtin", builtin) ] ->
+        let* id = type_decl_id_of_json ctx id in
         let* generics = box_of_json generic_args_of_json ctx generics in
-        Ok ({ id; generics } : type_decl_ref)
-    | _ -> Error "")
-
-and type_id_of_json (ctx : of_json_ctx) (js : json) : (type_id, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Adt", _0) ] ->
-        let* _0 = type_decl_id_of_json ctx _0 in
-        Ok (TAdtId _0)
-    | `Assoc [ ("Builtin", _0) ] ->
-        let* _0 = builtin_ty_of_json ctx _0 in
-        Ok (TBuiltin _0)
+        let* builtin = option_of_json builtin_ty_of_json ctx builtin in
+        Ok ({ id; generics; builtin } : type_decl_ref)
     | _ -> Error "")
 
 and type_param_of_json (ctx : of_json_ctx) (js : json) :
@@ -3792,6 +3795,9 @@ and type_source_of_json (ctx : of_json_ctx) (js : json) :
             ctx supertrait_map
         in
         Ok (VTableType (dyn_predicate, field_map, supertrait_map))
+    | `Assoc [ ("Builtin", _0) ] ->
+        let* _0 = builtin_ty_of_json ctx _0 in
+        Ok (BuiltinType _0)
     | _ -> Error "")
 
 and v_table_field_of_json (ctx : of_json_ctx) (js : json) :

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -1921,6 +1921,7 @@ and cli_options_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
      let* ops_to_function_calls = bool_of_postcard ctx st in
      let* index_to_function_calls = bool_of_postcard ctx st in
      let* treat_box_as_builtin = bool_of_postcard ctx st in
+     let* no_gen_tuple_structs = bool_of_postcard ctx st in
      let* raw_consts = bool_of_postcard ctx st in
      let* consts = option_of_postcard const_handling_of_postcard ctx st in
      let* unsized_strings = bool_of_postcard ctx st in
@@ -1976,6 +1977,7 @@ and cli_options_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
           ops_to_function_calls;
           index_to_function_calls;
           treat_box_as_builtin;
+          no_gen_tuple_structs;
           raw_consts;
           consts;
           unsized_strings;

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -342,6 +342,17 @@ and builtin_index_op_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
      let* is_range = bool_of_postcard ctx st in
      Ok ({ is_array; mutability; is_range } : builtin_index_op))
 
+and builtin_path_elem_of_postcard (ctx : of_postcard_ctx) (st : postcard_state)
+    : (builtin_path_elem, string) result =
+  combine_error_msgs st __FUNCTION__
+    (let* __tag = int_of_postcard ctx st in
+     match __tag with
+     | 0 ->
+         let* _0 = usize_of_postcard ctx st in
+         Ok (PeTuple _0)
+     | 1 -> Ok PeStr
+     | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
+
 and builtin_ty_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (builtin_ty, string) result =
   combine_error_msgs st __FUNCTION__
@@ -916,6 +927,9 @@ and path_elem_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
      | 3 ->
          let* _0 = string_of_postcard ctx st in
          Ok (PeTarget _0)
+     | 4 ->
+         let* _0 = builtin_path_elem_of_postcard ctx st in
+         Ok (PeBuiltin _0)
      | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
 
 and place_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
@@ -1319,22 +1333,10 @@ and type_decl_id_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
 and type_decl_ref_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (type_decl_ref, string) result =
   combine_error_msgs st __FUNCTION__
-    (let* id = type_id_of_postcard ctx st in
+    (let* id = type_decl_id_of_postcard ctx st in
      let* generics = box_of_postcard generic_args_of_postcard ctx st in
-     Ok ({ id; generics } : type_decl_ref))
-
-and type_id_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
-    (type_id, string) result =
-  combine_error_msgs st __FUNCTION__
-    (let* __tag = int_of_postcard ctx st in
-     match __tag with
-     | 0 ->
-         let* _0 = type_decl_id_of_postcard ctx st in
-         Ok (TAdtId _0)
-     | 1 ->
-         let* _0 = builtin_ty_of_postcard ctx st in
-         Ok (TBuiltin _0)
-     | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
+     let* builtin = option_of_postcard builtin_ty_of_postcard ctx st in
+     Ok ({ id; generics; builtin } : type_decl_ref))
 
 and type_param_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (type_param, string) result =
@@ -3206,6 +3208,9 @@ and type_source_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
              ctx st
          in
          Ok (VTableType (dyn_predicate, field_map, supertrait_map))
+     | 3 ->
+         let* _0 = builtin_ty_of_postcard ctx st in
+         Ok (BuiltinType _0)
      | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
 
 and v_table_field_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -295,9 +295,13 @@ and builtin_index_op = {
     TODO: update to not hardcode the types (except [Box] maybe) and be more
     modular. TODO: move to builtins.rs? *)
 and builtin_ty =
-  | TTuple  (** Tuple type. *)
-  | TBox  (** Boxes are de facto a primitive type. *)
-  | TStr  (** Primitive type *)
+  | TTuple  (** A tuple [(A, B, ...)], including [unit]. *)
+  | TBox
+      (** Boxes; always detected, though they are only treated as primitives
+          with [--treat-box-as-builtin] *)
+  | TStr
+      (** The [str] type, which corresponds to a [[u8]] that encodes a string
+          with UTF-8. *)
 
 (** A byte, in the MiniRust sense: it can either be uninitialized, a concrete u8
     value, or part of a pointer with provenance (e.g. to a global or a function)
@@ -698,12 +702,7 @@ and ty_kind =
       (** An ADT. Note that here ADTs are very general. They can be:
           - user-defined ADTs
           - tuples (including [unit], which is a 0-tuple)
-          - built-in types (includes some primitive types, e.g., arrays or
-            slices)
-
-          The information on the nature of the ADT is stored in
-          ([TypeId])[TypeId]. The last list is used encode const generics, e.g.,
-          the size of an array
+          - built-in types, namely [Box] and [str]
 
           Note: this is incorrectly named: this can refer to any valid
           [TypeDecl] including extern types. *)
@@ -763,25 +762,17 @@ and ty_kind =
           values are restricted by the pattern. *)
   | TError of string  (** A type that could not be computed or was incorrect. *)
 
-(** Reference to a type declaration or builtin type. *)
-and type_decl_ref = { id : type_id; generics : generic_args }
+(** Reference to a type declaration.
 
-(** Type identifier.
-
-    Allows us to factorize the code for built-in types and ADTs. *)
-and type_id =
-  | TAdtId of type_decl_id
-      (** A "regular" ADT type.
-
-          Includes transparent ADTs and opaque ADTs (local ADTs marked as
-          opaque, and external ADTs). *)
-  | TBuiltin of builtin_ty
-      (** Built-in type. Either a primitive type like array or slice, or a
-          non-primitive type coming from a standard library and that we handle
-          like a primitive type. Types falling into this category include: Box,
-          Vec, Cell... The Array and Slice types were initially modelled as
-          primitive in the [Ty] type. We decided to move them to built-in types
-          as it allows for more uniform treatment throughout the codebase. *)
+    This includes user-defined ADTs (structs, enums, unions), but also tuples,
+    boxes, and [str], which we translate as [struct str([u8])]. *)
+and type_decl_ref = {
+  id : type_decl_id;
+  generics : generic_args;
+  builtin : builtin_ty option;
+      (** If this points to a built-in type, it is recorded here for easier
+          identification. *)
+}
 
 (** A type variable in a signature or binder. *)
 and type_param = {
@@ -849,6 +840,13 @@ and variant_id = (VariantId.id[@visitors.opaque])
 (** Describes modifiers to the alignment and packing of the corresponding type.
     Represents [repr(align(n))] and [repr(packed(n))]. *)
 type alignment_modifier = Align of int | Pack of int
+
+(** Used for builtin items, rather than hardcoding these as strings. *)
+and builtin_path_elem =
+  | PeTuple of int  (** The tuple of the given arity. *)
+  | PeStr
+      (** [str], which is a struct containing a [[u8]] the standard library
+          expects to be valid UTF-8. *)
 
 (** Additional information for closures. *)
 and closure_info = {
@@ -1372,6 +1370,8 @@ and path_elem =
   | PeTarget of string
       (** This item is only available on the given target. Only appears in
           multi-target mode. *)
+  | PeBuiltin of builtin_path_elem
+      (** A path element for a builtin, like tuples *)
 
 (** The metadata stored in a pointer. That's the information stored in pointers
     alongside their address. It's empty for [Sized] types, and interesting for
@@ -1486,6 +1486,8 @@ and type_source =
           - [field_map]: Record what each vtable field means.
           - [supertrait_map]: For each implied clause that is also a supertrait
             clause, records which field of the vtable corresponds to it. *)
+  | BuiltinType of builtin_ty
+      (** A type declaration synthesised for a builtin type. *)
 
 and v_table_field =
   | VTableSize

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.245"
+version = "0.1.246"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -26,7 +26,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.245"
+version = "0.1.246"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/src/ast/bodies/expressions.rs
+++ b/charon/src/ast/bodies/expressions.rs
@@ -406,8 +406,9 @@ impl Rvalue {
         Rvalue::Aggregate(
             AggregateKind::Adt(
                 TypeDeclRef {
-                    id: TypeId::Builtin(BuiltinTy::Tuple),
+                    id: TypeDeclId::UNIT,
                     generics: Box::new(GenericArgs::empty()),
+                    builtin: Some(BuiltinTy::Tuple),
                 },
                 None,
                 None,

--- a/charon/src/ast/bodies/places.rs
+++ b/charon/src/ast/bodies/places.rs
@@ -190,38 +190,27 @@ impl ProjectionElem {
                 }
             }
             Field(variant_id, field_id) => {
-                let tref = ty.as_adt()?;
-                match tref.as_builtin() {
-                    None => {
-                        // Can fail if the type declaration was not translated.
-                        let type_decl = krate.type_decls.get(tref.adt_id())?;
-                        use TypeDeclKind::*;
-                        match &type_decl.kind {
-                            Struct(fields) | Union(fields) => {
-                                if variant_id.is_some() {
-                                    return None;
-                                };
-                                fields.get(*field_id)?.ty.clone().substitute(&tref.generics)
-                            }
-                            Enum(variants) => {
-                                let variant_id = (*variant_id)?;
-                                let variant = variants.get(variant_id)?;
-                                variant
-                                    .fields
-                                    .get(*field_id)?
-                                    .ty
-                                    .clone()
-                                    .substitute(&tref.generics)
-                            }
-                            Opaque | Alias(_) | Error(_) => return None,
-                        }
+                let tref = ty.as_adt().unwrap();
+                let type_decl = krate.type_decls.get(tref.id)?;
+                use TypeDeclKind::*;
+                match &type_decl.kind {
+                    Struct(fields) | Union(fields) => {
+                        if variant_id.is_some() {
+                            return None;
+                        };
+                        fields.get(*field_id)?.ty.clone().substitute(&tref.generics)
                     }
-                    Some(BuiltinTy::Tuple) => tref
-                        .generics
-                        .types
-                        .get(TypeVarId::from(usize::from(*field_id)))?
-                        .clone(),
-                    Some(_) => return None,
+                    Enum(variants) => {
+                        let variant_id = (*variant_id)?;
+                        let variant = variants.get(variant_id)?;
+                        variant
+                            .fields
+                            .get(*field_id)?
+                            .ty
+                            .clone()
+                            .substitute(&tref.generics)
+                    }
+                    Opaque | Alias(_) | Error(_) => return None,
                 }
             }
             PtrMetadata => ty.get_ptr_metadata(krate).into_type(),

--- a/charon/src/ast/items/item_ids.rs
+++ b/charon/src/ast/items/item_ids.rs
@@ -11,7 +11,8 @@ generate_index_type!(FunDeclId, "Fun");
 generate_index_type!(TypeDeclId, "Adt");
 
 impl TypeDeclId {
-    /// The declaration of the unit type `()`
+    /// The declaration of the unit type `()`. With `--no-gen-tuple-structs`, this is the
+    /// declaration of every tuple.
     pub const UNIT: Self = Self::ZERO;
 }
 generate_index_type!(GlobalDeclId, "Global");

--- a/charon/src/ast/items/item_ids.rs
+++ b/charon/src/ast/items/item_ids.rs
@@ -9,6 +9,11 @@ use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
 
 generate_index_type!(FunDeclId, "Fun");
 generate_index_type!(TypeDeclId, "Adt");
+
+impl TypeDeclId {
+    /// The declaration of the unit type `()`
+    pub const UNIT: Self = Self::ZERO;
+}
 generate_index_type!(GlobalDeclId, "Global");
 generate_index_type!(TraitDeclId, "TraitDecl");
 generate_index_type!(TraitImplId, "TraitImpl");
@@ -104,7 +109,10 @@ pub enum MaybeAssocItemId {
     Assoc(TraitDeclId, AssocItemId),
 }
 
-/// Reference to a type declaration or builtin type.
+/// Reference to a type declaration.
+///
+/// This includes user-defined ADTs (structs, enums, unions), but also tuples,
+/// boxes, and `str`, which we translate as `struct str([u8])`.
 #[derive(
     Debug,
     Clone,
@@ -120,49 +128,10 @@ pub enum MaybeAssocItemId {
     DriveTwo,
 )]
 pub struct TypeDeclRef {
-    pub id: TypeId,
+    pub id: TypeDeclId,
     pub generics: BoxedArgs,
-}
-
-/// Type identifier.
-///
-/// Allows us to factorize the code for built-in types and ADTs.
-#[derive(
-    Debug,
-    PartialEq,
-    Eq,
-    Clone,
-    Copy,
-    VariantName,
-    EnumAsGetters,
-    EnumIsA,
-    SerializeState,
-    DeserializeState,
-    Drive,
-    DriveMut,
-    DriveTwo,
-    Hash,
-    Ord,
-    PartialOrd,
-)]
-#[cfg_attr(feature = "charon_on_charon", charon::variants_prefix("T"))]
-pub enum TypeId {
-    /// A "regular" ADT type.
-    ///
-    /// Includes transparent ADTs and opaque ADTs (local ADTs marked as opaque,
-    /// and external ADTs).
-    #[cfg_attr(feature = "charon_on_charon", charon::rename("TAdtId"))]
-    Adt(TypeDeclId),
-    /// Built-in type. Either a primitive type like array or slice, or a
-    /// non-primitive type coming from a standard library
-    /// and that we handle like a primitive type. Types falling into this
-    /// category include: Box, Vec, Cell...
-    /// The Array and Slice types were initially modelled as primitive in
-    /// the [Ty] type. We decided to move them to built-in types as it allows
-    /// for more uniform treatment throughout the codebase.
-    #[cfg_attr(feature = "charon_on_charon", charon::rename("TBuiltin"))]
-    #[serde_state(stateless)]
-    Builtin(BuiltinTy),
+    /// If this points to a built-in type, it is recorded here for easier identification.
+    pub builtin: Option<BuiltinTy>,
 }
 
 /// Reference to a function declaration.
@@ -404,41 +373,31 @@ pub struct TraitImplRef {
 }
 
 impl TypeDeclRef {
-    pub fn new(id: TypeId, generics: GenericArgs) -> Self {
+    pub fn new(id: TypeDeclId, generics: GenericArgs, builtin: Option<BuiltinTy>) -> Self {
         Self {
             id,
             generics: Box::new(generics),
+            builtin,
         }
     }
 
     pub fn as_builtin(&self) -> Option<BuiltinTy> {
-        self.id.as_builtin().copied()
+        self.builtin
     }
 
-    pub fn as_adt(&self) -> Option<TypeDeclId> {
-        self.id.as_adt().copied()
-    }
-
-    pub fn as_adt_mut(&mut self) -> Option<&mut TypeDeclId> {
-        self.id.as_adt_mut()
-    }
-
-    #[track_caller]
-    pub fn adt_id(&self) -> TypeDeclId {
-        self.as_adt()
-            .expect("called `TypeDeclRef::adt_id` on a builtin type")
-    }
-
+    /// Whether this refers to `Box`.
     pub fn is_box(&self) -> bool {
-        self.as_builtin() == Some(BuiltinTy::Box)
+        matches!(self.builtin, Some(BuiltinTy::Box))
     }
 
+    /// Whether this refers to a tuple.
     pub fn is_tuple(&self) -> bool {
-        self.as_builtin() == Some(BuiltinTy::Tuple)
+        matches!(self.builtin, Some(BuiltinTy::Tuple))
     }
 
+    /// Whether this refers to `str`.
     pub fn is_str(&self) -> bool {
-        self.as_builtin() == Some(BuiltinTy::Str)
+        matches!(self.builtin, Some(BuiltinTy::Str))
     }
 }
 
@@ -534,7 +493,8 @@ macro_rules! convert_item_ref {
         }
     };
 }
-convert_item_ref!(TypeDeclRef(TypeId));
+// We do not provide a `DeclRef<_> -> TypeDeclRef` impl, because we lack information
+// about builtins here.
 convert_item_ref!(FunDeclRef(FunDeclId));
 convert_item_ref!(GlobalDeclRef(GlobalDeclId));
 convert_item_ref!(TraitDeclRef(TraitDeclId));
@@ -588,12 +548,6 @@ wrap_unwrap_enum!(AssocItemId::Type(AssocTypeId));
 wrap_unwrap_enum!(AssocItemId::Method(TraitMethodId));
 wrap_unwrap_enum!(AssocItemId::Const(AssocConstId));
 
-impl TryFrom<ItemId> for TypeId {
-    type Error = ();
-    fn try_from(x: ItemId) -> Result<Self, Self::Error> {
-        Ok(TypeId::Adt(x.try_into()?))
-    }
-}
 impl TryFrom<ItemId> for FunId {
     type Error = ();
     fn try_from(x: ItemId) -> Result<Self, Self::Error> {

--- a/charon/src/ast/items/layout_guarantees.rs
+++ b/charon/src/ast/items/layout_guarantees.rs
@@ -181,8 +181,7 @@ impl ExactSizeExpr {
                                 }
                                 _ => {
                                     if let Some(ty_ref) = ty.as_adt()
-                                        && let Some(id) = ty_ref.as_adt()
-                                        && let Some(decl) = self.krate.type_decls.get(id)
+                                        && let Some(decl) = self.krate.type_decls.get(ty_ref.id)
                                         && let Some(layout) = decl.layout.get(self.target)
                                         && let Some(value) = exact_guarantee(&layout.size)
                                     {
@@ -207,8 +206,7 @@ impl ExactSizeExpr {
                                 }
                                 _ => {
                                     if let Some(ty_ref) = ty.as_adt()
-                                        && let Some(id) = ty_ref.as_adt()
-                                        && let Some(decl) = self.krate.type_decls.get(id)
+                                        && let Some(decl) = self.krate.type_decls.get(ty_ref.id)
                                         && let Some(layout) = decl.layout.get(self.target)
                                         && let Some(value) = exact_guarantee(&layout.align)
                                     {
@@ -568,12 +566,13 @@ mod tests {
             },
         );
         let ty = TyKind::Adt(TypeDeclRef::new(
-            TypeId::Adt(id),
+            id,
             GenericArgs::new_types(
                 [TyKind::Literal(LiteralTy::UInt(UIntTy::U16)).into_ty()]
                     .into_iter()
                     .collect(),
             ),
+            None,
         ))
         .into_ty();
         let size_of = || {

--- a/charon/src/ast/items/type_decl.rs
+++ b/charon/src/ast/items/type_decl.rs
@@ -138,7 +138,17 @@ pub enum PtrMetadata {
 }
 
 /// Where a given type came from.
-#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
+#[derive(
+    Debug,
+    Clone,
+    SerializeState,
+    DeserializeState,
+    Drive,
+    DriveMut,
+    DriveTwo,
+    EnumIsA,
+    EnumAsGetters,
+)]
 #[cfg_attr(feature = "charon_on_charon", charon::variants_suffix("Type"))]
 pub enum TypeSource {
     /// A normal type declaration.
@@ -155,6 +165,8 @@ pub enum TypeSource {
         /// vtable corresponds to it.
         supertrait_map: IndexVec<TraitClauseId, Option<FieldId>>,
     },
+    /// A type declaration synthesised for a builtin type.
+    Builtin(BuiltinTy),
 }
 
 #[derive(

--- a/charon/src/ast/meta/names.rs
+++ b/charon/src/ast/meta/names.rs
@@ -2,6 +2,7 @@
 use crate::ast::*;
 use derive_generic_visitor::{Drive, DriveMut, DriveTwo};
 use macros::{EnumAsGetters, EnumIsA};
+use serde::{Deserialize, Serialize};
 use serde_state::{DeserializeState, SerializeState};
 
 generate_index_type!(Disambiguator);
@@ -41,6 +42,22 @@ pub enum PathElem {
     /// This item is only available on the given target. Only appears in multi-target mode.
     #[serde_state(stateless)]
     Target(TargetTriple),
+    /// A path element for a builtin, like tuples
+    #[serde_state(stateless)]
+    Builtin(BuiltinPathElem),
+}
+
+/// Used for builtin items, rather than hardcoding these as strings.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, EnumIsA, EnumAsGetters,
+)]
+#[cfg_attr(feature = "charon_on_charon", charon::variants_prefix("Pe"))]
+pub enum BuiltinPathElem {
+    /// The tuple of the given arity.
+    Tuple(usize),
+    /// `str`, which is a struct containing a `[u8]` the standard library expects
+    /// to be valid UTF-8.
+    Str,
 }
 
 /// There are two kinds of `impl` blocks:
@@ -228,9 +245,33 @@ impl Name {
         self
     }
 
+    /// Whether this names one of the items Rust builds into the language (tuples, `str`, arrays,
+    /// slices) or an item we generate for one, such as its drop glue. They belong to no crate, so
+    /// their name starts either with the builtin itself or with the `impl` block we generated for them.
+    pub fn is_builtin(&self) -> bool {
+        matches!(
+            self.name.first(),
+            Some(PathElem::Builtin(_) | PathElem::Impl(_))
+        )
+    }
+
     /// Get the last identifier of the name, if any. This is useful for error messages and such.
-    /// Panics if the name is empty or if the last element is not an identifier.
+    /// Returns `None` if the name is empty or if the last element has no identifier to give.
     pub fn short_str(&self) -> Option<&str> {
-        Some(self.name.last()?.as_ident()?.0)
+        match self.name.last()? {
+            PathElem::Builtin(builtin) => Some(builtin.ident()),
+            PathElem::Ident(str, _) => Some(str),
+            _ => None,
+        }
+    }
+}
+
+impl BuiltinPathElem {
+    pub fn ident(self) -> &'static str {
+        match self {
+            BuiltinPathElem::Tuple(0) => "unit",
+            BuiltinPathElem::Tuple(_) => "tuple",
+            BuiltinPathElem::Str => "str",
+        }
     }
 }

--- a/charon/src/ast/type_level/types.rs
+++ b/charon/src/ast/type_level/types.rs
@@ -47,10 +47,7 @@ pub enum TyKind {
     /// Note that here ADTs are very general. They can be:
     /// - user-defined ADTs
     /// - tuples (including `unit`, which is a 0-tuple)
-    /// - built-in types (includes some primitive types, e.g., arrays or slices)
-    ///
-    /// The information on the nature of the ADT is stored in (`TypeId`)[TypeId].
-    /// The last list is used encode const generics, e.g., the size of an array
+    /// - built-in types, namely `Box` and `str`
     ///
     /// Note: this is incorrectly named: this can refer to any valid `TypeDecl` including extern
     /// types.
@@ -270,8 +267,8 @@ pub enum LiteralTy {
     EnumIsA,
     EnumAsGetters,
     VariantName,
-    Serialize,
-    Deserialize,
+    SerializeState,
+    DeserializeState,
     Drive,
     DriveMut,
     DriveTwo,
@@ -281,23 +278,12 @@ pub enum LiteralTy {
 )]
 #[cfg_attr(feature = "charon_on_charon", charon::variants_prefix("T"))]
 pub enum BuiltinTy {
-    /// Tuple type.
+    /// A tuple `(A, B, ...)`, including `unit`.
     Tuple,
-    /// Boxes are de facto a primitive type.
+    /// Boxes; always detected, though they are only treated as primitives with `--treat-box-as-builtin`
     Box,
-    /// Primitive type
+    /// The `str` type, which corresponds to a `[u8]` that encodes a string with UTF-8.
     Str,
-}
-
-impl BuiltinTy {
-    pub fn get_name(self) -> Name {
-        let name: &[_] = match self {
-            BuiltinTy::Box => &["alloc", "boxed", "Box"],
-            BuiltinTy::Str => &["str"],
-            BuiltinTy::Tuple => &["Tuple"],
-        };
-        Name::from_path(name)
-    }
 }
 
 #[derive(
@@ -398,7 +384,11 @@ impl Ty {
 
     /// Return the unit type
     pub fn mk_unit() -> Ty {
-        static_type!(Ty::mk_tuple(vec![]).kind().clone())
+        static_type!(TyKind::Adt(TypeDeclRef {
+            id: TypeDeclId::UNIT,
+            generics: Box::new(GenericArgs::empty()),
+            builtin: Some(BuiltinTy::Tuple),
+        }))
     }
 
     pub fn mk_bool() -> Ty {
@@ -413,14 +403,6 @@ impl Ty {
         matches!(self.kind(), TyKind::Literal(LiteralTy::UInt(UIntTy::Usize)))
     }
 
-    pub fn mk_tuple(tys: Vec<Ty>) -> Ty {
-        TyKind::Adt(TypeDeclRef {
-            id: TypeId::Builtin(BuiltinTy::Tuple),
-            generics: Box::new(GenericArgs::new_types(tys.into())),
-        })
-        .into_ty()
-    }
-
     pub fn mk_array(ty: Ty, len: ConstantExpr) -> Ty {
         TyKind::Array(ty, len).into_ty()
     }
@@ -430,10 +412,7 @@ impl Ty {
     }
     /// Return true if it is actually unit (i.e.: 0-tuple)
     pub fn is_unit(&self) -> bool {
-        match self.as_tuple() {
-            Some(tys) => tys.is_empty(),
-            None => false,
-        }
+        *self == Ty::mk_unit()
     }
 
     /// Return true if this is a scalar type
@@ -476,6 +455,13 @@ impl Ty {
         }
     }
 
+    pub fn is_tuple(&self) -> bool {
+        match self.kind() {
+            TyKind::Adt(ty_ref) => ty_ref.is_tuple(),
+            _ => false,
+        }
+    }
+
     pub fn as_box(&self) -> Option<&Ty> {
         match self.kind() {
             TyKind::Adt(ty_ref) if ty_ref.is_box() => Some(&ty_ref.generics.types[0]),
@@ -484,7 +470,7 @@ impl Ty {
     }
 
     pub fn as_adt_id(&self) -> Option<TypeDeclId> {
-        self.kind().as_adt()?.as_adt()
+        self.kind().as_adt().map(|a| a.id)
     }
 
     pub fn get_ptr_metadata(&self, translated: &TranslatedCrate) -> PtrMetadata {
@@ -495,31 +481,14 @@ impl Ty {
                 // there are two cases:
                 // 1. if the declared type has a fixed metadata, just returns it
                 // 2. if it depends on some other types or the generic itself
-                match ty_ref.as_builtin() {
-                    None => {
-                        let Some(decl) = ty_decls.get(ty_ref.adt_id()) else {
-                            return PtrMetadata::InheritFrom(self.clone());
-                        };
-                        match decl.ptr_metadata.clone().substitute(&ty_ref.generics) {
-                            // if it depends on some type, recursion with the binding env
-                            PtrMetadata::InheritFrom(ty) => ty.get_ptr_metadata(translated),
-                            // otherwise, simply return it
-                            meta => meta,
-                        }
-                    }
-                    // the metadata of a tuple is simply the last field
-                    Some(BuiltinTy::Tuple) => {
-                        match ty_ref.generics.types.iter().last() {
-                            // `None` refers to the unit type `()`
-                            None => PtrMetadata::None,
-                            // Otherwise, simply recurse
-                            Some(ty) => ty.get_ptr_metadata(translated),
-                        }
-                    }
-                    // Box is a pointer like ref & raw ptr, hence no metadata
-                    Some(BuiltinTy::Box) => PtrMetadata::None,
-                    // `str` has metadata length
-                    Some(BuiltinTy::Str) => PtrMetadata::Length,
+                let Some(decl) = ty_decls.get(ty_ref.id) else {
+                    return PtrMetadata::InheritFrom(self.clone());
+                };
+                match decl.ptr_metadata.clone().substitute(&ty_ref.generics) {
+                    // if it depends on some type, recursion with the binding env
+                    PtrMetadata::InheritFrom(ty) => ty.get_ptr_metadata(translated),
+                    // otherwise, simply return it
+                    meta => meta,
                 }
             }
             TyKind::DynTrait(pred) => match pred.vtable_ref(translated) {
@@ -556,11 +525,33 @@ impl Ty {
         }
     }
 
-    pub fn as_tuple(&self) -> Option<&IndexVec<TypeVarId, Ty>> {
-        match self.kind() {
-            TyKind::Adt(ty_ref) if ty_ref.is_tuple() => Some(&ty_ref.generics.types),
-            _ => None,
+    /// The field types of a tuple, in order. Panics if the type is not a tuple,
+    /// or if the type declaration is not found in the crate.
+    pub fn as_tuple_fields(&self, translated: &TranslatedCrate) -> Vec<Ty> {
+        let Some(tref) = self.as_adt().filter(|tref| tref.is_tuple()) else {
+            unreachable!("as_tuple_fields called on non-tuple type {:?}", self);
+        };
+
+        // Avoid doing a substitution if the tuple is polymorphic and we can just
+        // retrieve the fields from the generics, since substitutions won't work
+        // in case `--unbind-item-vars` is set.
+        let is_instantiated = translated
+            .item_names
+            .get(&ItemId::Type(tref.id))
+            .map(|name| name.name.iter().any(|elem| elem.is_instantiated()))
+            .unwrap_or(false);
+        if !is_instantiated {
+            return tref.generics.types.as_vec().clone();
         }
+
+        translated
+            .type_decls
+            .get(tref.id)
+            .and_then(|decl| decl.kind.as_struct())
+            .expect("the declaration of specialized tuple {tref:?} is missing")
+            .iter()
+            .map(|f| f.ty.clone().substitute(&tref.generics))
+            .collect()
     }
 
     pub fn as_adt(&self) -> Option<&TypeDeclRef> {

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -53,7 +53,7 @@ use derive_generic_visitor::*;
         GlobalKind, ItemOpacity, LangItem, LifetimeMutability, OptimizeAttr, OverflowMode,
         ReprOptions, Variance,
         std::ops::RangeInclusive<ScalarValue>,
-        WithRetag,
+        WithRetag, BuiltinPathElem
     ),
     // Types that are completely skipped, even by `ZipAst`.
     skip(
@@ -70,7 +70,7 @@ use derive_generic_visitor::*;
         llbc_ast::ExprBody, llbc_ast::StatementKind, llbc_ast::Switch,
         Loc, Locals, NullOp, Operand, PathElem, PlaceKind,
         RawAttribute, RefKind, RegionId, RegionParam, ScalarValue, TraitItemName, TraitMethodId, AssocTypeId, AssocConstId, AssocItemId, MaybeAssocItemId,
-        TranslatedCrate, TypeDeclKind, TypeId, TypeParam, TypePattern, TypeVarId,
+        TranslatedCrate, TypeDeclKind, TypeParam, TypePattern, TypeVarId,
         ullbc_ast::BlockData, ullbc_ast::BlockId, ullbc_ast::ExprBody, ullbc_ast::StatementKind,
         ullbc_ast::TerminatorKind, ullbc_ast::SwitchTargets,
         UnOp, UnsizingMetadata, Local, Variant, VariantId, LocalId, Layout, VariantLayout,
@@ -198,9 +198,9 @@ impl<K: BodyVisitable + Hash + Eq, T: BodyVisitable> BodyVisitable for SeqHashMa
     skip(
         AbortKind, BinOp, BorrowKind, BuiltinAssertKind, ConstantExpr, FieldId,
         TypeDeclRef, FunDeclId, FunDeclRef, FnPtrKind, GenericArgs, GlobalDeclRef, IntegerTy, IntTy, UIntTy,
-        NullOp, RefKind, ScalarValue, Span, Ty, TypeDeclId, TypeId, UnOp, VariantId,
+        NullOp, RefKind, ScalarValue, Span, Ty, TypeDeclId,  UnOp, VariantId,
         TraitRef, LiteralTy, Literal, Region, RegionId, (), String, PathBuf, bool, usize,
-        DropKind, Error, Variance, WithRetag,
+        DropKind, Error, Variance, WithRetag, BuiltinTy, BuiltinPathElem,
         llbc_ast::BlockId, llbc_ast::StatementId,
     ),
     // Types that we unconditionally explore.
@@ -596,10 +596,7 @@ mod wrappers {
             x.drive(self.inner())
         }
         fn visit_type_decl_ref(&mut self, x: &TypeDeclRef) -> ControlFlow<Self::Break> {
-            match x.as_adt() {
-                Some(id) => self.0.visit_item_ref(ItemId::Type(id), &x.generics),
-                None => self.visit_inner(x),
-            }
+            self.0.visit_item_ref(ItemId::Type(x.id), &x.generics)
         }
         fn visit_fun_decl_ref(&mut self, x: &FunDeclRef) -> ControlFlow<Self::Break> {
             self.0.visit_item_ref(ItemId::Fun(x.id), &x.generics)
@@ -630,10 +627,7 @@ mod wrappers {
             x.drive_mut(self.inner())
         }
         fn visit_type_decl_ref(&mut self, x: &mut TypeDeclRef) -> ControlFlow<Self::Break> {
-            match x.as_adt() {
-                Some(id) => self.0.visit_item_ref(ItemId::Type(id), &mut x.generics),
-                None => self.visit_inner(x),
-            }
+            self.0.visit_item_ref(ItemId::Type(x.id), &mut x.generics)
         }
         fn visit_fun_decl_ref(&mut self, x: &mut FunDeclRef) -> ControlFlow<Self::Break> {
             self.0.visit_item_ref(ItemId::Fun(x.id), &mut x.generics)

--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -60,6 +60,7 @@ where
                 SyntheticItem::Array => AdtKind::Array,
                 SyntheticItem::Slice => AdtKind::Slice,
                 SyntheticItem::Tuple(..) => AdtKind::Tuple,
+                SyntheticItem::Str => AdtKind::Str,
             };
             let param_env = get_param_env(s, args);
             let destruct_impl = {
@@ -370,6 +371,9 @@ pub enum FullDefKind<'tcx> {
         inline: InlineAttr,
         is_const: bool,
         sig: PolyFnSig,
+        /// The arguments of this function, tupled as the `Fn*` traits take them, e.g. `(A, B, C)`.
+        /// Binds the same variables as `sig`. `None` if this function doesn't implement `Fn*`.
+        tupled_args_ty: Option<Binder<Ty>>,
         /// Info required to construct a virtual `FnOnce` impl for this function, if compatible.
         fn_once_impl: Option<Box<VirtualTraitImpl>>,
         /// Info required to construct a virtual `FnMut` impl for this function, if compatible.
@@ -389,6 +393,9 @@ pub enum FullDefKind<'tcx> {
         /// signature with `Self` replaced by `dyn Trait` and associated types normalized.
         vtable_sig: Option<PolyFnSig>,
         sig: PolyFnSig,
+        /// The arguments of this function, tupled as the `Fn*` traits take them, e.g. `(A, B, C)`.
+        /// Binds the same variables as `sig`. `None` if this function doesn't implement `Fn*`.
+        tupled_args_ty: Option<Binder<Ty>>,
         /// Info required to construct a virtual `FnOnce` impl for this function, if compatible.
         fn_once_impl: Option<Box<VirtualTraitImpl>>,
         /// Info required to construct a virtual `FnMut` impl for this function, if compatible.
@@ -482,6 +489,9 @@ pub enum FullDefKind<'tcx> {
         fields: IndexVec<FieldIdx, FieldDef>,
         output_ty: Ty,
         sig: PolyFnSig,
+        /// The arguments of this constructor, tupled as the `Fn*` traits take them, e.g. `(A, B,
+        /// C)`. Binds the same variables as `sig`. Always `Somes`.
+        tupled_args_ty: Option<Binder<Ty>>,
         /// Info required to construct a virtual `FnOnce` impl for this constructor.
         fn_once_impl: Option<Box<VirtualTraitImpl>>,
         /// Info required to construct a virtual `FnMut` impl for this constructor.
@@ -862,11 +872,15 @@ where
         RDefKind::Fn { .. } => {
             let sig = tcx.fn_sig(def_id);
             let fn_trait_impls = fn_def_trait_impls(def_id, sig);
+            let sig = inst_binder(tcx, s.typing_env(), args, sig);
             FullDefKind::Fn {
                 param_env: get_param_env(s, args),
                 inline: tcx.codegen_fn_attrs(def_id).inline.sinto(s),
                 is_const: matches!(tcx.constness(def_id), rustc_hir::Constness::Const { .. }),
-                sig: inst_binder(tcx, s.typing_env(), args, sig).sinto(s),
+                tupled_args_ty: fn_trait_impls
+                    .is_some()
+                    .then(|| tupled_args_ty(s, sig).sinto(s)),
+                sig: sig.sinto(s),
                 fn_once_impl: fn_trait_impls.as_ref().map(|(vimpl, _, _)| vimpl.clone()),
                 fn_mut_impl: fn_trait_impls.as_ref().map(|(_, vimpl, _)| vimpl.clone()),
                 fn_impl: fn_trait_impls.map(|(_, _, vimpl)| vimpl),
@@ -875,13 +889,17 @@ where
         RDefKind::AssocFn { .. } => {
             let item = tcx.associated_item(def_id);
             let fn_trait_impls = fn_def_trait_impls(def_id, tcx.fn_sig(def_id));
+            let sig = get_method_sig(tcx, s.typing_env(), def_id, args);
             FullDefKind::AssocFn {
                 param_env: get_param_env(s, args),
                 associated_item: AssocItem::sfrom_instantiated(s, &item, args),
                 inline: tcx.codegen_fn_attrs(def_id).inline.sinto(s),
                 is_const: matches!(tcx.constness(def_id), rustc_hir::Constness::Const { .. }),
                 vtable_sig: gen_vtable_sig(s, args),
-                sig: get_method_sig(tcx, s.typing_env(), def_id, args).sinto(s),
+                tupled_args_ty: fn_trait_impls
+                    .is_some()
+                    .then(|| tupled_args_ty(s, sig).sinto(s)),
+                sig: sig.sinto(s),
                 fn_once_impl: fn_trait_impls.as_ref().map(|(vimpl, _, _)| vimpl.clone()),
                 fn_mut_impl: fn_trait_impls.as_ref().map(|(_, vimpl, _)| vimpl.clone()),
                 fn_impl: fn_trait_impls.map(|(_, _, vimpl)| vimpl),
@@ -1008,13 +1026,15 @@ where
                 .map(|f| FieldDef::sfrom(s, f, args))
                 .collect();
             let output_ty = ty::Ty::new_adt(tcx, adt_def, args).sinto(s);
+            let sig = inst_binder(tcx, s.typing_env(), Some(args), sig);
             FullDefKind::Ctor {
                 adt_def_id: adt_def_id.sinto(s),
                 ctor_of,
                 variant_id: variant_id.sinto(s),
                 fields,
                 output_ty,
-                sig: inst_binder(tcx, s.typing_env(), Some(args), sig).sinto(s),
+                tupled_args_ty: Some(tupled_args_ty(s, sig).sinto(s)),
+                sig: sig.sinto(s),
                 fn_once_impl: fn_trait_impls.as_ref().map(|(vimpl, _, _)| vimpl.clone()),
                 fn_mut_impl: fn_trait_impls.as_ref().map(|(_, vimpl, _)| vimpl.clone()),
                 fn_impl: fn_trait_impls.map(|(_, _, vimpl)| vimpl),

--- a/charon/src/bin/charon-driver/hax/types/new/synthetic_items.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/synthetic_items.rs
@@ -11,9 +11,10 @@ use {
 
 /// We create some extra `DefId`s to represent things that rustc doesn't have a `DefId` for. This
 /// makes the pipeline much easier to have "real" def_ids for them.
-/// We generate fake struct-like items for each of: arrays, slices, and tuples. This makes it
-/// easier to emit trait impls for these types, especially with monomorphization. This enum tracks
-/// identifies these builtin types.
+/// We generate fake struct-like items for each of: arrays, slices, tuples and `str`. This makes it
+/// easier to emit trait impls for these types, especially with monomorphization, and it lets
+/// tuples and `str` have a type declaration like other ADTs. This enum identifies these builtin
+/// types.
 #[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
 pub enum SyntheticItem {
     /// Fake ADT representing the `[T; N]` type.
@@ -22,6 +23,8 @@ pub enum SyntheticItem {
     Slice,
     /// Fake ADT representing the length-n tuple `(A, B, ...)`.
     Tuple(usize),
+    /// Fake ADT representing `str`, which wraps a `[u8]`.
+    Str,
 }
 
 #[derive(Clone, Copy)]
@@ -74,6 +77,7 @@ impl SyntheticItem {
             SyntheticItem::Array => "<array>".to_string(),
             SyntheticItem::Slice => "<slice>".to_string(),
             SyntheticItem::Tuple(n) => format!("<tuple_{n}>"),
+            SyntheticItem::Str => "<str>".to_string(),
         }
     }
 
@@ -134,6 +138,7 @@ impl SyntheticItem {
                 let tys = tcx.arena.alloc_from_iter(tys);
                 ty::Ty::new_tup(tcx, tys)
             }
+            SyntheticItem::Str => tcx.types.str_,
         };
         ty::EarlyBinder::bind(tcx, type_of)
     }
@@ -251,6 +256,7 @@ impl<'tcx> GlobalCache<'tcx> {
                     clauses.push(ty_is_sized.upcast(tcx));
                 }
             }
+            SyntheticItem::Str => {}
         }
 
         let clauses = tcx.arena.alloc_from_iter(clauses);

--- a/charon/src/bin/charon-driver/hax/types/ty.rs
+++ b/charon/src/bin/charon-driver/hax/types/ty.rs
@@ -775,7 +775,12 @@ pub enum TyKind {
         ItemRef::translate_synthetic(s, SyntheticItem::Tuple(tys.len()), args)
     }),)]
     Tuple(ItemRef),
-    Str,
+    /// The `ItemRef` uses the fake `Str` def_id.
+    #[custom_arm(FROM_TYPE::Str => TO_TYPE::Str({
+        let args = s.base().tcx.mk_args(&[]);
+        ItemRef::translate_synthetic(s, SyntheticItem::Str, args)
+    }),)]
+    Str(ItemRef),
     RawPtr(Box<Ty>, Mutability),
     Ref(Region, Box<Ty>, Mutability),
     #[custom_arm(FROM_TYPE::Dynamic(preds, region) => TyKind::Dynamic(resolve_for_dyn(s, preds, |_, _| ()), region.sinto(s)),)]
@@ -915,8 +920,10 @@ pub enum AdtKind {
     Array,
     /// We sometimes pretend slices are an ADT and generate a `FullDef` for them.
     Slice,
-    /// We sometimes pretend tuples are an ADT and generate a `FullDef` for them.
+    /// Tuples get a type declaration of their own, we always generate a `FullDef` for them.
     Tuple,
+    /// `str` gets a type declaration of its own, we always generate a `FullDef` for it.
+    Str,
 }
 
 impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, AdtKind> for ty::AdtKind {
@@ -1352,6 +1359,7 @@ impl<'tcx> BinderVariances<'tcx> for ty::FnSig<'tcx> {
     }
 }
 
+impl<'tcx> BinderVariances<'tcx> for ty::Ty<'tcx> {}
 impl<'tcx> BinderVariances<'tcx> for ty::ClauseKind<'tcx> {}
 impl<'tcx> BinderVariances<'tcx> for ty::PredicateKind<'tcx> {}
 impl<'tcx> BinderVariances<'tcx> for ty::TraitRef<'tcx> {}
@@ -1399,6 +1407,17 @@ pub struct CoercePredicate {
     pub b: Ty,
 }
 
+/// The arguments of the given signature, tupled as the `Fn*` traits take them, e.g. `(A, B, C)`.
+/// The result binds the same variables as the signature it comes from, so that the two agree on
+/// the regions they use.
+pub fn tupled_args_ty<'tcx>(
+    s: &impl UnderOwnerState<'tcx>,
+    sig: ty::PolyFnSig<'tcx>,
+) -> ty::Binder<'tcx, ty::Ty<'tcx>> {
+    let tcx = s.base().tcx;
+    sig.map_bound(|sig| ty::Ty::new_tup(tcx, sig.inputs()))
+}
+
 /// Reflects [`ty::ClosureArgs`]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 
@@ -1409,6 +1428,9 @@ pub struct ClosureArgs {
     pub kind: ClosureKind,
     /// The signature of the function that the closure implements, e.g. `fn(A, B, C) -> D`.
     pub fn_sig: PolyFnSig,
+    /// The arguments of the closure, tupled as the `Fn*` traits take them, e.g. `(A, B, C)`.
+    /// Binds the same variables as `fn_sig`.
+    pub tupled_args_ty: Binder<Ty>,
     /// The set of captured variables. Together they form the state of the closure.
     pub upvar_tys: Vec<Ty>,
 }
@@ -1510,6 +1532,7 @@ impl ClosureArgs {
         ClosureArgs {
             item,
             kind: closure.kind().sinto(s),
+            tupled_args_ty: tupled_args_ty(s, sig).sinto(s),
             fn_sig: sig.sinto(s),
             upvar_tys: closure.upvar_tys().sinto(s),
         }

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -289,7 +289,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                 let mut field_path = vec![];
                 for &(trait_id, clause_id) in &clause_path {
                     if let Ok(ItemRef::TraitDecl(tdecl)) = self.get_or_translate(trait_id.into())
-                        && let vtable_decl_id = tdecl.vtable.as_ref().unwrap().adt_id()
+                        && let vtable_decl_id = tdecl.vtable.as_ref().unwrap().id
                         && let Ok(ItemRef::Type(vtable_decl)) =
                             self.get_or_translate(vtable_decl_id.into())
                     {
@@ -998,7 +998,7 @@ impl<'tcx> BlockTransCtx<'tcx, '_, '_, '_> {
                                     assert!(generics.const_generics.is_empty());
                                     ProjectionElem::Field(None, field_id)
                                 }
-                                Some(BuiltinTy::Box) => {
+                                Some(BuiltinTy::Box) if self.t_ctx.options.treat_box_as_builtin => {
                                     // Some sanity checks
                                     assert!(generics.regions.is_empty());
                                     assert!(generics.types.len() == 2);
@@ -1015,6 +1015,7 @@ impl<'tcx> BlockTransCtx<'tcx, '_, '_, '_> {
                                         )
                                     }
                                 }
+                                Some(BuiltinTy::Box) => ProjectionElem::Field(None, field_id),
                                 Some(_) => {
                                     raise_error!(self, span, "Unexpected field projection")
                                 }
@@ -1312,10 +1313,10 @@ impl<'tcx> BlockTransCtx<'tcx, '_, '_, '_> {
                         Ok(Rvalue::Aggregate(AggregateKind::Array(t_ty, c), operands_t))
                     }
                     mir::AggregateKind::Tuple => {
-                        let tref = TypeDeclRef::new(
-                            TypeId::Builtin(BuiltinTy::Tuple),
-                            GenericArgs::empty(),
-                        );
+                        let tys = operands.iter().map(|op| op.ty(self.local_decls, self.tcx));
+                        let ty = ty::Ty::new_tup_from_iter(self.tcx, tys);
+                        let ty = self.translate_rustc_ty(span, &ty)?;
+                        let tref = ty.as_adt().unwrap().clone();
                         Ok(Rvalue::Aggregate(
                             AggregateKind::Adt(tref, None, None),
                             operands_t,

--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -63,6 +63,8 @@ enum Callable<'a> {
     FnDef {
         item: &'a hax::ItemRef,
         sig: &'a hax::PolyFnSig,
+        /// The arguments, tupled as the `Fn*` traits take them. Binds the same variables as `sig`.
+        tupled_args_ty: &'a hax::Binder<hax::Ty>,
     },
 }
 
@@ -78,6 +80,15 @@ impl<'a> Callable<'a> {
         match self {
             Callable::Closure(args) => &args.fn_sig,
             Callable::FnDef { sig, .. } => sig,
+        }
+    }
+
+    /// The arguments, tupled as the `Fn*` traits take them, e.g. `(A, B, C)`. This is under the
+    /// same binder as `sig`.
+    fn tupled_args_ty(self) -> &'a hax::Ty {
+        match self {
+            Callable::Closure(args) => args.tupled_args_ty.hax_skip_binder_ref(),
+            Callable::FnDef { tupled_args_ty, .. } => tupled_args_ty.hax_skip_binder_ref(),
         }
     }
 }
@@ -107,6 +118,7 @@ impl<'a> CallableFnImpls<'a> {
             }),
             hax::FullDefKind::Fn {
                 sig,
+                tupled_args_ty,
                 fn_once_impl,
                 fn_mut_impl,
                 fn_impl,
@@ -114,6 +126,7 @@ impl<'a> CallableFnImpls<'a> {
             }
             | hax::FullDefKind::AssocFn {
                 sig,
+                tupled_args_ty,
                 fn_once_impl,
                 fn_mut_impl,
                 fn_impl,
@@ -121,6 +134,7 @@ impl<'a> CallableFnImpls<'a> {
             }
             | hax::FullDefKind::Ctor {
                 sig,
+                tupled_args_ty,
                 fn_once_impl,
                 fn_mut_impl,
                 fn_impl,
@@ -129,6 +143,7 @@ impl<'a> CallableFnImpls<'a> {
                 callable: Callable::FnDef {
                     item: def.this(),
                     sig,
+                    tupled_args_ty: tupled_args_ty.as_ref()?,
                 },
                 fn_once_impl: fn_once_impl.as_deref(),
                 fn_mut_impl: fn_mut_impl.as_deref(),
@@ -235,7 +250,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         span: Span,
         closure: &hax::ClosureArgs,
     ) -> Result<TypeDeclRef, Error> {
-        self.translate_item(span, &closure.item, TransItemSourceKind::Type)
+        self.translate_type_decl_ref(span, &closure.item)
     }
 
     /// For stateless closures, translate a function reference to the top-level function that
@@ -407,10 +422,10 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             }
         };
 
-        // The types that the closure takes as input.
-        let input_tys: Vec<Ty> = mem::take(&mut fun_sig.inputs);
-        // The method takes `self` and the closure inputs as a tuple.
-        fun_sig.inputs = vec![state_ty, Ty::mk_tuple(input_tys)];
+        let tupled_args_ty = self
+            .translate_ty(span, callable.tupled_args_ty())?
+            .move_under_binder();
+        fun_sig.inputs = vec![state_ty, tupled_args_ty];
 
         Ok(RegionBinder {
             regions: bound_regions,
@@ -476,6 +491,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                     }
                 });
 
+                // Remember how many arguments there are
+                let closure_arg_count = locals.arg_count - 1;
                 let mut old_locals = mem::take(&mut locals.locals).into_iter();
                 locals.arg_count = 2;
                 locals.locals.push(old_locals.next().unwrap()); // ret
@@ -486,8 +503,14 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                     l
                 }));
 
-                let untupled_args = tupled_ty.as_tuple().unwrap();
-                let new_stts = untupled_args.iter().cloned().enumerate().map(|(i, ty)| {
+                let untupled_args = locals
+                    .locals
+                    .iter()
+                    .skip(3)
+                    .take(closure_arg_count)
+                    .map(|l| &l.ty)
+                    .cloned();
+                let new_stts = untupled_args.enumerate().map(|(i, ty)| {
                     let nth_field = tupled_arg
                         .clone()
                         .project(ProjectionElem::Field(None, FieldId::new(i)), ty);
@@ -605,11 +628,17 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
         let output = builder.new_var(None, signature.output.clone());
         let _state = builder.new_var(Some("state".to_string()), signature.inputs[0].clone());
-        let tupled_args = builder.new_var(Some("args".to_string()), signature.inputs[1].clone());
-        let arg_tys = signature.inputs[1].as_tuple().unwrap();
+        let tupled_args_ty = &signature.inputs[1];
+        let tupled_args = builder.new_var(Some("args".to_string()), tupled_args_ty.clone());
+
+        // We need the type declaration to have been translated to get the fields (since in monomorphic)
+        // mode they aren't in the generics. So ensure it's been translated!
+        let tuple_id = tupled_args_ty.as_adt().unwrap().id;
+        let _ = self.get_or_translate(ItemId::Type(tuple_id))?;
+        let arg_tys = tupled_args_ty.as_tuple_fields(&self.t_ctx.translated);
+
         let args = arg_tys
-            .iter()
-            .cloned()
+            .into_iter()
             .enumerate()
             .map(|(i, ty)| {
                 let nth_field = tupled_args
@@ -650,7 +679,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         let impl_ref = self.translate_callable_impl_ref(span, callable.item(), target_kind)?;
         let src = FunSource::TraitImpl {
             impl_ref,
-            trait_ref: implemented_trait,
+            trait_ref: implemented_trait.clone(),
             item_id: method_id,
             reuses_default: false,
         };
@@ -790,7 +819,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                 .enumerate()
                 .map(|(i, ty)| builder.new_var(Some(format!("arg{}", i + 1)), ty.clone()))
                 .collect();
-            let args_tupled_ty = Ty::mk_tuple(signature.inputs.clone());
+            let args_tupled_ty =
+                self.translate_ty(span, closure.tupled_args_ty.hax_skip_binder_ref())?;
             let args_tupled = builder.new_var(Some("args".to_string()), args_tupled_ty.clone());
             let state = builder.new_var(Some("state".to_string()), state_ty.clone());
 

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -514,6 +514,20 @@ impl<'tcx> TranslateCtx<'tcx> {
         Ok(*item_id.as_const().unwrap())
     }
 
+    /// Claim the first type id for the declaration of the unit type.
+    pub(crate) fn reserve_unit_decl(&mut self) {
+        let def_id = hax::DefId::make_synthetic(&self.hax_state, hax::SyntheticItem::Tuple(0));
+        let item_src = if self.options.monomorphize_with_hax
+            && let Ok(def) = self.poly_hax_def(&def_id)
+        {
+            TransItemSource::monomorphic(def.this(), TransItemSourceKind::Type)
+        } else {
+            TransItemSource::polymorphic(&def_id, TransItemSourceKind::Type)
+        };
+        let id: Option<TypeDeclId> = self.register_no_enqueue(&None, &item_src);
+        assert_eq!(id, Some(TypeDeclId::UNIT), "the unit type must come first");
+    }
+
     pub(crate) fn register_target_info(&mut self) {
         let target_data = &self.tcx.data_layout;
         let triple = self.get_target_triple();
@@ -798,17 +812,30 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         span: Span,
         item: &hax::ItemRef,
     ) -> Result<TypeDeclRef, Error> {
-        match self.recognize_builtin_type(item)? {
-            Some(id) => {
-                let generics =
-                    self.translate_generic_args(span, &item.generic_args, &item.trait_proofs)?;
-                Ok(TypeDeclRef {
-                    id: TypeId::Builtin(id),
-                    generics: Box::new(generics),
-                })
-            }
-            None => self.translate_item(span, item, TransItemSourceKind::Type),
-        }
+        self.translate_type_decl_ref_maybe_enqueue(span, item, TransItemSourceKind::Type, true)
+    }
+
+    /// Register a type item and maybe enqueue it for translation. Use this to
+    /// obtain a `TypeDeclRef`, don't construct one manually.
+    pub(crate) fn translate_type_decl_ref_maybe_enqueue(
+        &mut self,
+        span: Span,
+        item: &hax::ItemRef,
+        kind: TransItemSourceKind,
+        enqueue: bool,
+    ) -> Result<TypeDeclRef, Error> {
+        let item_ref: DeclRef<ItemId> =
+            self.translate_item_maybe_enqueue(span, item, kind, enqueue)?;
+        assert!(item_ref.trait_ref.is_none());
+        let builtin = match kind {
+            TransItemSourceKind::Type => self.recognize_builtin_type(item),
+            _ => None,
+        };
+        Ok(TypeDeclRef {
+            id: item_ref.id.try_into().unwrap(),
+            generics: item_ref.generics,
+            builtin,
+        })
     }
 
     /// Translate a reference to a trait method declaration without registering the declaration as
@@ -1028,6 +1055,7 @@ pub fn translate<'tcx>(
         lt_mutability_computer: Default::default(),
     };
     ctx.register_target_info();
+    ctx.reserve_unit_decl();
 
     // Start translating from the selected items.
     for start_from in ctx.options.start_from.clone() {

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -524,7 +524,11 @@ impl<'tcx> TranslateCtx<'tcx> {
         } else {
             TransItemSource::polymorphic(&def_id, TransItemSourceKind::Type)
         };
-        let id: Option<TypeDeclId> = self.register_no_enqueue(&None, &item_src);
+        let id: Option<TypeDeclId> = if self.options.no_gen_tuple_structs {
+            self.register_and_enqueue(&None, item_src)
+        } else {
+            self.register_no_enqueue(&None, &item_src)
+        };
         assert_eq!(id, Some(TypeDeclId::UNIT), "the unit type must come first");
     }
 
@@ -824,13 +828,23 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         kind: TransItemSourceKind,
         enqueue: bool,
     ) -> Result<TypeDeclRef, Error> {
-        let item_ref: DeclRef<ItemId> =
-            self.translate_item_maybe_enqueue(span, item, kind, enqueue)?;
-        assert!(item_ref.trait_ref.is_none());
         let builtin = match kind {
             TransItemSourceKind::Type => self.recognize_builtin_type(item),
             _ => None,
         };
+        if builtin == Some(BuiltinTy::Tuple) && self.t_ctx.options.no_gen_tuple_structs {
+            let mut generics = self.translate_generic_args(span, &item.generic_args, &[])?;
+            // The declaration has no clauses, so we drop the `Sized` proofs of the fields.
+            generics.trait_refs.clear();
+            return Ok(TypeDeclRef {
+                id: TypeDeclId::UNIT,
+                generics: Box::new(generics),
+                builtin,
+            });
+        }
+        let item_ref: DeclRef<ItemId> =
+            self.translate_item_maybe_enqueue(span, item, kind, enqueue)?;
+        assert!(item_ref.trait_ref.is_none());
         Ok(TypeDeclRef {
             id: item_ref.id.try_into().unwrap(),
             generics: item_ref.generics,

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -438,12 +438,13 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         let span = item_meta.span;
 
         // Get the kind of the type decl.
-        let src = match def.kind() {
-            hax::FullDefKind::Closure { args, .. } => {
-                let info = self.translate_closure_info(span, args)?;
-                TypeSource::Closure { info }
-            }
-            _ => TypeSource::Normal,
+        let src = if let hax::FullDefKind::Closure { args, .. } = def.kind() {
+            let info = self.translate_closure_info(span, args)?;
+            TypeSource::Closure { info }
+        } else if let Some(builtin) = self.recognize_builtin_type(def.this()) {
+            TypeSource::Builtin(builtin)
+        } else {
+            TypeSource::Normal
         };
 
         // Translate type body

--- a/charon/src/bin/charon-driver/translate/translate_meta.rs
+++ b/charon/src/bin/charon-driver/translate/translate_meta.rs
@@ -205,6 +205,13 @@ impl<'tcx> TranslateCtx<'tcx> {
         item: &RustcItem,
     ) -> Result<Option<PathElem>, Error> {
         let def_id = item.def_id();
+        if let Some(synthetic) = def_id.as_synthetic(&self.hax_state) {
+            return Ok(match synthetic {
+                hax::SyntheticItem::Tuple(n) => Some(PathElem::Builtin(BuiltinPathElem::Tuple(n))),
+                hax::SyntheticItem::Str => Some(PathElem::Builtin(BuiltinPathElem::Str)),
+                hax::SyntheticItem::Array | hax::SyntheticItem::Slice => None,
+            });
+        }
         let path_elem = def_id.path_item(&self.hax_state);
         // Disambiguator disambiguates identically-named (but distinct) identifiers. This happens
         // notably with macros and inherent impl blocks.
@@ -342,7 +349,8 @@ impl<'tcx> TranslateCtx<'tcx> {
         let def_id = item.def_id();
         trace!("Computing name for `{def_id:?}`");
 
-        let parent_name = if let Some(parent_id) = def_id.parent(&self.hax_state) {
+        let is_builtin = def_id.as_synthetic(&self.hax_state).is_some();
+        let parent_name = if !is_builtin && let Some(parent_id) = def_id.parent(&self.hax_state) {
             let def = self.hax_def_for_item(item)?;
             if matches!(item, RustcItem::Mono(..))
                 && let Some(parent_item) = def.typing_parent(&self.hax_state)

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -257,8 +257,12 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
         // Don't enqueue the vtable for translation by default. It will be enqueued if used in a
         // `dyn Trait`.
-        let mut vtable_ref: TypeDeclRef =
-            self.translate_item_maybe_enqueue(span, tref, TransItemSourceKind::VTable, enqueue)?;
+        let mut vtable_ref = self.translate_type_decl_ref_maybe_enqueue(
+            span,
+            tref,
+            TransItemSourceKind::VTable,
+            enqueue,
+        )?;
         // Remove the `Self` type variable from the generic parameters.
         vtable_ref
             .generics
@@ -936,8 +940,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         // Retrieve the expected field types from the struct definition. This avoids complicated
         // substitutions.
         let field_tys = {
-            let vtable_decl_id = vtable_struct_ref.adt_id();
-            let ItemRef::Type(vtable_def) = self.t_ctx.get_or_translate(vtable_decl_id.into())?
+            let ItemRef::Type(vtable_def) =
+                self.t_ctx.get_or_translate(vtable_struct_ref.id.into())?
             else {
                 unreachable!()
             };

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -775,6 +775,10 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             return Ok(TypeDeclKind::Opaque);
         }
 
+        if matches!(adt_kind, AdtKind::Tuple) && self.t_ctx.options.no_gen_tuple_structs {
+            return Ok(TypeDeclKind::Opaque);
+        }
+
         // hax's synthetic ADTs have no variants; we must construct the fields ourselves
         let synthetic_fields = match adt_kind {
             AdtKind::Tuple => {

--- a/charon/src/bin/charon-driver/translate/translate_types.rs
+++ b/charon/src/bin/charon-driver/translate/translate_types.rs
@@ -164,8 +164,8 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 let tref = self.translate_type_decl_ref(span, item)?;
                 TyKind::Adt(tref)
             }
-            hax::TyKind::Str => {
-                let tref = TypeDeclRef::new(TypeId::Builtin(BuiltinTy::Str), GenericArgs::empty());
+            hax::TyKind::Str(item_ref) => {
+                let tref = self.translate_type_decl_ref(span, item_ref)?;
                 TyKind::Adt(tref)
             }
             hax::TyKind::Array(item_ref) => {
@@ -187,8 +187,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 TyKind::Slice(args.types.pop().unwrap())
             }
             hax::TyKind::Tuple(item_ref) => {
-                let args = self.translate_generic_args(span, &item_ref.generic_args, &[])?;
-                let tref = TypeDeclRef::new(TypeId::Builtin(BuiltinTy::Tuple), args);
+                let tref = self.translate_type_decl_ref(span, item_ref)?;
                 TyKind::Adt(tref)
             }
             hax::TyKind::Ref(region, ty, mutability) => {
@@ -402,19 +401,18 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         })
     }
 
-    /// Checks whether the given id corresponds to a built-in type.
-    pub(crate) fn recognize_builtin_type(
-        &mut self,
-        item: &hax::ItemRef,
-    ) -> Result<Option<BuiltinTy>, Error> {
-        let def = self.hax_def(item)?;
-        let ty = if def.lang_item == Some(sym::owned_box) && self.t_ctx.options.treat_box_as_builtin
-        {
-            Some(BuiltinTy::Box)
-        } else {
-            None
-        };
-        Ok(ty)
+    /// Whether Rust treats this type specially, i.e. whether it is a tuple, `str` or `Box`.
+    pub(crate) fn recognize_builtin_type(&mut self, item: &hax::ItemRef) -> Option<BuiltinTy> {
+        item.def_id
+            .as_synthetic(self.hax_state())
+            .and_then(|synthetic| match synthetic {
+                hax::SyntheticItem::Tuple(_) => Some(BuiltinTy::Tuple),
+                hax::SyntheticItem::Str => Some(BuiltinTy::Str),
+                hax::SyntheticItem::Array | hax::SyntheticItem::Slice => None,
+            })
+            .or_else(|| {
+                (self.hax_def(item).ok()?.lang_item? == sym::owned_box).then_some(BuiltinTy::Box)
+            })
     }
 
     /// Translate a Dynamically Sized Type metadata kind.
@@ -775,6 +773,34 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
 
         if item_meta.opacity.is_opaque() {
             return Ok(TypeDeclKind::Opaque);
+        }
+
+        // hax's synthetic ADTs have no variants; we must construct the fields ourselves
+        let synthetic_fields = match adt_kind {
+            AdtKind::Tuple => {
+                let item = def.this();
+                let args = self.translate_generic_args(def_span, &item.generic_args, &[])?;
+                Some(args.types.into_iter().collect_vec())
+            }
+            AdtKind::Str => {
+                let u8_ty = TyKind::Literal(LiteralTy::UInt(UIntTy::U8)).into_ty();
+                Some(vec![Ty::mk_slice(u8_ty)])
+            }
+            _ => None,
+        };
+        if let Some(tys) = synthetic_fields {
+            let fields = tys
+                .into_iter()
+                .enumerate()
+                .map(|(field_id, ty)| Field {
+                    span: def_span,
+                    attr_info: AttrInfo::dummy_public(),
+                    name: format!("_{field_id}"),
+                    is_positional: true,
+                    ty,
+                })
+                .collect();
+            return Ok(TypeDeclKind::Struct(fields));
         }
 
         trace!("{}", trans_id);

--- a/charon/src/bin/generate-asts/generate_ml.rs
+++ b/charon/src/bin/generate-asts/generate_ml.rs
@@ -42,9 +42,10 @@ impl<'a> GenerateCtx<'a> {
         let mut type_tree = HashMap::default();
         for ty in &crate_data.type_decls {
             let long_name = repr_name(&ty.item_meta.name);
-            if long_name.starts_with("charon_lib") {
-                let short_name = ty.item_meta.name.short_str().unwrap().to_string();
-                name_to_type.insert(short_name, ty);
+            if long_name.starts_with("charon_lib")
+                && let Some(short_name) = ty.item_meta.name.short_str()
+            {
+                name_to_type.insert(short_name.to_string(), ty);
             }
             name_to_type.insert(long_name, ty);
 

--- a/charon/src/bin/generate-asts/generate_ml/of_json.rs
+++ b/charon/src/bin/generate-asts/generate_ml/of_json.rs
@@ -92,8 +92,9 @@ const MANUAL_IMPLS: &[(&str, &str)] = &[
 impl<'a> GenerateCtx<'a> {
     fn build_function(&self, decl: &TypeDecl, branches: &str) -> String {
         let ty = TyKind::Adt(TypeDeclRef {
-            id: TypeId::Adt(decl.def_id),
+            id: decl.def_id,
             generics: decl.generics.identity_args().into(),
+            builtin: decl.src.as_builtin().cloned(),
         })
         .into_ty();
         let (ty_name, _) = self.type_to_ocaml_ident_raw(decl);
@@ -158,17 +159,17 @@ impl<'a> GenerateCtx<'a> {
                 let mut wrap_in_map = false;
                 match tref.as_builtin() {
                     None => {
-                        let id = tref.adt_id();
-                        let mut first = if let Some(tdecl) = self.crate_data.type_decls.get(id) {
+                        let mut first = if let Some(tdecl) = self.crate_data.type_decls.get(tref.id)
+                        {
                             let (name, module) = self.type_to_ocaml_ident_raw(tdecl);
                             match module {
-                                Some((_, short)) if !self.current_ids.contains(&id) => {
+                                Some((_, short)) if !self.current_ids.contains(&tref.id) => {
                                     format!("{short}.{name}")
                                 }
                                 _ => name,
                             }
                         } else {
-                            format!("missing_type_{id}")
+                            format!("missing_type_{}", tref.id)
                         };
                         if first == "vec" {
                             first = "list".to_string();

--- a/charon/src/bin/generate-asts/generate_ml/of_postcard.rs
+++ b/charon/src/bin/generate-asts/generate_ml/of_postcard.rs
@@ -85,8 +85,9 @@ const MANUAL_IMPLS: &[(&str, &str)] = &[
 impl<'a> GenerateCtx<'a> {
     fn build_postcard_function(&self, decl: &TypeDecl, body: &str) -> String {
         let ty = TyKind::Adt(TypeDeclRef {
-            id: TypeId::Adt(decl.def_id),
+            id: decl.def_id,
             generics: decl.generics.identity_args().into(),
+            builtin: decl.src.as_builtin().cloned(),
         })
         .into_ty();
         let (ty_name, _) = self.type_to_ocaml_ident_raw(decl);
@@ -160,17 +161,17 @@ impl<'a> GenerateCtx<'a> {
                 let mut wrap_in_map = false;
                 match tref.as_builtin() {
                     None => {
-                        let id = tref.adt_id();
-                        let mut first = if let Some(tdecl) = self.crate_data.type_decls.get(id) {
+                        let mut first = if let Some(tdecl) = self.crate_data.type_decls.get(tref.id)
+                        {
                             let (name, module) = self.type_to_ocaml_ident_raw(tdecl);
                             match module {
-                                Some((_, short)) if !self.current_ids.contains(&id) => {
+                                Some((_, short)) if !self.current_ids.contains(&tref.id) => {
                                     format!("{short}.{name}")
                                 }
                                 _ => name,
                             }
                         } else {
-                            format!("missing_type_{id}")
+                            format!("missing_type_{}", tref.id)
                         };
                         if first == "vec" {
                             first = "list".to_string();

--- a/charon/src/bin/generate-asts/generate_ml/util.rs
+++ b/charon/src/bin/generate-asts/generate_ml/util.rs
@@ -14,6 +14,8 @@ pub fn repr_name(n: &Name) -> String {
             PathElem::Impl(..) => "<impl>".to_string(),
             PathElem::Instantiated(..) => "<mono>".to_string(),
             PathElem::Target(target) => target.clone(),
+            PathElem::Builtin(BuiltinPathElem::Tuple(n)) => format!("<tuple_{n}>"),
+            PathElem::Builtin(BuiltinPathElem::Str) => "<str>".to_string(),
         })
         .join("::")
 }
@@ -118,7 +120,7 @@ impl<'a> GenerateCtx<'a> {
 
     /// For a type that refers to an ADT, return the name of that ADT.
     pub fn type_to_rust_name(&self, ty: &Ty) -> Option<&str> {
-        let index_ty = ty.as_adt()?.as_adt()?;
+        let index_ty = ty.as_adt()?.id;
         self.crate_data.item_name(index_ty).short_str()
     }
 
@@ -155,14 +157,14 @@ impl<'a> GenerateCtx<'a> {
                     .collect_vec();
                 match tref.as_builtin() {
                     None => {
-                        let id = tref.adt_id();
-                        let mut base_ty = if let Some(tdecl) = self.crate_data.type_decls.get(id) {
-                            self.type_to_ocaml_ident(tdecl)
-                        } else {
-                            let name = self.crate_data.item_name(id);
-                            eprintln!("Warning: type {} missing from llbc", repr_name(name));
-                            name.short_str().unwrap().to_lowercase()
-                        };
+                        let mut base_ty =
+                            if let Some(tdecl) = self.crate_data.type_decls.get(tref.id) {
+                                self.type_to_ocaml_ident(tdecl)
+                            } else {
+                                let name = self.crate_data.item_name(tref.id);
+                                eprintln!("Warning: type {} missing from llbc", repr_name(name));
+                                name.short_str().unwrap().to_lowercase()
+                            };
                         if base_ty == "vec" {
                             base_ty = "list".to_string();
                         }

--- a/charon/src/bin/generate-asts/generate_rust.rs
+++ b/charon/src/bin/generate-asts/generate_rust.rs
@@ -387,6 +387,8 @@ impl<'a> Generator<'a> {
                 PathElem::Impl(_) => "<impl>".to_string(),
                 PathElem::Instantiated(_) => "<mono>".to_string(),
                 PathElem::Target(target) => target.clone(),
+                PathElem::Builtin(BuiltinPathElem::Tuple(n)) => format!("<tuple_{n}>"),
+                PathElem::Builtin(BuiltinPathElem::Str) => "<str>".to_string(),
             })
             .join("::")
     }

--- a/charon/src/bin/generate-asts/generate_rust/ast.rs
+++ b/charon/src/bin/generate-asts/generate_rust/ast.rs
@@ -162,17 +162,14 @@ impl Generator<'_> {
         tref: &TypeDeclRef,
     ) -> fmt::Result {
         match tref.as_builtin() {
-            None => {
-                let id = tref.adt_id();
-                match self.datatype_for(id) {
-                    Some(RustcDatatype::Special {
-                        fmt_type: generated_type,
-                        ..
-                    }) => generated_type(self, f, &tref.generics),
-                    _ if self.enqueue(id) => write!(f, "{}", self.type_name(id)),
-                    _ => self.unsupported_type(self.debug_type_name(id)),
-                }
-            }
+            None => match self.datatype_for(tref.id) {
+                Some(RustcDatatype::Special {
+                    fmt_type: generated_type,
+                    ..
+                }) => generated_type(self, f, &tref.generics),
+                _ if self.enqueue(tref.id) => write!(f, "{}", self.type_name(tref.id)),
+                _ => self.unsupported_type(self.debug_type_name(tref.id)),
+            },
             Some(BuiltinTy::Tuple) => self.fmt_tuple_type(f, &tref.generics.types),
             Some(BuiltinTy::Box) => {
                 let ty = tref.generics.types.iter().next().unwrap();

--- a/charon/src/bin/generate-asts/generate_rust/translation.rs
+++ b/charon/src/bin/generate-asts/generate_rust/translation.rs
@@ -223,19 +223,16 @@ impl Generator<'_> {
         value: &str,
     ) -> fmt::Result {
         match tref.as_builtin() {
-            None => {
-                let id = tref.adt_id();
-                match self.datatype_for(id) {
-                    Some(RustcDatatype::Special {
-                        fmt_translation: translation_expr,
-                        ..
-                    }) => translation_expr(self, f, &tref.generics, value),
-                    _ if self.enqueue(id) => {
-                        write!(f, "self.{}({value})?", self.translate_fn_name(id))
-                    }
-                    _ => self.unsupported_type(self.debug_type_name(id)),
+            None => match self.datatype_for(tref.id) {
+                Some(RustcDatatype::Special {
+                    fmt_translation: translation_expr,
+                    ..
+                }) => translation_expr(self, f, &tref.generics, value),
+                _ if self.enqueue(tref.id) => {
+                    write!(f, "self.{}({value})?", self.translate_fn_name(tref.id))
                 }
-            }
+                _ => self.unsupported_type(self.debug_type_name(tref.id)),
+            },
             Some(BuiltinTy::Tuple) => {
                 self.fmt_tuple_translation_expr(f, &tref.generics.types, value)
             }

--- a/charon/src/export/multi_target.rs
+++ b/charon/src/export/multi_target.rs
@@ -913,9 +913,7 @@ impl<'a> IdRefMapperVisitor<'a> {
 
 impl VisitAstMut for IdRefMapperVisitor<'_> {
     fn enter_type_decl_ref(&mut self, x: &mut TypeDeclRef) {
-        if let Some(id) = x.as_adt_mut() {
-            self.map(id);
-        }
+        self.map(&mut x.id);
     }
     fn enter_fun_decl_ref(&mut self, x: &mut FunDeclRef) {
         self.map(&mut x.id);

--- a/charon/src/name_matcher/mod.rs
+++ b/charon/src/name_matcher/mod.rs
@@ -147,11 +147,8 @@ impl Pattern {
         }
         match ty.kind() {
             TyKind::Adt(tref) => {
-                let name = match tref.as_builtin() {
-                    Some(builtin_ty) => &builtin_ty.get_name(),
-                    None => ctx.item_name(tref.adt_id()),
-                };
-                self.matches_with_generics(ctx, name, Some(&tref.generics))
+                let type_name = ctx.item_name(tref.id);
+                self.matches_with_generics(ctx, type_name, Some(&tref.generics))
             }
             TyKind::Array(ty, len) => {
                 let type_name = Name::from_path(&["Array"]);
@@ -258,6 +255,14 @@ impl PatElem {
                     pat_ident == ident || (pat_ident == "crate" && ident == &ctx.crate_name);
                 same_ident && PatTy::matches_generics(ctx, generics, args)
             }
+            (
+                PatElem::Ident {
+                    name: pat_ident,
+                    generics,
+                    ..
+                },
+                PathElem::Builtin(BuiltinPathElem::Str),
+            ) => pat_ident == "str" && PatTy::matches_generics(ctx, generics, args),
             (PatElem::Impl(_pat), PathElem::Impl(ImplElem::Ty(..))) => {
                 // TODO
                 false

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -217,6 +217,14 @@ pub struct CliOpts {
     #[clap(long)]
     #[serde(default)]
     pub treat_box_as_builtin: bool,
+    /// Don't generate a type declaration per tuple arity. Instead, every tuple type refers to the
+    /// single opaque declaration with id `TypeDeclId::UNIT`, and stores its field types in its
+    /// generic arguments. This is meant for consumers that build tuples of arbitrary arity on the
+    /// fly and don't care about their declaration. Note that this makes tuple types ill-typed with
+    /// respect to their declaration; it is also incompatible with `--monomorphize`.
+    #[clap(long)]
+    #[serde(default)]
+    pub no_gen_tuple_structs: bool,
     /// Do not inline or evaluate constants.
     #[clap(long)]
     #[serde(default)]
@@ -478,6 +486,7 @@ impl CliOpts {
                     self.remove_adt_clauses = true;
                     self.unbind_item_vars = true;
                     self.deallocate_all_locals = true;
+                    self.no_gen_tuple_structs = true;
                 }
                 Preset::Eurydice => {
                     self.hide_allocator = true;
@@ -545,6 +554,12 @@ impl CliOpts {
             anyhow::bail!(
                 "`--monomorphize-mut=except-types` should be used with `--remove-adt-clauses` \
                 to avoid generics mismatches"
+            )
+        }
+        if self.no_gen_tuple_structs && self.monomorphize {
+            anyhow::bail!(
+                "`--no-gen-tuple-structs` is not compatible with `--monomorphize`, as \
+                monomorphization requires each tuple to have its own type declaration"
             )
         }
         if self.no_serialize && self.format.is_some() {
@@ -659,6 +674,9 @@ pub struct TranslateOptions {
     pub print_built_llbc: bool,
     /// Treat `Box<T>` as if it was a built-in type.
     pub treat_box_as_builtin: bool,
+    /// Make all tuples refer to the single opaque `TypeDeclId::UNIT` declaration, and store their
+    /// field types in their generic arguments.
+    pub no_gen_tuple_structs: bool,
     /// Don't inline or evaluate constants.
     pub raw_consts: bool,
     /// Whether to evaluate the value of named constants and statics, or to keep a call
@@ -825,6 +843,7 @@ impl TranslateOptions {
             print_built_llbc: options.print_built_llbc,
             item_opacities,
             treat_box_as_builtin: options.treat_box_as_builtin,
+            no_gen_tuple_structs: options.no_gen_tuple_structs,
             raw_consts: options.raw_consts,
             consts: options.consts.unwrap_or_default(),
             unsized_strings: options.unsized_strings,

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -847,6 +847,10 @@ impl TranslateOptions {
     /// `#[charon::opaque]` annotations, only cli parameters.
     #[tracing::instrument(skip(self, krate), ret)]
     pub fn opacity_for_name(&self, krate: &TranslatedCrate, name: &Name) -> ItemOpacity {
+        // Builtin names (str, tuples) are always transparent.
+        if name.is_builtin() {
+            return ItemOpacity::Transparent;
+        }
         // Find the most precise pattern that matches this name. There is always one since
         // the list contains the `_` pattern. If there are conflicting settings for this item, we
         // err on the side of being more opaque.

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1259,13 +1259,12 @@ impl<C: AstFormatter> FmtWithCtx<C> for NullOp {
             NullOp::SizeOf => "size_of",
             NullOp::AlignOf => "align_of",
             &NullOp::OffsetOf(ref ty, variant, field) => {
-                let tid = ty.adt_id();
                 write!(f, "offset_of({}.", ty.with_ctx(ctx))?;
                 if let Some(variant) = variant {
-                    ctx.format_enum_variant_name(f, tid, variant)?;
+                    ctx.format_enum_variant_name(f, ty.id, variant)?;
                     write!(f, ".")?;
                 }
-                ctx.format_field_name(f, tid, variant, field)?;
+                ctx.format_field_name(f, ty.id, variant, field)?;
                 write!(f, ")")?;
                 return Ok(());
             }
@@ -1316,6 +1315,12 @@ impl<C: AstFormatter> FmtWithCtx<C> for PathElem {
                 }
                 write!(f, "{}", impl_elem.with_ctx(ctx))
             }
+            PathElem::Builtin(BuiltinPathElem::Tuple(n)) => {
+                let fields = std::iter::repeat_n("_", *n).format(", ");
+                let trailing_comma = if *n == 1 { "," } else { "" };
+                write!(f, "({fields}{trailing_comma})")
+            }
+            PathElem::Builtin(BuiltinPathElem::Str) => write!(f, "str"),
             PathElem::Instantiated(binder) => {
                 // Anonymize all parameters.
                 let underscore = "_".to_string();
@@ -1360,21 +1365,15 @@ impl<C: AstFormatter> FmtWithCtx<C> for Place {
                     ProjectionElem::Deref => write!(f, "(*{sub})"),
                     ProjectionElem::Field(variant_id, field_id) => {
                         let tref = subplace.ty().as_adt().unwrap();
-                        match tref.as_adt() {
-                            Some(adt_id) => {
-                                match variant_id {
-                                    None => write!(f, "{sub}.")?,
-                                    Some(variant_id) => {
-                                        write!(f, "({sub} as variant ")?;
-                                        ctx.format_enum_variant(f, adt_id, *variant_id)?;
-                                        write!(f, ").")?;
-                                    }
-                                }
-                                ctx.format_field_name(f, adt_id, *variant_id, *field_id)
+                        match variant_id {
+                            None => write!(f, "{sub}.")?,
+                            Some(variant_id) => {
+                                write!(f, "({sub} as variant ")?;
+                                ctx.format_enum_variant(f, tref.id, *variant_id)?;
+                                write!(f, ").")?;
                             }
-                            None if tref.is_tuple() => write!(f, "{sub}.{field_id}"),
-                            None => unreachable!("field projection on builtin type"),
                         }
+                        ctx.format_field_name(f, tref.id, *variant_id, *field_id)
                     }
                     ProjectionElem::PtrMetadata => write!(f, "{sub}.metadata"),
                     ProjectionElem::Index {
@@ -1596,45 +1595,24 @@ impl<C: AstFormatter> FmtWithCtx<C> for ConstantExpr {
             ConstantExprKind::Literal(c) => write!(f, "{}", c),
             ConstantExprKind::Adt(variant_id, values) => {
                 let values = values.iter().map(|v| v.with_ctx(ctx));
-                match self.ty().as_adt() {
-                    Some(ty_ref) => match ty_ref.as_builtin() {
-                        Some(BuiltinTy::Tuple) => {
-                            let trailing_comma = if values.len() == 1 { "," } else { "" };
-                            let values = values.format(", ");
-                            write!(f, "({values}{trailing_comma})")
-                        }
-                        Some(BuiltinTy::Box) => {
-                            let values = values.format(", ");
-                            write!(f, "Box({values})")
-                        }
-                        Some(BuiltinTy::Str) => {
-                            let values = values.format(", ");
-                            write!(f, "[{values}]")
-                        }
-                        None => {
-                            let ty_id = ty_ref.adt_id();
-                            match variant_id {
-                                None => ty_id.fmt_with_ctx(ctx, f)?,
-                                Some(variant_id) => {
-                                    ctx.format_enum_variant(f, ty_id, *variant_id)?
-                                }
-                            }
-                            write!(f, " {{ ")?;
-                            for (comma, (i, val)) in
-                                repeat_except_first(", ").zip(values.enumerate())
-                            {
-                                write!(f, "{}", comma.unwrap_or_default())?;
-                                let field_id = FieldId::new(i);
-                                ctx.format_field_name(f, ty_id, *variant_id, field_id)?;
-                                write!(f, ": {}", val)?;
-                            }
-                            write!(f, " }}")
-                        }
-                    },
-                    None => {
-                        let values = values.format(", ");
-                        write!(f, "ConstAdt [{values}]")
+                let ty_ref = self.ty().as_adt().unwrap();
+                if ty_ref.is_tuple() {
+                    let trailing_comma = if values.len() == 1 { "," } else { "" };
+                    let values = values.format(", ");
+                    write!(f, "({values}{trailing_comma})")
+                } else {
+                    match variant_id {
+                        None => ty_ref.id.fmt_with_ctx(ctx, f)?,
+                        Some(variant_id) => ctx.format_enum_variant(f, ty_ref.id, *variant_id)?,
                     }
+                    write!(f, " {{ ")?;
+                    for (comma, (i, val)) in repeat_except_first(", ").zip(values.enumerate()) {
+                        write!(f, "{}", comma.unwrap_or_default())?;
+                        let field_id = FieldId::new(i);
+                        ctx.format_field_name(f, ty_ref.id, *variant_id, field_id)?;
+                        write!(f, ": {}", val)?;
+                    }
+                    write!(f, " }}")
                 }
             }
             ConstantExprKind::Array(values) => {
@@ -1874,40 +1852,32 @@ impl<C: AstFormatter> FmtWithCtx<C> for Rvalue {
                 let ops_s = ops.iter().map(|op| op.with_ctx(ctx)).format(", ");
                 match kind {
                     AggregateKind::Adt(ty_ref, variant_id, field_id) => {
-                        match ty_ref.as_builtin() {
-                            Some(BuiltinTy::Tuple) => {
-                                let trailing_comma = if ops.len() == 1 { "," } else { "" };
-                                write!(f, "({ops_s}{trailing_comma})")
+                        if ty_ref.is_tuple() {
+                            let trailing_comma = if ops.len() == 1 { "," } else { "" };
+                            write!(f, "({ops_s}{trailing_comma})")
+                        } else {
+                            match variant_id {
+                                None => ty_ref.id.fmt_with_ctx(ctx, f)?,
+                                Some(variant_id) => {
+                                    ctx.format_enum_variant(f, ty_ref.id, *variant_id)?
+                                }
                             }
-                            Some(BuiltinTy::Box) => write!(f, "Box({})", ops_s),
-                            Some(BuiltinTy::Str) => {
-                                write!(f, "[{}]", ops_s)
-                            }
-                            None => {
-                                let ty_id = ty_ref.adt_id();
-                                match variant_id {
-                                    None => ty_id.fmt_with_ctx(ctx, f)?,
-                                    Some(variant_id) => {
-                                        ctx.format_enum_variant(f, ty_id, *variant_id)?
+                            write!(f, " {{ ")?;
+                            for (comma, (i, op)) in
+                                repeat_except_first(", ").zip(ops.iter().enumerate())
+                            {
+                                write!(f, "{}", comma.unwrap_or_default())?;
+                                let field_id = match *field_id {
+                                    None => FieldId::new(i),
+                                    Some(field_id) => {
+                                        assert_eq!(i, 0); // there should be only one operand
+                                        field_id
                                     }
-                                }
-                                write!(f, " {{ ")?;
-                                for (comma, (i, op)) in
-                                    repeat_except_first(", ").zip(ops.iter().enumerate())
-                                {
-                                    write!(f, "{}", comma.unwrap_or_default())?;
-                                    let field_id = match *field_id {
-                                        None => FieldId::new(i),
-                                        Some(field_id) => {
-                                            assert_eq!(i, 0); // there should be only one operand
-                                            field_id
-                                        }
-                                    };
-                                    ctx.format_field_name(f, ty_id, *variant_id, field_id)?;
-                                    write!(f, ": {}", op.with_ctx(ctx))?;
-                                }
-                                write!(f, " }}")
+                                };
+                                ctx.format_field_name(f, ty_ref.id, *variant_id, field_id)?;
+                                write!(f, ": {}", op.with_ctx(ctx))?;
                             }
+                            write!(f, " }}")
                         }
                     }
                     AggregateKind::Array(..) => {
@@ -2577,18 +2547,18 @@ impl<C: AstFormatter> FmtWithCtx<C> for TraitTypeConstraint {
 impl<C: AstFormatter> FmtWithCtx<C> for Ty {
     fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind() {
-            TyKind::Adt(tref) => match tref.as_builtin() {
-                Some(BuiltinTy::Tuple) => {
-                    let generics = tref.generics.fmt_explicits(ctx).format(", ");
-                    let trailing_comma = if tref.generics.types.len() == 1 {
-                        ","
-                    } else {
-                        ""
-                    };
-                    write!(f, "({generics}{trailing_comma})")
-                }
-                _ => write!(f, "{}", tref.with_ctx(ctx)),
-            },
+            // Print tuples as `(T1, T2, ...)` instead of `(_, _, ...)<T1, T2, ...>`.
+            TyKind::Adt(tref)
+                if tref.is_tuple()
+                    && let Some(krate) = ctx.get_crate() =>
+            {
+                let fields = self.as_tuple_fields(krate);
+                let trailing_comma = if fields.len() == 1 { "," } else { "" };
+                let fields = fields.iter().map(|ty| ty.with_ctx(ctx)).format(", ");
+                write!(f, "({fields}{trailing_comma})",)
+            }
+            TyKind::Adt(tref) if tref.is_str() => write!(f, "str"),
+            TyKind::Adt(tref) => write!(f, "{}", tref.with_ctx(ctx)),
             TyKind::TypeVar(id) => write!(f, "{}", id.with_ctx(ctx)),
             TyKind::Literal(kind) => write!(f, "{kind}"),
             TyKind::Never => write!(f, "!"),
@@ -2730,16 +2700,6 @@ impl<C: AstFormatter> FmtWithCtx<C> for TypeDeclRef {
         let id = self.id.with_ctx(ctx);
         let generics = self.generics.with_ctx(ctx);
         write!(f, "{id}{generics}")
-    }
-}
-
-impl<C: AstFormatter> FmtWithCtx<C> for TypeId {
-    fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            TypeId::Builtin(BuiltinTy::Tuple) => Ok(()),
-            TypeId::Adt(def_id) => write!(f, "{}", def_id.with_ctx(ctx)),
-            TypeId::Builtin(aty) => write!(f, "{}", aty.get_name().with_ctx(ctx)),
-        }
     }
 }
 

--- a/charon/src/transform/add_missing_info/add_implied_outlives.rs
+++ b/charon/src/transform/add_missing_info/add_implied_outlives.rs
@@ -88,8 +88,7 @@ impl VisitAst for OutlivesGatherer<'_> {
                 }
             }
             TyKind::Adt(type_ref)
-                if let Some(type_id) = type_ref.as_adt()
-                    && let Some(decl) = self.type_decls.get(type_id)
+                if let Some(decl) = self.type_decls.get(type_ref.id)
                     && let Some(generics) = type_ref
                         .generics
                         .clone()
@@ -163,10 +162,8 @@ impl<'a> ClosureOutlivesComputer<'a> {
             self.type_decls[type_id]
                 .kind
                 .dyn_visit(|type_ref: &TypeDeclRef| {
-                    if let Some(type_id) = type_ref.as_adt()
-                        && self.closure_tys.get(&type_id).is_some()
-                    {
-                        dependencies.push(type_id);
+                    if self.closure_tys.get(&type_ref.id).is_some() {
+                        dependencies.push(type_ref.id);
                     }
                 });
             for dependency in dependencies {

--- a/charon/src/transform/add_missing_info/compute_short_names.rs
+++ b/charon/src/transform/add_missing_info/compute_short_names.rs
@@ -122,17 +122,7 @@ fn trait_impl_short_name(
             TyKind::Literal(literal) => literal.to_string(),
             TyKind::Slice(..) => "slice".to_owned(),
             TyKind::Array(..) => "array".to_owned(),
-            TyKind::Adt(tref) => match tref.as_adt() {
-                None if tref.is_tuple() && tref.generics.types.is_empty() => "unit".to_owned(),
-                None if tref.is_tuple() => "tuple".to_owned(),
-                Some(id) => item_to_ident(item_names, ItemId::Type(id))?,
-                None => tref
-                    .as_builtin()
-                    .unwrap()
-                    .get_name()
-                    .short_str()?
-                    .to_owned(),
-            },
+            TyKind::Adt(tref) => item_to_ident(item_names, ItemId::Type(tref.id))?,
             _ => return None,
         })
     }

--- a/charon/src/transform/add_missing_info/reorder_decls.rs
+++ b/charon/src/transform/add_missing_info/reorder_decls.rs
@@ -379,10 +379,12 @@ fn compute_declarations_graph(ctx: &TransformCtx) -> DiGraphMap<ItemId, ()> {
         .translated
         .all_items()
         .filter(|item| {
-            ctx.options
-                .start_from
-                .iter()
-                .any(|pat| pat.matches(&ctx.translated, item.item_meta()))
+            item.item_meta().name.is_builtin()
+                || ctx
+                    .options
+                    .start_from
+                    .iter()
+                    .any(|pat| pat.matches(&ctx.translated, item.item_meta()))
         })
         .map(|item| item.id())
         .collect();

--- a/charon/src/transform/normalize/expand_associated_types.rs
+++ b/charon/src/transform/normalize/expand_associated_types.rs
@@ -1349,9 +1349,7 @@ impl VisitAstMut for UpdateItemBody<'_> {
 
     // Update item generics.
     fn enter_type_decl_ref(&mut self, x: &mut TypeDeclRef) {
-        if let Some(id) = x.as_adt() {
-            self.update_item_generics(id, &mut x.generics)
-        }
+        self.update_item_generics(x.id, &mut x.generics)
     }
     fn enter_fun_decl_ref(&mut self, x: &mut FunDeclRef) {
         self.update_item_generics(x.id, &mut x.generics);

--- a/charon/src/transform/normalize/partial_monomorphization.rs
+++ b/charon/src/transform/normalize/partial_monomorphization.rs
@@ -195,11 +195,7 @@ impl<'pm, 'ctx> VisitAstMut for MutabilityShapeBuilder<'pm, 'ctx> {
         }
     }
     fn exit_ty_kind(&mut self, kind: &mut TyKind) {
-        if let TyKind::Adt(TypeDeclRef {
-            id: TypeId::Adt(id),
-            generics,
-        }) = kind
-        {
+        if let TyKind::Adt(TypeDeclRef { id, generics, .. }) = kind {
             // Since the type was not replaced with a type var, it's an infected type. We've
             // traversed it so we have its final explicit arguments. Now we need to satisfy its
             // predicates. For that we add all its predicates to the new item, and pass those new
@@ -335,26 +331,19 @@ impl<'a> PartialMonomorphizer<'a> {
             | TyKind::Array(ty, _)
             | TyKind::Pattern(ty, _)
             | TyKind::Slice(ty) => self.is_infected(ty),
-            TyKind::Adt(tref) => match tref.as_adt() {
-                Some(id) => {
-                    let ty_infected = self.infected_types.contains(&id);
-                    let args_infected = if self.specialize_adts {
-                        // Since we make sure to only call the method on a processed type, any type
-                        // with infected arguments would have been replaced with a fresh instantiated
-                        // (and infected type). Hence we don't need to check the arguments here, only
-                        // the type id.
-                        false
-                    } else {
-                        tref.generics.types.iter().any(|ty| self.is_infected(ty))
-                    };
-                    ty_infected || args_infected
-                }
-                None => {
-                    // Builtin types have no declaration to specialize, so infected arguments stay
-                    // visible inside them.
+            TyKind::Adt(tref) => {
+                let ty_infected = self.infected_types.contains(&tref.id);
+                let args_infected = if self.specialize_adts {
+                    // Since we make sure to only call the method on a processed type, any type
+                    // with infected arguments would have been replaced with a fresh instantiated
+                    // (and infected type). Hence we don't need to check the arguments here, only
+                    // the type id.
+                    false
+                } else {
                     tref.generics.types.iter().any(|ty| self.is_infected(ty))
-                }
-            },
+                };
+                ty_infected || args_infected
+            }
             // A function pointer/item by itself doesn't carry any mutable reference, even if it
             // uses some in its signature. Compare with closures: a closure without captures
             // doesn't trigger partial mono regardless of its signature.
@@ -497,10 +486,10 @@ impl VisitAstMut for PartialMonomorphizer<'_> {
 
     fn exit_type_decl_ref(&mut self, x: &mut TypeDeclRef) {
         if self.specialize_adts
-            && let Some(id) = x.as_adt()
-            && let Some(new_decl_ref) = self.process_generics(id.into(), &x.generics)
+            && let Some(new_decl_ref) = self.process_generics(x.id.into(), &x.generics)
         {
-            *x = new_decl_ref.try_into().unwrap()
+            x.id = new_decl_ref.id.try_into().unwrap();
+            x.generics = new_decl_ref.generics;
         }
     }
     fn exit_fn_ptr(&mut self, x: &mut FnPtr) {

--- a/charon/src/transform/normalize/partial_monomorphization.rs
+++ b/charon/src/transform/normalize/partial_monomorphization.rs
@@ -485,6 +485,9 @@ impl VisitAstMut for PartialMonomorphizer<'_> {
     }
 
     fn exit_type_decl_ref(&mut self, x: &mut TypeDeclRef) {
+        if x.is_tuple() && self.ctx.options.no_gen_tuple_structs {
+            return;
+        }
         if self.specialize_adts
             && let Some(new_decl_ref) = self.process_generics(x.id.into(), &x.generics)
         {

--- a/charon/src/transform/normalize/transform_dyn_trait_calls.rs
+++ b/charon/src/transform/normalize/transform_dyn_trait_calls.rs
@@ -71,8 +71,8 @@ fn transform_dyn_trait_call(
         };
         vtable_ty.clone().substitute_with_tref(trait_ref)
     };
-    let vtable_decl_id = vtable_decl_ref.adt_id();
-    let Some(vtable_decl) = ctx.ctx.translated.type_decls.get(vtable_decl_id) else {
+
+    let Some(vtable_decl) = ctx.ctx.translated.type_decls.get(vtable_decl_ref.id) else {
         return Ok(()); // Missing data
     };
 
@@ -87,7 +87,7 @@ fn transform_dyn_trait_call(
         .iter_enumerated()
         .find(|(_, field)| **field == VTableField::Method(*method_id))
     else {
-        let vtable_name = vtable_decl_id.with_ctx(fmt_ctx).to_string();
+        let vtable_name = vtable_decl_ref.id.with_ctx(fmt_ctx).to_string();
         raise_error!(
             ctx.ctx,
             ctx.span,
@@ -143,7 +143,7 @@ fn transform_dyn_trait_call(
             .ctx
             .translated
             .type_decls
-            .get(current_vtable_ref.adt_id())
+            .get(current_vtable_ref.id)
             .expect("vtable declaration should have been translated");
         let TypeDeclKind::Struct(fields) = &current_vtable.kind else {
             panic!("vtable declaration should be a struct")

--- a/charon/src/transform/resugar/reconstruct_fallible_operations.rs
+++ b/charon/src/transform/resugar/reconstruct_fallible_operations.rs
@@ -159,7 +159,7 @@ struct PendingShiftCheck {
 /// Rustc inserts dynamic checks during MIR lowering. They all end in an `Assert` statement (and
 /// this is the only use of this statement).
 fn remove_dynamic_checks(
-    _ctx: &mut TransformCtx,
+    ctx: &mut TransformCtx,
     uses: &LocalUses,
     block_id: BlockId,
     locals: &mut Locals,
@@ -540,7 +540,7 @@ fn remove_dynamic_checks(
                         uses_of_tuple += 1;
                     }
                     if let Some((sub, ProjectionElem::Field(_, fid))) = p.as_projection()
-                        && sub.ty().as_tuple().is_some()
+                        && sub.ty().is_tuple()
                         && fid.index() == 0
                         && sub == tuple
                     {
@@ -566,7 +566,7 @@ fn remove_dynamic_checks(
                 ..,
             ] = rest
                 && let Some((sub, ProjectionElem::Field(_, fid))) = assert_cond.as_projection()
-                && sub.ty().as_tuple().is_some()
+                && sub.ty().is_tuple()
                 && fid.index() == 1
                 && sub == tuple
             {
@@ -592,14 +592,17 @@ fn remove_dynamic_checks(
             }
             // Fixup the local type.
             let result_local = &mut locals.locals[tuple_local_id];
-            result_local.ty = result_local.ty.as_tuple().unwrap()[0].clone();
+            result_local.ty = result_local
+                .ty
+                .as_tuple_fields(&ctx.translated)
+                .swap_remove(0);
             // Fixup the place type.
             let new_result_place = locals.place_for_var(tuple_local_id);
             // Replace uses of `r.0` with `r`.
             for stmt in rest.iter_mut() {
                 stmt.dyn_visit_in_body_mut(|p: &mut Place| {
                     if let Some((sub, ProjectionElem::Field(_, fid))) = p.as_projection()
-                        && sub.ty().as_tuple().is_some()
+                        && sub.ty().is_tuple()
                         && sub == tuple
                     {
                         assert_eq!(fid.index(), 0);

--- a/charon/src/transform/resugar/reconstruct_intrinsics.rs
+++ b/charon/src/transform/resugar/reconstruct_intrinsics.rs
@@ -22,7 +22,6 @@ impl UllbcPass for Transform {
                 && let generics = fn_ptr.pre_mono_generics(&ctx.ctx.translated)
                 && let Some(ty) = generics.types.get(TypeVarId::ZERO)
                 && let TyKind::Adt(tref) = ty.kind()
-                && let Some(type_id) = tref.as_adt()
                 && let [Operand::Const(arg0), Operand::Const(arg1)] = call.args.as_slice()
                 && let ConstantExprKind::Literal(Literal::Scalar(ScalarValue::Unsigned(
                     UIntTy::U32,
@@ -32,7 +31,7 @@ impl UllbcPass for Transform {
                     UIntTy::U32,
                     field_id,
                 ))) = arg1.kind()
-                && let Some(tdecl) = ctx.ctx.translated.type_decls.get(type_id)
+                && let Some(tdecl) = ctx.ctx.translated.type_decls.get(tref.id)
             {
                 // TODO: move into a pass, maybe also size_of/align_of? or remove the nullops.
                 // maybe this is a constant also.

--- a/charon/src/transform/resugar/reconstruct_matches.rs
+++ b/charon/src/transform/resugar/reconstruct_matches.rs
@@ -34,17 +34,14 @@ impl Transform {
                     let TyKind::Adt(tdecl_ref) = p.ty().kind() else {
                         continue;
                     };
-                    let Some(adt_id) = tdecl_ref.as_adt() else {
-                        continue;
-                    };
 
                     // Lookup the type of the scrutinee
-                    let tkind = ctx.translated.type_decls.get(adt_id).map(|x| &x.kind);
+                    let tkind = ctx.translated.type_decls.get(tdecl_ref.id).map(|x| &x.kind);
                     let Some(TypeDeclKind::Enum(variants)) = tkind else {
                         match tkind {
                             // This can happen if the type was declared as invisible or opaque.
                             None | Some(TypeDeclKind::Opaque) => {
-                                let name = ctx.translated.item_name(adt_id);
+                                let name = ctx.translated.item_name(tdecl_ref.id);
                                 register_error!(
                                     ctx,
                                     block.span,
@@ -111,7 +108,8 @@ impl Transform {
                                                         ctx,
                                                         block.span,
                                                         "Found incorrect discriminant \
-                                                        {discr} for enum {adt_id}"
+                                                        {discr} for enum {}",
+                                                        tdecl_ref.id
                                                     );
                                                     None
                                                 })

--- a/charon/src/transform/resugar/reconstruct_vec_boxes.rs
+++ b/charon/src/transform/resugar/reconstruct_vec_boxes.rs
@@ -85,13 +85,7 @@ fn assume_init_fn_ptr<'a>(ctx: &TransformCtx, call: &'a Call) -> Option<&'a FnPt
 }
 
 fn box_inner(ty: &Ty) -> Option<Ty> {
-    let TyKind::Adt(TypeDeclRef {
-        id: TypeId::Builtin(BuiltinTy::Box),
-        generics,
-    }) = ty.kind()
-    else {
-        return None;
-    };
+    let TypeDeclRef { generics, .. } = ty.as_adt().filter(|tref| tref.is_box())?;
     Some(generics.types[TypeVarId::from_usize(0)].clone())
 }
 
@@ -331,7 +325,7 @@ impl UllbcPass for Transform {
                 let uninit_box = call.dest.clone();
                 let maybe_uninit_array_ty = box_inner(uninit_box.ty())?;
                 let maybe_uninit_ref = maybe_uninit_array_ty.as_adt()?;
-                let mu_decl = &ctx.translated.type_decls.get(maybe_uninit_ref.as_adt()?)?;
+                let mu_decl = &ctx.translated.type_decls.get(maybe_uninit_ref.id)?;
                 if mu_decl.item_meta.lang_item.as_ref() != Some(&from_rustc::LangItem::MaybeUninit)
                 {
                     return None;

--- a/charon/src/transform/simplify_output/hide_allocator_param.rs
+++ b/charon/src/transform/simplify_output/hide_allocator_param.rs
@@ -7,7 +7,7 @@ use crate::transform::{TransformCtx, ctx::TransformPass};
 
 #[derive(Visitor)]
 struct RemoveLastParamVisitor {
-    types: HashSet<TypeId>,
+    types: HashSet<TypeDeclId>,
 }
 
 impl VisitAstMut for RemoveLastParamVisitor {
@@ -36,21 +36,17 @@ impl TransformPass for Transform {
             .iter()
             .map(|s| NamePattern::parse(s).unwrap())
             .collect_vec();
-        let types: HashSet<TypeId> = ctx
+        let types: HashSet<TypeDeclId> = ctx
             .translated
             .item_names
             .iter()
             .filter(|(_, name)| types.iter().any(|p| p.matches(&ctx.translated, name)))
             .filter_map(|(id, _)| id.as_type())
             .copied()
-            .map(TypeId::Adt)
-            .chain([TypeId::Builtin(BuiltinTy::Box)])
             .collect();
 
         for &id in &types {
-            if let Some(&id) = id.as_adt()
-                && let Some(tdecl) = ctx.translated.type_decls.get_mut(id)
-            {
+            if let Some(tdecl) = ctx.translated.type_decls.get_mut(id) {
                 if tdecl.generics.types.is_empty() {
                     // We monomorpohized this type.
                     let args = tdecl.item_meta.name.mono_args_mut().unwrap();

--- a/charon/src/transform/simplify_output/remove_adt_clauses.rs
+++ b/charon/src/transform/simplify_output/remove_adt_clauses.rs
@@ -90,9 +90,7 @@ impl VisitAstMut for RemoveAdtClausesVisitor<'_> {
     }
 
     fn enter_type_decl_ref(&mut self, tref: &mut TypeDeclRef) {
-        if let Some(id) = tref.as_adt()
-            && !self.untouchable_adts.contains(&id)
-        {
+        if !self.untouchable_adts.contains(&tref.id) {
             tref.generics.trait_refs.clear();
         }
     }

--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -505,10 +505,7 @@ impl VisitAstMut for TypeCheckVisitor<'_> {
 
     // Check that generics match the parameters of the target item.
     fn enter_type_decl_ref(&mut self, x: &mut TypeDeclRef) {
-        // TODO: check builtin generics.
-        if let Some(id) = x.as_adt() {
-            self.assert_matches_item(id, &mut x.generics)
-        }
+        self.assert_matches_item(x.id, &mut x.generics)
     }
     fn enter_fun_decl_ref(&mut self, x: &mut FunDeclRef) {
         self.assert_matches_item(x.id, &mut x.generics);

--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -505,6 +505,11 @@ impl VisitAstMut for TypeCheckVisitor<'_> {
 
     // Check that generics match the parameters of the target item.
     fn enter_type_decl_ref(&mut self, x: &mut TypeDeclRef) {
+        // With `--no-gen-tuple-structs`, a tuple stores its field types in its generics while
+        // pointing to the parameter-less opaque unit declaration, so the two don't match.
+        if x.is_tuple() && self.ctx.options.no_gen_tuple_structs {
+            return;
+        }
         self.assert_matches_item(x.id, &mut x.generics)
     }
     fn enter_fun_decl_ref(&mut self, x: &mut FunDeclRef) {

--- a/charon/src/transform/utils.rs
+++ b/charon/src/transform/utils.rs
@@ -47,12 +47,9 @@ impl GenericsSource {
     }
 }
 
-impl TypeId {
+impl TypeDeclId {
     pub fn generics_target(&self) -> GenericsSource {
-        match *self {
-            TypeId::Adt(decl_id) => GenericsSource::item(decl_id),
-            TypeId::Builtin(..) => GenericsSource::Builtin,
-        }
+        GenericsSource::item(*self)
     }
 }
 impl FunId {

--- a/charon/tests/cargo/build-script.out
+++ b/charon/tests/cargo/build-script.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_cargo_build_script::FOO
 pub fn FOO() -> u8
 {

--- a/charon/tests/cargo/dependencies.out
+++ b/charon/tests/cargo/dependencies.out
@@ -59,6 +59,12 @@ pub enum AssertKind {
   Match,
 }
 
+struct (_,)<A> {
+  _0: A,
+}
+
+struct () {}
+
 // Full name: take_mut::take
 pub fn take<'_0, T, F>(_1: &'_0 mut T, _2: F)
 where
@@ -68,6 +74,14 @@ where
     TypeOutlives0: T: '_0,
     TypeConstraint0: TraitClause2::Output = T,
 = <opaque>
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
 
 // Full name: test_cargo_dependencies::main::silly_incr::closure
 struct closure {}
@@ -85,13 +99,13 @@ fn call_once(_1: closure, tupled_args: (u32,)) -> u32
     storage_live(_0)
     storage_live(y)
     storage_live(_5)
-    y = move tupled_args.0
+    y = move tupled_args._0
     storage_live(_4)
     _4 = copy y
     _5 = copy _4 checked.+ const 1u32
-    assert(move _5.1 == false) (overflow) else panic
+    assert(move _5._1 == false) (overflow) else panic
     ↳⚡ unwind_continue
-    _0 = move _5.0
+    _0 = move _5._0
     storage_dead(_4)
     return
 }
@@ -140,24 +154,24 @@ fn main()
     let _2: (); // anonymous local
     let _3: &'1 mut u32; // anonymous local
     let _4: &'2 mut u32; // anonymous local
-    let _5: (&'6 u32, &'7 u32); // anonymous local
-    let _6: &'8 u32; // anonymous local
-    let _7: &'9 u32; // anonymous local
-    let left_val: &'10 u32; // local
-    let right_val: &'11 u32; // local
+    let _5: (&'11 u32, &'12 u32); // anonymous local
+    let _6: &'16 u32; // anonymous local
+    let _7: &'17 u32; // anonymous local
+    let left_val: &'18 u32; // local
+    let right_val: &'19 u32; // local
     let _10: bool; // anonymous local
     let _11: u32; // anonymous local
     let _12: u32; // anonymous local
     let kind: AssertKind; // local
     let _14: AssertKind; // anonymous local
-    let _15: &'12 u32; // anonymous local
-    let _16: &'13 u32; // anonymous local
-    let _17: &'14 u32; // anonymous local
-    let _18: &'15 u32; // anonymous local
-    let _19: Option<Arguments<'23>>[{built_in impl Sized for Arguments<'23>}]; // anonymous local
-    let _20: &'27 u32; // anonymous local
-    let _21: &'30 u32; // anonymous local
-    let _22: &'39 u32; // anonymous local
+    let _15: &'20 u32; // anonymous local
+    let _16: &'21 u32; // anonymous local
+    let _17: &'22 u32; // anonymous local
+    let _18: &'23 u32; // anonymous local
+    let _19: Option<Arguments<'31>>[{built_in impl Sized for Arguments<'31>}]; // anonymous local
+    let _20: &'35 u32; // anonymous local
+    let _21: &'38 u32; // anonymous local
+    let _22: &'52 u32; // anonymous local
     let _23: u32; // anonymous local
 
     storage_live(_0)
@@ -171,7 +185,7 @@ fn main()
     storage_live(_4)
     _4 = &mut x
     _3 = &two-phase-mut (*_4)
-    _2 = silly_incr<'29>(move _3)
+    _2 = silly_incr<'37>(move _3)
     ↳⚡ unwind_continue
     storage_live(_21)
     storage_live(_22)
@@ -192,9 +206,9 @@ fn main()
     storage_dead(_7)
     storage_dead(_6)
     storage_live(left_val)
-    left_val = copy _5.0
+    left_val = copy _5._0
     storage_live(right_val)
-    right_val = copy _5.1
+    right_val = copy _5._1
     storage_live(_10)
     storage_live(_11)
     _11 = copy (*left_val)

--- a/charon/tests/cargo/issue-396-lib-bin.out
+++ b/charon/tests/cargo/issue-396-lib-bin.out
@@ -35,6 +35,8 @@ pub opaque type Argument<'a>
 pub unsafe fn new<'a, const N : usize, const M : usize>(_1: &'a [u8; N], _2: &'a [Argument<'a>; M]) -> Arguments<'a>
 = <opaque>
 
+struct () {}
+
 // Full name: core::marker::MetaSized
 #[fundamental]
 #[lang_item(MetaSized)]
@@ -102,6 +104,10 @@ pub fn hello() -> u32
     return
 }
 
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: issue_396_lib_bin::main
 fn main()
 {
@@ -119,7 +125,7 @@ fn main()
     let _11: &'16 [Argument<'17>; 1usize]; // anonymous local
     let _12: &'18 [Argument<'19>; 1usize]; // anonymous local
     let _13: [u8; 4usize]; // anonymous local
-    let _14: &'25 [u8; 4usize]; // anonymous local
+    let _14: &'26 [u8; 4usize]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -137,8 +143,8 @@ fn main()
     storage_live(args_6)
     storage_live(_7)
     storage_live(_8)
-    _8 = &(*args_3.0)
-    _7 = new_display<'21, '23, u32>[{built_in impl Sized for u32}, impl_Display_for_u32](move _8)
+    _8 = &(*args_3._0)
+    _7 = new_display<'22, '24, u32>[{built_in impl Sized for u32}, impl_Display_for_u32](move _8)
     ↳⚡ unwind_continue
     storage_dead(_8)
     args_6 = [move _7]
@@ -156,13 +162,13 @@ fn main()
     storage_live(_12)
     _12 = &args_6
     _11 = &(*_12)
-    _2 = new<'27, 4usize, 1usize>(move _9, move _11)
+    _2 = new<'28, 4usize, 1usize>(move _9, move _11)
     ↳⚡ unwind_continue
     storage_dead(_12)
     storage_dead(_11)
     storage_dead(_10)
     storage_dead(_9)
-    _1 = _print<'29>(move _2)
+    _1 = _print<'30>(move _2)
     ↳⚡ unwind_continue
     storage_dead(_2)
     storage_dead(args_6)

--- a/charon/tests/cargo/issue-412-dup-deps.out
+++ b/charon/tests/cargo/issue-412-dup-deps.out
@@ -36,6 +36,16 @@ pub enum AssertKind {
   Match,
 }
 
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 pub fn mydup::hello() -> u32
 {
     let _0: u32; // return
@@ -60,28 +70,28 @@ fn main()
     let _0: (); // return
     let a: u32; // local
     let b: u32; // local
-    let _3: (&'3 u32, &'4 u32); // anonymous local
-    let _4: &'5 u32; // anonymous local
+    let _3: (&'8 u32, &'9 u32); // anonymous local
+    let _4: &'13 u32; // anonymous local
     let _5: u32; // anonymous local
     let _6: u32; // anonymous local
     let _7: u32; // anonymous local
     let _8: (u32, bool); // anonymous local
-    let _9: &'6 u32; // anonymous local
-    let left_val: &'7 u32; // local
-    let right_val: &'8 u32; // local
+    let _9: &'14 u32; // anonymous local
+    let left_val: &'15 u32; // local
+    let right_val: &'16 u32; // local
     let _12: bool; // anonymous local
     let _13: u32; // anonymous local
     let _14: u32; // anonymous local
     let kind: AssertKind; // local
     let _16: AssertKind; // anonymous local
-    let _17: &'9 u32; // anonymous local
-    let _18: &'10 u32; // anonymous local
-    let _19: &'11 u32; // anonymous local
-    let _20: &'12 u32; // anonymous local
-    let _21: Option<Arguments<'20>>[{built_in impl Sized for Arguments<'20>}]; // anonymous local
-    let _22: &'24 u32; // anonymous local
-    let _23: &'25 u32; // anonymous local
-    let _24: &'34 u32; // anonymous local
+    let _17: &'17 u32; // anonymous local
+    let _18: &'18 u32; // anonymous local
+    let _19: &'19 u32; // anonymous local
+    let _20: &'20 u32; // anonymous local
+    let _21: Option<Arguments<'28>>[{built_in impl Sized for Arguments<'28>}]; // anonymous local
+    let _22: &'32 u32; // anonymous local
+    let _23: &'33 u32; // anonymous local
+    let _24: &'47 u32; // anonymous local
     let _25: u32; // anonymous local
 
     storage_live(_0)
@@ -104,7 +114,7 @@ fn main()
     storage_live(_7)
     _7 = copy b
     _8 = copy _6 checked.+ copy _7
-    assert(move _8.1 == false) (overflow) else panic
+    assert(move _8._1 == false) (overflow) else panic
     ↳⚡ unwind_continue
     storage_live(_23)
     storage_live(_24)
@@ -112,7 +122,7 @@ fn main()
     _25 = const 3u32
     _24 = &_25
     _23 = move _24
-    _5 = move _8.0
+    _5 = move _8._0
     storage_dead(_7)
     storage_dead(_6)
     _4 = &_5
@@ -123,9 +133,9 @@ fn main()
     storage_dead(_9)
     storage_dead(_4)
     storage_live(left_val)
-    left_val = copy _3.0
+    left_val = copy _3._0
     storage_live(right_val)
-    right_val = copy _3.1
+    right_val = copy _3._1
     storage_live(_12)
     storage_live(_13)
     _13 = copy (*left_val)

--- a/charon/tests/cargo/multi-targets.out
+++ b/charon/tests/cargo/multi-targets.out
@@ -1,3 +1,23 @@
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait core::marker::MetaSized<Self>
+
+#[fundamental]
+#[lang_item(Sized)]
+pub trait core::marker::Sized<Self>
+{
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
+    non-dyn-compatible
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: core::marker::Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 pub fn multi_targets::no_os(left: u64, right: u64) -> u64
 {
     let _0: u64; // return
@@ -14,9 +34,9 @@ pub fn multi_targets::no_os(left: u64, right: u64) -> u64
     storage_live(_4)
     _4 = copy right
     _5 = copy _3 checked.+ copy _4
-    assert(move _5.1 == false) (overflow) else panic
+    assert(move _5._1 == false) (overflow) else panic
     ↳⚡ unwind_continue
-    _0 = move _5.0
+    _0 = move _5._0
     storage_dead(_4)
     storage_dead(_3)
     return
@@ -38,9 +58,9 @@ pub fn multi_targets::on_unix(left: u64, right: u64) -> u64
     storage_live(_4)
     _4 = copy right
     _5 = copy _3 checked.+ copy _4
-    assert(move _5.1 == false) (overflow) else panic
+    assert(move _5._1 == false) (overflow) else panic
     ↳⚡ unwind_continue
-    _0 = move _5.0
+    _0 = move _5._0
     storage_dead(_4)
     storage_dead(_3)
     return

--- a/charon/tests/cargo/test-attributes.out
+++ b/charon/tests/cargo/test-attributes.out
@@ -7,6 +7,8 @@ pub opaque type Layout
 // Full name: core::alloc::AllocError
 pub struct AllocError {}
 
+struct () {}
+
 // Full name: core::marker::MetaSized
 #[fundamental]
 #[lang_item(MetaSized)]
@@ -58,6 +60,10 @@ pub trait Borrow<Self, Borrowed>
 // Full name: core::fmt::Arguments
 #[lang_item(FormatArguments)]
 pub opaque type Arguments<'a>
+
+struct str {
+  _0: [u8],
+}
 
 // Full name: core::fmt::{Arguments<'a>}::from_str
 pub fn from_str<'a>(_1: &'static str) -> Arguments<'a>
@@ -293,6 +299,10 @@ pub struct TestDesc {
   compile_fail: bool,
   no_run: bool,
   test_type: TestType,
+}
+
+struct (_,)<A> {
+  _0: A,
 }
 
 // Full name: test::types::TestFn

--- a/charon/tests/cargo/toml.out
+++ b/charon/tests/cargo/toml.out
@@ -48,6 +48,8 @@ where
     return
 }
 
+struct () {}
+
 // Full name: test_cargo_toml::included::run
 pub fn run()
 {

--- a/charon/tests/cargo/unsafe_.out
+++ b/charon/tests/cargo/unsafe_.out
@@ -4,9 +4,15 @@
 #[lang_item(FormatArguments)]
 pub opaque type Arguments<'a>
 
+struct str {
+  _0: [u8],
+}
+
 // Full name: core::fmt::{Arguments<'a>}::from_str
 pub fn from_str<'a>(_1: &'static str) -> Arguments<'a>
 = <opaque>
+
+struct () {}
 
 // Full name: std::io::stdio::_print
 pub fn _print<'_0>(_1: Arguments<'_0>)

--- a/charon/tests/cargo/workspace.out
+++ b/charon/tests/cargo/workspace.out
@@ -1,5 +1,19 @@
 # Final LLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
 // Full name: crate1::random_number
 pub fn random_number() -> u32
 {
@@ -8,6 +22,14 @@ pub fn random_number() -> u32
     storage_live(_0)
     _0 = const 4u32
     return
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
 }
 
 // Full name: crate2::extra_random_number
@@ -24,9 +46,9 @@ pub fn extra_random_number() -> u32
     _1 = random_number()
     ↳⚡ unwind_continue
     _2 = copy _1 checked.+ const 1u32
-    assert(move _2.1 == false) (overflow) else panic
+    assert(move _2._1 == false) (overflow) else panic
     ↳⚡ unwind_continue
-    _0 = move _2.0
+    _0 = move _2._0
     storage_dead(_1)
     return
 }

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -17,6 +17,16 @@ fn translate(code: impl std::fmt::Display) -> anyhow::Result<TranslatedCrate> {
     util::translate_rust_text(code, &[])
 }
 
+/// The type declarations written by the user, in order. Every crate also declares the types Rust
+/// treats specially -- tuples, starting with `()` -- which these tests aren't about.
+fn user_type_decls(crate_data: &TranslatedCrate) -> Vec<&TypeDecl> {
+    crate_data
+        .type_decls
+        .iter()
+        .filter(|decl| decl.src.is_normal())
+        .collect()
+}
+
 /// A general item, with information shared by all items.
 struct Item<'c> {
     name_str: String,
@@ -54,8 +64,9 @@ fn type_decl() -> anyhow::Result<()> {
         fn main() {}
         ",
     )?;
+    let type_decls = user_type_decls(&crate_data);
     assert_eq!(
-        repr_name(&crate_data, &crate_data.type_decls[0].item_meta.name),
+        repr_name(&crate_data, &type_decls[0].item_meta.name),
         "test_crate::Struct"
     );
     Ok(())
@@ -145,15 +156,16 @@ fn file_name() -> anyhow::Result<()> {
         type Foo = Option<()>;
         ",
     )?;
+    let type_decls = user_type_decls(&crate_data);
     assert_eq!(
-        repr_name(&crate_data, &crate_data.type_decls[0].item_meta.name),
+        repr_name(&crate_data, &type_decls[0].item_meta.name),
         "test_crate::Foo"
     );
     assert_eq!(
-        repr_name(&crate_data, &crate_data.type_decls[1].item_meta.name),
+        repr_name(&crate_data, &type_decls[1].item_meta.name),
         "core::option::Option"
     );
-    let file_id = crate_data.type_decls[1].item_meta.span.data.file_id;
+    let file_id = type_decls[1].item_meta.span.data.file_id;
     let file = &crate_data.files[file_id];
     assert_eq!(file.name.to_string(), "/rustc/library/core/src/option.rs");
     Ok(())
@@ -380,11 +392,12 @@ fn attributes() -> anyhow::Result<()> {
         }
         "#,
     )?;
+    let type_decls = user_type_decls(&crate_data);
     assert_eq!(
-        unknown_attrs(&crate_data.type_decls[0].item_meta),
+        unknown_attrs(&type_decls[0].item_meta),
         vec!["clippy::foo", "clippy::foo(arg)", "clippy::foo(\"arg\")"]
     );
-    assert!(unknown_attrs(&crate_data.type_decls[1].item_meta).is_empty());
+    assert!(unknown_attrs(&type_decls[1].item_meta).is_empty());
     assert_eq!(
         unknown_attrs(&crate_data.trait_decls[0].item_meta),
         vec!["clippy::foo"]
@@ -436,23 +449,24 @@ fn visibility() -> anyhow::Result<()> {
         }
         "#,
     )?;
+    let type_decls = user_type_decls(&crate_data);
     assert_eq!(
-        repr_name(&crate_data, &crate_data.type_decls[0].item_meta.name),
+        repr_name(&crate_data, &type_decls[0].item_meta.name),
         "test_crate::Pub"
     );
-    assert!(crate_data.type_decls[0].item_meta.attr_info.public);
+    assert!(type_decls[0].item_meta.attr_info.public);
     assert_eq!(
-        repr_name(&crate_data, &crate_data.type_decls[1].item_meta.name),
+        repr_name(&crate_data, &type_decls[1].item_meta.name),
         "test_crate::Priv"
     );
-    assert!(!crate_data.type_decls[1].item_meta.attr_info.public);
+    assert!(!type_decls[1].item_meta.attr_info.public);
     // Note how we think `PubInPriv` is public. It kind of is but there is no path to it. This is
     // probably fine.
     assert_eq!(
-        repr_name(&crate_data, &crate_data.type_decls[2].item_meta.name),
+        repr_name(&crate_data, &type_decls[2].item_meta.name),
         "test_crate::private::PubInPriv"
     );
-    assert!(crate_data.type_decls[2].item_meta.attr_info.public);
+    assert!(type_decls[2].item_meta.attr_info.public);
     Ok(())
 }
 
@@ -471,6 +485,7 @@ fn discriminants() -> anyhow::Result<()> {
         }
         "#,
     )?;
+    let type_decls = user_type_decls(&crate_data);
     fn get_enum_discriminants(ty: &TypeDecl) -> Vec<Literal> {
         ty.kind
             .as_enum()
@@ -480,14 +495,14 @@ fn discriminants() -> anyhow::Result<()> {
             .collect()
     }
     assert_eq!(
-        get_enum_discriminants(&crate_data.type_decls[0]),
+        get_enum_discriminants(type_decls[0]),
         vec![
             Literal::Scalar(ScalarValue::Signed(IntTy::Isize, 0)),
             Literal::Scalar(ScalarValue::Signed(IntTy::Isize, 1))
         ]
     );
     assert_eq!(
-        get_enum_discriminants(&crate_data.type_decls[1]),
+        get_enum_discriminants(type_decls[1]),
         vec![
             Literal::Scalar(ScalarValue::Unsigned(UIntTy::U32, 3)),
             Literal::Scalar(ScalarValue::Unsigned(UIntTy::U32, 42))
@@ -563,6 +578,7 @@ fn rename_attribute() -> anyhow::Result<()> {
         type Test2 = u32;
         "#,
     )?;
+    let type_decls = user_type_decls(&crate_data);
 
     assert_eq!(
         crate_data.trait_decls[0]
@@ -618,38 +634,26 @@ fn rename_attribute() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        crate_data.type_decls[0]
-            .item_meta
-            .attr_info
-            .rename
-            .as_deref(),
+        type_decls[0].item_meta.attr_info.rename.as_deref(),
         Some("TypeTest")
     );
 
     assert_eq!(
-        crate_data.type_decls[1]
-            .item_meta
-            .attr_info
-            .rename
-            .as_deref(),
+        type_decls[1].item_meta.attr_info.rename.as_deref(),
         Some("VariantsTest")
     );
 
     assert_eq!(
-        crate_data.type_decls[1].kind.as_enum().unwrap()[0].renamed_name(),
+        type_decls[1].kind.as_enum().unwrap()[0].renamed_name(),
         "Variant1"
     );
     assert_eq!(
-        crate_data.type_decls[1].kind.as_enum().unwrap()[1].renamed_name(),
+        type_decls[1].kind.as_enum().unwrap()[1].renamed_name(),
         "SimpleSecondVariant_"
     );
 
     assert_eq!(
-        crate_data.type_decls[2]
-            .item_meta
-            .attr_info
-            .rename
-            .as_deref(),
+        type_decls[2].item_meta.attr_info.rename.as_deref(),
         Some("StructTest")
     );
 
@@ -663,16 +667,12 @@ fn rename_attribute() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        crate_data.type_decls[3]
-            .item_meta
-            .attr_info
-            .rename
-            .as_deref(),
+        type_decls[3].item_meta.attr_info.rename.as_deref(),
         Some("_TypeAeneas36")
     );
 
     assert_eq!(
-        crate_data.type_decls[2].kind.as_struct().unwrap()[0]
+        type_decls[2].kind.as_struct().unwrap()[0]
             .attr_info
             .rename
             .as_deref(),
@@ -713,7 +713,8 @@ fn declaration_groups() -> anyhow::Result<()> {
     assert!(matches!(global.src, GlobalSource::TraitDefault { .. }));
 
     let decl_groups = crate_data.ordered_decls.unwrap();
-    assert_eq!(decl_groups.len(), 6);
+    // One of the groups is the declaration of `()`, which every crate has.
+    assert_eq!(decl_groups.len(), 7);
 
     Ok(())
 }

--- a/charon/tests/help-output.txt
+++ b/charon/tests/help-output.txt
@@ -123,6 +123,9 @@ Options:
       --treat-box-as-builtin
           Treat `Box<T>` as if it was a built-in type
 
+      --no-gen-tuple-structs
+          Don't generate a type declaration per tuple arity. Instead, every tuple type refers to the single opaque declaration with id `TypeDeclId::UNIT`, and stores its field types in its generic arguments. This is meant for consumers that build tuples of arbitrary arity on the fly and don't care about their declaration. Note that this makes tuple types ill-typed with respect to their declaration; it is also incompatible with `--monomorphize`
+
       --raw-consts
           Do not inline or evaluate constants
 

--- a/charon/tests/layout.rs
+++ b/charon/tests/layout.rs
@@ -243,7 +243,12 @@ fn type_layout() -> anyhow::Result<()> {
         .type_decls
         .iter()
         .filter_map(|tdecl| {
-            if tdecl.item_meta.name.name[0].as_ident().unwrap().0 != "test_crate" {
+            // Skips the builtin types too, whose names start with a `PathElem::Builtin`.
+            let is_local = matches!(
+                tdecl.item_meta.name.name.first().and_then(|e| e.as_ident()),
+                Some((crate_name, _)) if crate_name == "test_crate"
+            );
+            if !is_local {
                 return None;
             }
             let name = repr_name(&crate_data, &tdecl.item_meta.name);

--- a/charon/tests/ptr-metadata.json
+++ b/charon/tests/ptr-metadata.json
@@ -1,4 +1,5 @@
 {
+  "<tuple_0>": "None",
   "test_crate::Alias": "Length",
   "test_crate::StrDst": "Length",
   "test_crate::SliceDst": "Length",
@@ -22,6 +23,7 @@
   "test_crate::GenericBehindIndirection": "None",
   "test_crate::GenericBehindIndirectionUnsized": "None",
   "test_crate::ThinGeneric": "None",
+  "<str>": "Length",
   "alloc::boxed::Box": "None",
   "alloc::alloc::Global": "None",
   "core::alloc::layout::Layout": "None",

--- a/charon/tests/test-rust-name-matcher.rs
+++ b/charon/tests/test-rust-name-matcher.rs
@@ -110,9 +110,10 @@ fn test_partial_mono_name_matcher() -> anyhow::Result<()> {
         let Ok(ty) = instantiation.skip_binder.types.iter().exactly_one() else {
             return false;
         };
-        let Some(fields) = ty.as_tuple() else {
+        if !ty.is_tuple() {
             return false;
-        };
+        }
+        let fields = ty.as_tuple_fields(&crate_data);
         fields.len() == 2
             && fields
                 .iter()

--- a/charon/tests/ui/advanced-const-generics.out
+++ b/charon/tests/ui/advanced-const-generics.out
@@ -9,6 +9,8 @@ pub trait PartialEq<Self, Rhs>
     vtable: core::cmp::PartialEq::{vtable}<Rhs>
 }
 
+struct () {}
+
 // Full name: core::cmp::Eq
 #[diagnostic_item("Eq")]
 pub trait Eq<Self>
@@ -65,6 +67,18 @@ where
 {
   Ok { _0: T },
   Err { _0: E },
+}
+
+struct str {
+  _0: [u8],
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
 }
 
 // Full name: test_crate::Foo

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -60,6 +60,8 @@ where
     TypeOutlives2: I: '_0,
 = <opaque>
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -242,7 +244,15 @@ where
     TypeOutlives0: T: '_0,
 = <opaque>
 
-// Full name: test_crate::<slice>::{impl Destruct for [T]}::drop_glue
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+// Full name: {impl Destruct for [T]}::drop_glue
 unsafe fn impl_Destruct_for_slice::drop_glue<'_0, T>(_1: &'_0 mut [T])
 where
     TraitClause0: (T: Sized),
@@ -337,7 +347,7 @@ where
     return
 }
 
-// Full name: test_crate::<slice>::{impl Destruct for [T]}
+// Full name: {impl Destruct for [T]}
 impl<T> "impl_Destruct_for_slice" Destruct for [T]
 where
     TraitClause0: (T: Sized),
@@ -346,7 +356,7 @@ where
     non-dyn-compatible
 }
 
-// Full name: test_crate::<array>::{impl Destruct for [T; N]}::drop_glue
+// Full name: {impl Destruct for [T; N]}::drop_glue
 unsafe fn impl_Destruct_for_array::drop_glue<'_0, T, const N : usize>(_1: &'_0 mut [T; N])
 where
     TraitClause0: (T: Sized),
@@ -370,7 +380,7 @@ where
     return
 }
 
-// Full name: test_crate::<array>::{impl Destruct for [T; N]}
+// Full name: {impl Destruct for [T; N]}
 impl<T, const N : usize> "impl_Destruct_for_array" Destruct for [T; N]
 where
     TraitClause0: (T: Sized),

--- a/charon/tests/ui/assert-kinds-reconstruct-fallible.out
+++ b/charon/tests/ui/assert-kinds-reconstruct-fallible.out
@@ -1,5 +1,29 @@
 # Final ULLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/assert-kinds.out
+++ b/charon/tests/ui/assert-kinds.out
@@ -1,5 +1,29 @@
 # Final ULLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::main
 fn main()
 {
@@ -57,11 +81,11 @@ fn main()
         storage_dead(_1);
         storage_live(_4);
         _5 = const 5i32 checked.* const 10i32;
-        assert assert(move _5.1 == false) (overflow) -> bb3 (unwind: bb1);
+        assert assert(move _5._1 == false) (overflow) -> bb3 (unwind: bb1);
     }
 
     bb3: {
-        _4 = move _5.0;
+        _4 = move _5._0;
         storage_dead(_4);
         storage_live(x);
         x = const 127i8;

--- a/charon/tests/ui/assoc-const-with-generics.out
+++ b/charon/tests/ui/assoc-const-with-generics.out
@@ -14,6 +14,16 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::V
 struct V<T, const N : usize>
 where

--- a/charon/tests/ui/associated_types/assoc-constraint-on-assoc-ty-nested.out
+++ b/charon/tests/ui/associated_types/assoc-constraint-on-assoc-ty-nested.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Trait
 trait Trait<Self, Self_Assoc>
 {

--- a/charon/tests/ui/associated_types/assoc-constraint-on-assoc-ty.2.out
+++ b/charon/tests/ui/associated_types/assoc-constraint-on-assoc-ty.2.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Trait
 trait Trait<Self, Self_Assoc>
 {

--- a/charon/tests/ui/associated_types/assoc-constraint-on-assoc-ty.out
+++ b/charon/tests/ui/associated_types/assoc-constraint-on-assoc-ty.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/associated_types/assoc-ty-bound-refers-to-assoc-ty.out
+++ b/charon/tests/ui/associated_types/assoc-ty-bound-refers-to-assoc-ty.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/associated_types/assoc-ty-default-with-self-bound.out
+++ b/charon/tests/ui/associated_types/assoc-ty-default-with-self-bound.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::MyTrait
 pub trait MyTrait<Self>
 {

--- a/charon/tests/ui/associated_types/assoc-ty-via-supertrait-and-bounds.out
+++ b/charon/tests/ui/associated_types/assoc-ty-via-supertrait-and-bounds.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::HasOutput
 pub trait HasOutput<Self, Self_Output>
 {

--- a/charon/tests/ui/associated_types/assoc-type-with-fn-bound.out
+++ b/charon/tests/ui/associated_types/assoc-type-with-fn-bound.out
@@ -62,6 +62,8 @@ pub trait Fn<Self, Args, Self_Clause1_Clause1_Output>
     vtable: core::ops::function::Fn::{vtable}<Args, Self_Clause1_Clause1_Output>
 }
 
+struct () {}
+
 // Full name: test_crate::Trait
 pub trait Trait<Self, Self_Foo>
 {

--- a/charon/tests/ui/associated_types/associated-types.out
+++ b/charon/tests/ui/associated_types/associated-types.out
@@ -72,6 +72,8 @@ where
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -132,6 +134,14 @@ pub trait ToOwned<Self, Self_Owned>
     proof ImpliedClause2: (Self_Owned: Borrow<Self>)
     fn to_owned<'_0_1>;
     non-dyn-compatible
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
 }
 
 trait test_crate::Foo<'a, Self, Self_Item>

--- a/charon/tests/ui/associated_types/closure-inside-impl-with-bound-with-assoc-ty.out
+++ b/charon/tests/ui/associated_types/closure-inside-impl-with-bound-with-assoc-ty.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -68,6 +70,10 @@ pub trait Fn<Self, Args, Self_Clause1_Clause1_Output>
     proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1>;
     vtable: core::ops::function::Fn::{vtable}<Args, Self_Clause1_Clause1_Output>
+}
+
+struct (_,)<A> {
+  _0: A,
 }
 
 // Full name: test_crate::PrimeField
@@ -143,7 +149,7 @@ where
     storage_live(_0)
     storage_live(_x)
     _0 = ()
-    _x = move tupled_args.0
+    _x = move tupled_args._0
     _0 = ()
     storage_dead(_x)
     storage_dead(tupled_args)

--- a/charon/tests/ui/associated_types/dictionary_passing_style_woes.out
+++ b/charon/tests/ui/associated_types/dictionary_passing_style_woes.out
@@ -34,12 +34,22 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
 {
     fn drop_glue<'_0_1>;
     non-dyn-compatible
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
 }
 
 // Full name: test_crate::Iterator

--- a/charon/tests/ui/associated_types/gat-used-in-method.out
+++ b/charon/tests/ui/associated_types/gat-used-in-method.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Foo
 trait Foo<Self>
 {

--- a/charon/tests/ui/associated_types/generic-impl-with-defaulted-method-with-clause-with-assoc-ty.out
+++ b/charon/tests/ui/associated_types/generic-impl-with-defaulted-method-with-clause-with-assoc-ty.out
@@ -25,6 +25,8 @@ where
   Some { _0: T },
 }
 
+struct () {}
+
 // Full name: test_crate::HasType
 trait HasType<Self, Self_Type>
 {

--- a/charon/tests/ui/associated_types/impl-with-dyn-assoc-ty.out
+++ b/charon/tests/ui/associated_types/impl-with-dyn-assoc-ty.out
@@ -16,6 +16,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 struct test_crate::DynableTrait::{vtable}<Ty0> {
   size: usize,
   align: usize,

--- a/charon/tests/ui/associated_types/issue-1068-double-visit.out
+++ b/charon/tests/ui/associated_types/issue-1068-double-visit.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Witness1
 pub struct Witness1 {}
 

--- a/charon/tests/ui/associated_types/issue-1078-default-assoc-ty-self-ref-clause.2.out
+++ b/charon/tests/ui/associated_types/issue-1078-default-assoc-ty-self-ref-clause.2.out
@@ -25,6 +25,8 @@ where
   Some { _0: T },
 }
 
+struct () {}
+
 // Full name: test_crate::Tuple
 struct Tuple<A, B>
 where

--- a/charon/tests/ui/associated_types/issue-1078-default-assoc-ty-self-ref-clause.out
+++ b/charon/tests/ui/associated_types/issue-1078-default-assoc-ty-self-ref-clause.out
@@ -25,6 +25,8 @@ where
   Some { _0: T },
 }
 
+struct () {}
+
 // Full name: test_crate::Tuple
 struct Tuple<A, B>
 where

--- a/charon/tests/ui/associated_types/issue-1260-self-ref-assoc-const.out
+++ b/charon/tests/ui/associated_types/issue-1260-self-ref-assoc-const.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/associated_types/issue-1326-assoc-through-supertrait.out
+++ b/charon/tests/ui/associated_types/issue-1326-assoc-through-supertrait.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/associated_types/iter-empty.out
+++ b/charon/tests/ui/associated_types/iter-empty.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/associated_types/mem-discriminant-from-derive.out
+++ b/charon/tests/ui/associated_types/mem-discriminant-from-derive.out
@@ -34,12 +34,35 @@ where
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
 // Full name: core::marker::StructuralPartialEq
 #[lang_item(StructuralPeq)]
 pub trait StructuralPartialEq<Self>
 {
     proof ImpliedClause0: (Self: MetaSized)
     vtable: core::marker::StructuralPartialEq::{vtable}
+}
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct str {
+  _0: [u8],
 }
 
 // Full name: test_crate::Enum
@@ -68,13 +91,13 @@ pub fn impl_PartialEq_Enum_for_Enum::eq<'_0, '_1>(self: &'_0 Enum, other: &'_1 E
     let _7: bool; // anonymous local
     let _8: isize; // anonymous local
     let _9: isize; // anonymous local
-    let _10: (&'7 Enum, &'8 Enum); // anonymous local
-    let _11: &'9 Enum; // anonymous local
-    let _12: &'10 Enum; // anonymous local
-    let __self_0: &'12 u8; // local
-    let __arg1_0: &'13 u8; // local
-    let _15: &'16 &'17 u8; // anonymous local
-    let _16: &'18 &'19 u8; // anonymous local
+    let _10: (&'12 Enum, &'13 Enum); // anonymous local
+    let _11: &'17 Enum; // anonymous local
+    let _12: &'18 Enum; // anonymous local
+    let __self_0: &'20 u8; // local
+    let __arg1_0: &'21 u8; // local
+    let _15: &'24 &'25 u8; // anonymous local
+    let _16: &'26 &'27 u8; // anonymous local
 
     storage_live(_0)
     storage_live(__self_discr)
@@ -117,19 +140,19 @@ pub fn impl_PartialEq_Enum_for_Enum::eq<'_0, '_1>(self: &'_0 Enum, other: &'_1 E
     _10 = (move _11, move _12)
     storage_dead(_12)
     storage_dead(_11)
-    match (*_10.0) {
+    match (*_10._0) {
         Enum::Some => {
-            match (*_10.1) {
+            match (*_10._1) {
                 Enum::Some => {
                     storage_live(__self_0)
-                    __self_0 = &((*_10.0) as variant Enum::Some)._0
+                    __self_0 = &((*_10._0) as variant Enum::Some)._0
                     storage_live(__arg1_0)
-                    __arg1_0 = &((*_10.1) as variant Enum::Some)._0
+                    __arg1_0 = &((*_10._1) as variant Enum::Some)._0
                     storage_live(_15)
                     _15 = &__self_0
                     storage_live(_16)
                     _16 = &__arg1_0
-                    _0 = {impl PartialEq<&'_0 B> for &'_1 A}::eq<'28, '29, '32, '33, u8, u8>[impl_PartialEq_u8_for_u8](move _15, move _16)
+                    _0 = {impl PartialEq<&'_0 B> for &'_1 A}::eq<'41, '42, '45, '46, u8, u8>[impl_PartialEq_u8_for_u8](move _15, move _16)
                     ↳⚡ storage_dead(other)
                         storage_dead(self)
                         unwind_continue

--- a/charon/tests/ui/associated_types/method-with-assoc-type-constraint.out
+++ b/charon/tests/ui/associated_types/method-with-assoc-type-constraint.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/associated_types/pointee_metadata.out
+++ b/charon/tests/ui/associated_types/pointee_metadata.out
@@ -80,6 +80,8 @@ pub trait Ord<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::hash::Hasher
 pub trait Hasher<Self>
 {
@@ -124,6 +126,14 @@ pub trait Freeze<Self>
 #[lang_item(Unpin)]
 pub trait Unpin<Self>
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: core::ptr::metadata::Pointee
 #[lang_item(PointeeTrait)]
 pub trait Pointee<Self>
@@ -144,6 +154,10 @@ pub trait Pointee<Self>
 // Full name: core::ptr::const_ptr::{*const T}::to_raw_parts
 pub fn to_raw_parts<T>(_1: *const T) -> (*const (), {built_in impl Pointee for T}::Metadata)
 = <opaque>
+
+struct str {
+  _0: [u8],
+}
 
 // Full name: test_crate::empty_metadata
 fn empty_metadata()

--- a/charon/tests/ui/associated_types/quantified-trait-type-constraint.out
+++ b/charon/tests/ui/associated_types/quantified-trait-type-constraint.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Trait
 trait Trait<'a, Self, Self_Type>
 {

--- a/charon/tests/ui/borrowck-statements.out
+++ b/charon/tests/ui/borrowck-statements.out
@@ -80,6 +80,8 @@ where
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -92,8 +94,16 @@ pub trait Destruct<Self>
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -116,7 +126,15 @@ impl "impl_Clone_for_String" Clone for String {
     non-dyn-compatible
 }
 
-// Full name: test_crate::<tuple_2>::{impl Destruct for (A, B)}::drop_glue
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+// Full name: (_, _)::{impl Destruct for (A, B)}::drop_glue
 unsafe fn impl_Destruct_for_tuple::drop_glue<'_0, A, B>(_1: &'_0 mut (A, B))
 where
     TraitClause0: (A: Sized),
@@ -128,20 +146,20 @@ where
 
     storage_live(_0)
     _0 = ()
-    drop[{built_in impl Destruct for A}::drop_glue<'2>] (*_1).0
-    ↳⚡ drop[{built_in impl Destruct for B}::drop_glue<'4>] (*_1).1
+    drop[{built_in impl Destruct for A}::drop_glue<'2>] (*_1)._0
+    ↳⚡ drop[{built_in impl Destruct for B}::drop_glue<'4>] (*_1)._1
         ↳⚡ storage_dead(_1)
             unwind_terminate
         storage_dead(_1)
         unwind_continue
-    drop[{built_in impl Destruct for B}::drop_glue<'3>] (*_1).1
+    drop[{built_in impl Destruct for B}::drop_glue<'3>] (*_1)._1
     ↳⚡ storage_dead(_1)
         unwind_continue
     storage_dead(_1)
     return
 }
 
-// Full name: test_crate::<tuple_2>::{impl Destruct for (A, B)}
+// Full name: (_, _)::{impl Destruct for (A, B)}
 impl<A, B> "impl_Destruct_for_tuple" Destruct for (A, B)
 where
     TraitClause0: (A: Sized),
@@ -181,7 +199,7 @@ pub fn destructure<'a>(input: &'a Either<(u32, u64)>[{built_in impl Sized for (u
     }
     set_type(typeof(_3) <= &'6 Either<(u32, u64)>[{built_in impl Sized for (u32, u64)}])
     storage_live(x)
-    x = &((*_3) as variant Either::Left)._0.0
+    x = &((*_3) as variant Either::Left)._0._0
     storage_dead(_3)
     _0 = &(*x)
     storage_dead(x)
@@ -275,18 +293,18 @@ pub fn impl_trait_binding(value_1: u32) -> u32
 }
 
 // Full name: test_crate::nested_impl_trait
-pub fn nested_impl_trait(value_1: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}])
+pub fn nested_impl_trait(value_1: Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}])
 {
     let _0: (); // return
-    let value_1: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}]; // arg #1
-    let value_2: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}]; // local
+    let value_1: Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}]; // arg #1
+    let value_2: Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}]; // local
 
     storage_live(_0)
     _0 = ()
     storage_live(value_2)
     value_2 = move value_1
     fake_read(value_2)
-    set_type(typeof(value_2) == alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}])
+    set_type(typeof(value_2) == Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}])
     predicate_holds({built_in impl Sized for u32})
     predicate_holds(impl_Copy_for_u32)
     _0 = ()

--- a/charon/tests/ui/call-to-known-trait-method.out
+++ b/charon/tests/ui/call-to-known-trait-method.out
@@ -74,6 +74,8 @@ impl "impl_Default_for_bool" Default for bool {
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -85,6 +87,14 @@ pub trait Destruct<Self>
 // Full name: alloc::string::String
 #[lang_item(String)]
 pub opaque type String
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
 
 // Full name: test_crate::Struct
 struct Struct<A>

--- a/charon/tests/ui/closure-as-fn.out
+++ b/charon/tests/ui/closure-as-fn.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -1,5 +1,9 @@
 # Final LLBC before serialization:
 
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: core::marker::MetaSized
 #[fundamental]
 #[lang_item(MetaSized)]
@@ -48,6 +52,8 @@ pub trait FnMut<Self, Args, Self_Clause1_Output>
     fn call_mut<'_0_1>;
     vtable: core::ops::function::FnMut::{vtable}<Args, Self_Clause1_Output>
 }
+
+struct () {}
 
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
@@ -121,7 +127,15 @@ where
     TypeOutlives0: T: '_0,
 = <opaque>
 
-// Full name: test_crate::<tuple_1>::{impl Destruct for (A,)}::drop_glue
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+// Full name: (_,)::{impl Destruct for (A,)}::drop_glue
 unsafe fn impl_Destruct_for_tuple::drop_glue<'_0, A>(_1: &'_0 mut (A,))
 where
     TypeOutlives0: A: '_0,
@@ -131,14 +145,14 @@ where
 
     storage_live(_0)
     _0 = ()
-    drop[{built_in impl Destruct for A}::drop_glue<'2>] (*_1).0
+    drop[{built_in impl Destruct for A}::drop_glue<'2>] (*_1)._0
     ↳⚡ storage_dead(_1)
         unwind_continue
     storage_dead(_1)
     return
 }
 
-// Full name: test_crate::<tuple_1>::{impl Destruct for (A,)}
+// Full name: (_,)::{impl Destruct for (A,)}
 impl<A> "impl_Destruct_for_tuple" Destruct for (A,) {
     fn drop_glue<'_0_1> = impl_Destruct_for_tuple::drop_glue<'_0_1, A>
     non-dyn-compatible
@@ -172,7 +186,7 @@ pub fn {impl Fn<(u32,), u32> for incr_u32}::call<'_0>(state: &'_0 incr_u32, args
     let args: (u32,); // arg #2
 
     storage_live(_0)
-    _0 = incr_u32(move args.0)
+    _0 = incr_u32(move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -189,7 +203,7 @@ pub fn {impl FnMut<(u32,), u32> for incr_u32}::call_mut<'_0>(state: &'_0 mut inc
     let args: (u32,); // arg #2
 
     storage_live(_0)
-    _0 = incr_u32(move args.0)
+    _0 = incr_u32(move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -206,7 +220,7 @@ pub fn {impl FnOnce<(u32,), u32> for incr_u32}::call_once(state: incr_u32, args:
     let args: (u32,); // arg #2
 
     storage_live(_0)
-    _0 = incr_u32(move args.0)
+    _0 = incr_u32(move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -468,7 +482,7 @@ fn {impl Fn<(u32,), u32> for test_crate::test_closure_u32::closure}::call<'_0>(_
 
     storage_live(_0)
     storage_live(x)
-    x = move tupled_args.0
+    x = move tupled_args._0
     _0 = copy x
     storage_dead(x)
     storage_dead(tupled_args)
@@ -651,8 +665,8 @@ fn {impl Fn<(u32, u32), u32> for test_crate::test_closure_u32s::closure}::call<'
     storage_live(x)
     storage_live(y)
     storage_live(_7)
-    x = move tupled_args.0
-    y = move tupled_args.1
+    x = move tupled_args._0
+    y = move tupled_args._1
     storage_live(_5)
     _5 = copy x
     storage_live(_6)
@@ -845,7 +859,7 @@ fn {impl Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::closure}:
 
     storage_live(_0)
     storage_live(y)
-    y = move tupled_args.0
+    y = move tupled_args._0
     _0 = copy y
     storage_dead(y)
     storage_dead(tupled_args)
@@ -1037,7 +1051,7 @@ where
 
     storage_live(_0)
     storage_live(x)
-    x = move tupled_args.0
+    x = move tupled_args._0
     _0 = copy x
     storage_dead(x)
     storage_dead(tupled_args)
@@ -1265,7 +1279,7 @@ where
 
     storage_live(_0)
     storage_live(y)
-    y = move tupled_args.0
+    y = move tupled_args._0
     _0 = copy y
     storage_dead(y)
     storage_dead(tupled_args)
@@ -1483,7 +1497,7 @@ fn {impl Fn<(u32,), u32> for test_crate::test_map_option2::closure}::call<'_0>(_
     storage_live(_0)
     storage_live(x)
     storage_live(_5)
-    x = move tupled_args.0
+    x = move tupled_args._0
     storage_live(_4)
     _4 = copy x
     _5 = copy _4 panic.+ const 1u32
@@ -1669,7 +1683,7 @@ where
     let args: (T,); // arg #2
 
     storage_live(_0)
-    _0 = id<T>[TraitClause0](move args.0)
+    _0 = id<T>[TraitClause0](move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -1689,7 +1703,7 @@ where
     let args: (T,); // arg #2
 
     storage_live(_0)
-    _0 = id<T>[TraitClause0](move args.0)
+    _0 = id<T>[TraitClause0](move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -1708,7 +1722,7 @@ where
     let args: (T,); // arg #2
 
     storage_live(_0)
-    _0 = id<T>[TraitClause0](move args.0)
+    _0 = id<T>[TraitClause0](move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -1842,7 +1856,7 @@ where
     let args: (T,); // arg #2
 
     storage_live(_0)
-    _0 = id_clone<T>[TraitClause0, TraitClause1](move args.0)
+    _0 = id_clone<T>[TraitClause0, TraitClause1](move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -1864,7 +1878,7 @@ where
     let args: (T,); // arg #2
 
     storage_live(_0)
-    _0 = id_clone<T>[TraitClause0, TraitClause1](move args.0)
+    _0 = id_clone<T>[TraitClause0, TraitClause1](move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -1885,7 +1899,7 @@ where
     let args: (T,); // arg #2
 
     storage_live(_0)
-    _0 = id_clone<T>[TraitClause0, TraitClause1](move args.0)
+    _0 = id_clone<T>[TraitClause0, TraitClause1](move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -2037,7 +2051,7 @@ fn {impl Fn<(u32,), u32> for test_crate::test_map_option3::closure}::call<'_0>(_
     storage_live(_0)
     storage_live(x)
     storage_live(_5)
-    x = move tupled_args.0
+    x = move tupled_args._0
     storage_live(_4)
     _4 = copy x
     _5 = copy _4 panic.+ const 1u32
@@ -2188,7 +2202,7 @@ where
 
     storage_live(_0)
     storage_live(x)
-    x = move tupled_args.0
+    x = move tupled_args._0
     _0 = copy (*(*x))
     storage_dead(x)
     storage_dead(tupled_args)
@@ -2219,7 +2233,7 @@ pub fn test_regions<'a>(x: &'a u32) -> u32
     _6 = &x
     _5 = &(*_6)
     _4 = (move _5,)
-    _0 = {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}::call<'22, '23, '24>(move _3, move _4)
+    _0 = {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::closure}::call<'24, '25, '26>(move _3, move _4)
     ↳⚡ storage_dead(x)
         unwind_continue
     storage_dead(_5)
@@ -2363,7 +2377,7 @@ where
 
     storage_live(_0)
     storage_live(x)
-    x = move tupled_args.0
+    x = move tupled_args._0
     _0 = copy (*(*x))
     storage_dead(x)
     storage_dead(tupled_args)
@@ -2552,7 +2566,7 @@ where
     storage_live(z)
     storage_live(_7)
     storage_live(_9)
-    z = move tupled_args.0
+    z = move tupled_args._0
     storage_live(_4)
     storage_live(_5)
     _5 = copy (*(*_1)._0)
@@ -2747,7 +2761,7 @@ where
 
     storage_live(_0)
     storage_live(x)
-    x = move tupled_args.0
+    x = move tupled_args._0
     storage_live(_4)
     _4 = &x
     _0 = TraitClause1::clone<'4>(move _4)
@@ -2987,7 +3001,7 @@ fn {impl FnMut<(i32,), i32> for test_crate::test_array_map::closure}::call_mut<'
 
     storage_live(_0)
     storage_live(v)
-    v = move tupled_args.0
+    v = move tupled_args._0
     _0 = copy v
     storage_dead(v)
     storage_dead(tupled_args)
@@ -3089,7 +3103,7 @@ where
     storage_live(x)
     storage_live(_5)
     _0 = ()
-    x = move tupled_args.0
+    x = move tupled_args._0
     storage_live(_4)
     _4 = copy (*x)
     _5 = copy (*(*_1)._0) panic.+ copy _4
@@ -3117,7 +3131,7 @@ fn test_fnmut_with_ref()
     let _8: &'12 usize; // anonymous local
     let _9: &'13 usize; // anonymous local
     let _10: &'15 usize; // anonymous local
-    let _11: &'24 usize; // anonymous local
+    let _11: &'25 usize; // anonymous local
     let _12: usize; // anonymous local
 
     storage_live(_10)
@@ -3148,7 +3162,7 @@ fn test_fnmut_with_ref()
     _8 = &(*_9)
     _7 = &(*_8)
     _6 = (move _7,)
-    _4 = {impl FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::closure<'_0>}::call_mut<'21, '22, '23>(move _5, move _6)
+    _4 = {impl FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::closure<'_0>}::call_mut<'22, '23, '24>(move _5, move _6)
     ↳⚡ storage_dead(_9)
         unwind_continue
     storage_dead(_7)

--- a/charon/tests/ui/closures_with_where.out
+++ b/charon/tests/ui/closures_with_where.out
@@ -1,5 +1,9 @@
 # Final LLBC before serialization:
 
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: core::marker::MetaSized
 #[fundamental]
 #[lang_item(MetaSized)]
@@ -49,6 +53,8 @@ pub trait FnMut<Self, Args>
     fn call_mut<'_0_1>;
     vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
+
+struct () {}
 
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
@@ -125,7 +131,7 @@ where
 
     storage_live(_0)
     storage_live(i)
-    i = move tupled_args.0
+    i = move tupled_args._0
     storage_live(_4)
     _4 = copy i
     _0 = TraitClause1::of_usize(move _4)

--- a/charon/tests/ui/comments.out
+++ b/charon/tests/ui/comments.out
@@ -27,6 +27,8 @@ pub trait Default<Self>
 pub fn impl_Default_for_u32::default() -> u32
 = <opaque>
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -60,6 +62,18 @@ where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_0,
 = <opaque>
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct str {
+  _0: [u8],
+}
 
 // Full name: test_crate::function_call
 fn function_call(_1: u32)
@@ -347,25 +361,25 @@ fn foo()
     let _13: u32; // anonymous local
     let _14: u32; // anonymous local
     let a: [u32; 10usize]; // local
-    let _16: (&'3 u32, &'4 u32); // anonymous local
-    let _17: &'5 u32; // anonymous local
+    let _16: (&'8 u32, &'9 u32); // anonymous local
+    let _17: &'13 u32; // anonymous local
     let _18: usize; // anonymous local
-    let _19: &'6 u32; // anonymous local
-    let left_val: &'7 u32; // local
-    let right_val: &'8 u32; // local
+    let _19: &'14 u32; // anonymous local
+    let left_val: &'15 u32; // local
+    let right_val: &'16 u32; // local
     let _22: bool; // anonymous local
     let _23: u32; // anonymous local
     let _24: u32; // anonymous local
     let kind: AssertKind; // local
     let _26: AssertKind; // anonymous local
-    let _27: &'9 u32; // anonymous local
-    let _28: &'10 u32; // anonymous local
-    let _29: &'11 u32; // anonymous local
-    let _30: &'12 u32; // anonymous local
-    let _31: Option<Arguments<'20>>[{built_in impl Sized for Arguments<'20>}]; // anonymous local
-    let _32: &'24 u32; // anonymous local
-    let _33: &'25 u32; // anonymous local
-    let _34: &'34 u32; // anonymous local
+    let _27: &'17 u32; // anonymous local
+    let _28: &'18 u32; // anonymous local
+    let _29: &'19 u32; // anonymous local
+    let _30: &'20 u32; // anonymous local
+    let _31: Option<Arguments<'28>>[{built_in impl Sized for Arguments<'28>}]; // anonymous local
+    let _32: &'32 u32; // anonymous local
+    let _33: &'33 u32; // anonymous local
+    let _34: &'47 u32; // anonymous local
     let _35: u32; // anonymous local
     let _36: &'_ [u32; 10usize]; // anonymous local
     let _37: &'_ u32; // anonymous local
@@ -483,9 +497,9 @@ fn foo()
     storage_dead(_19)
     storage_dead(_17)
     storage_live(left_val)
-    left_val = copy _16.0
+    left_val = copy _16._0
     storage_live(right_val)
-    right_val = copy _16.1
+    right_val = copy _16._1
     storage_live(_22)
     storage_live(_23)
     _23 = copy (*left_val)

--- a/charon/tests/ui/constants.out
+++ b/charon/tests/ui/constants.out
@@ -29,6 +29,14 @@ pub fn MAX() -> u32
 // Full name: core::num::{u32}::MAX
 pub const MAX: u32 = MAX()
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::X0
 pub fn X0() -> u32
 {

--- a/charon/tests/ui/constructor-ref.out
+++ b/charon/tests/ui/constructor-ref.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -43,6 +45,10 @@ pub trait FnOnce<Self, Args>
     type Output
     fn call_once;
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
+}
+
+struct (_,)<A> {
+  _0: A,
 }
 
 // Full name: test_crate::Wrapper
@@ -77,7 +83,7 @@ where
     let args: (T,); // arg #2
 
     storage_live(_0)
-    _0 = Value<T>[TraitClause0](move args.0)
+    _0 = Value<T>[TraitClause0](move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue

--- a/charon/tests/ui/consts/evaluate-consts-inline.out
+++ b/charon/tests/ui/consts/evaluate-consts-inline.out
@@ -1,5 +1,27 @@
 # Final LLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::promoted_scalar
 pub fn promoted_scalar() -> &'static i32
 {

--- a/charon/tests/ui/consts/evaluate-consts-mono.out
+++ b/charon/tests/ui/consts/evaluate-consts-mono.out
@@ -8,6 +8,11 @@ opaque type {vtable}
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct (_, _)::<usize, bool> {
+  _0: usize,
+  _1: bool,
+}
+
 // Full name: test_crate::HasLen
 trait HasLen<Self>
 {

--- a/charon/tests/ui/consts/evaluate-consts.out
+++ b/charon/tests/ui/consts/evaluate-consts.out
@@ -14,6 +14,14 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::SIMPLE
 pub const SIMPLE: u32 = 42u32
 

--- a/charon/tests/ui/consts/pointer-cast-const-pattern.out
+++ b/charon/tests/ui/consts/pointer-cast-const-pattern.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::DISGUISED_INT
 fn DISGUISED_INT() -> *const ()
 {

--- a/charon/tests/ui/consts/ptr-null-constevalval.out
+++ b/charon/tests/ui/consts/ptr-null-constevalval.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: core::ptr::metadata::from_raw_parts::<u8, ()>
 pub fn from_raw_parts::<u8, ()>(data_pointer: *const (), metadata: ()) -> *const u8
 {

--- a/charon/tests/ui/consts/string-new-constevalval.out
+++ b/charon/tests/ui/consts/string-new-constevalval.out
@@ -55,7 +55,9 @@ pub fn alloc::string::{String}::new() -> String
     return
 }
 
-// Full name: test_crate::<slice>::{impl Destruct for [T]}
+struct () {}
+
+// Full name: {impl Destruct for [T]}
 impl<T> "impl_Destruct_for_slice" Destruct for [T]
 where
     TraitClause0: (T: Sized),
@@ -63,7 +65,7 @@ where
     non-dyn-compatible
 }
 
-// Full name: test_crate::<slice>::{impl Destruct for [T]}::drop_glue
+// Full name: {impl Destruct for [T]}::drop_glue
 unsafe fn impl_Destruct_for_slice::drop_glue<'_0, T>(_1: &'_0 mut [T])
 where
     TraitClause0: (T: Sized),

--- a/charon/tests/ui/contracts.out
+++ b/charon/tests/ui/contracts.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/control-flow/ambiguous-loop-exit.out
+++ b/charon/tests/ui/control-flow/ambiguous-loop-exit.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::f
 pub fn f(x: u32) -> u32
 {

--- a/charon/tests/ui/control-flow/duplicated-statement.out
+++ b/charon/tests/ui/control-flow/duplicated-statement.out
@@ -1,5 +1,29 @@
 # Final LLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::rej_sample
 fn rej_sample<'_0>(a: &'_0 [u8]) -> usize
 {

--- a/charon/tests/ui/control-flow/empty-loop.out
+++ b/charon/tests/ui/control-flow/empty-loop.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/control-flow/issue-1051-missing-loop-jump.out
+++ b/charon/tests/ui/control-flow/issue-1051-missing-loop-jump.out
@@ -94,6 +94,14 @@ impl "impl_PartialOrd_i32_for_i32" PartialOrd<i32> for i32 {
     vtable: impl_PartialOrd_i32_for_i32::{vtable}
 }
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: core::iter::range::Step
 #[diagnostic_item("range_step")]
 pub trait Step<Self>
@@ -191,6 +199,12 @@ where
     TraitClause0: (I: Sized),
     TraitClause1: (I: Iterator),
 = <opaque>
+
+struct () {}
+
+struct (_,)<A> {
+  _0: A,
+}
 
 // Full name: test_crate::f
 pub fn f()

--- a/charon/tests/ui/control-flow/issue-1051-return-break.out
+++ b/charon/tests/ui/control-flow/issue-1051-return-break.out
@@ -1,5 +1,29 @@
 # Final LLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::f
 pub fn f(y: u32) -> bool
 {

--- a/charon/tests/ui/control-flow/issue-297-cfg.out
+++ b/charon/tests/ui/control-flow/issue-297-cfg.out
@@ -81,6 +81,20 @@ where
     TypeOutlives0: T: '_0,
 = <opaque>
 
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: test_crate::f1
 fn f1<'_0>(a: &'_0 [u8]) -> usize
 {

--- a/charon/tests/ui/control-flow/issue-507-cfg.out
+++ b/charon/tests/ui/control-flow/issue-507-cfg.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::CONST
 fn CONST() -> u8
 {

--- a/charon/tests/ui/control-flow/issue-899-forward-jump-incorrectly-reconstructed.out
+++ b/charon/tests/ui/control-flow/issue-899-forward-jump-incorrectly-reconstructed.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::condition
 fn condition(_x: u32) -> bool
 {

--- a/charon/tests/ui/control-flow/lazy-boolean-op-in-if.out
+++ b/charon/tests/ui/control-flow/lazy-boolean-op-in-if.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::foo
 fn foo() -> bool
 {

--- a/charon/tests/ui/control-flow/loop-break.out
+++ b/charon/tests/ui/control-flow/loop-break.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::foo
 fn foo() -> bool
 {

--- a/charon/tests/ui/control-flow/loops.out
+++ b/charon/tests/ui/control-flow/loops.out
@@ -158,6 +158,14 @@ impl "impl_PartialOrd_u32_for_u32" PartialOrd<u32> for u32 {
     vtable: impl_PartialOrd_u32_for_u32::{vtable}
 }
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: core::iter::range::Step
 #[diagnostic_item("range_step")]
 pub trait Step<Self>
@@ -405,6 +413,14 @@ where
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
 // Full name: alloc::vec::Vec
 #[diagnostic_item("Vec")]
 pub opaque type Vec<T>
@@ -432,6 +448,12 @@ where
     TypeOutlives2: TraitClause3::Output: '_0,
     TypeOutlives3: I: '_0,
 = <opaque>
+
+struct () {}
+
+struct (_,)<A> {
+  _0: A,
+}
 
 // Full name: test_crate::test_loop1
 pub fn test_loop1(max: u32) -> u32
@@ -1673,7 +1695,7 @@ pub enum List<T>
 where
     TraitClause0: (T: Sized),
 {
-  Cons { _0: T, _1: alloc::boxed::Box<List<T>[TraitClause0]>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}] },
+  Cons { _0: T, _1: Box<List<T>[TraitClause0]>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}] },
   Nil,
 }
 
@@ -1684,7 +1706,7 @@ pub fn get_elem_mut<'_0>(ls: &'_0 mut List<usize>[{built_in impl Sized for usize
     let ls: &'3 mut List<usize>[{built_in impl Sized for usize}]; // arg #1
     let x: usize; // arg #2
     let y: &'4 mut usize; // local
-    let tl: &'6 mut alloc::boxed::Box<List<usize>[{built_in impl Sized for usize}]>[{built_in impl MetaSized for List<usize>[{built_in impl Sized for usize}]}, {built_in impl Sized for Global}]; // local
+    let tl: &'6 mut Box<List<usize>[{built_in impl Sized for usize}]>[{built_in impl MetaSized for List<usize>[{built_in impl Sized for usize}]}, {built_in impl Sized for Global}]; // local
     let _5: bool; // anonymous local
     let _6: usize; // anonymous local
     let _7: usize; // anonymous local
@@ -1746,7 +1768,7 @@ where
     let ls: &'3 mut List<T>[TraitClause0]; // arg #1
     let i: u32; // arg #2
     let x: &'4 mut T; // local
-    let tl: &'6 mut alloc::boxed::Box<List<T>[TraitClause0]>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
+    let tl: &'6 mut Box<List<T>[TraitClause0]>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
     let _5: bool; // anonymous local
     let _6: u32; // anonymous local
     let _7: &'7 mut List<T>[TraitClause0]; // anonymous local

--- a/charon/tests/ui/control-flow/simple-fallthrough.out
+++ b/charon/tests/ui/control-flow/simple-fallthrough.out
@@ -25,6 +25,8 @@ where
   Some { _0: T },
 }
 
+struct () {}
+
 // Full name: test_crate::do_something
 fn do_something()
 {

--- a/charon/tests/ui/control-flow/ullbc-control-flow.out
+++ b/charon/tests/ui/control-flow/ullbc-control-flow.out
@@ -126,6 +126,14 @@ impl "impl_PartialOrd_usize_for_usize" PartialOrd<usize> for usize {
     vtable: impl_PartialOrd_usize_for_usize::{vtable}
 }
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: core::iter::range::Step
 #[diagnostic_item("range_step")]
 pub trait Step<Self>
@@ -256,6 +264,12 @@ where
     TraitClause0: (I: Sized),
     TraitClause1: (I: Iterator),
 = <opaque>
+
+struct () {}
+
+struct (_,)<A> {
+  _0: A,
+}
 
 // Full name: test_crate::nested_loops_enum
 pub fn nested_loops_enum(step_out: usize, step_in: usize) -> usize

--- a/charon/tests/ui/copy_nonoverlapping.out
+++ b/charon/tests/ui/copy_nonoverlapping.out
@@ -9,6 +9,8 @@ pub opaque type Layout
 pub unsafe fn from_size_align_unchecked(_1: usize, _2: usize) -> Layout
 = <opaque>
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -136,6 +138,10 @@ impl "impl_Clone_for_usize" Clone for usize {
 #[rustc_intrinsic]
 pub fn abort() -> !
 = <intrinsic:abort>
+
+struct str {
+  _0: [u8],
+}
 
 // Full name: core::ptr::non_null::NonNull
 #[diagnostic_item("NonNull")]
@@ -494,6 +500,14 @@ fn check_language_ub() -> bool
     return
 }
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: core::panicking::panic_nounwind_fmt
 #[track_caller]
 pub fn panic_nounwind_fmt<'_0>(fmt: Arguments<'_0>, force_no_backtrace: bool) -> !
@@ -501,8 +515,8 @@ pub fn panic_nounwind_fmt<'_0>(fmt: Arguments<'_0>, force_no_backtrace: bool) ->
     let _0: !; // return
     let fmt: Arguments<'1>; // arg #1
     let force_no_backtrace: bool; // arg #2
-    let _3: (Arguments<'3>, bool); // anonymous local
-    let _4: Arguments<'4>; // anonymous local
+    let _3: (Arguments<'8>, bool); // anonymous local
+    let _4: Arguments<'12>; // anonymous local
     let _5: bool; // anonymous local
 
     storage_live(_0)
@@ -514,7 +528,7 @@ pub fn panic_nounwind_fmt<'_0>(fmt: Arguments<'_0>, force_no_backtrace: bool) ->
     _3 = (move _4, move _5)
     storage_dead(_5)
     storage_dead(_4)
-    _0 = core::panicking::panic_nounwind_fmt::runtime<'6>(move _3.0, move _3.1)
+    _0 = core::panicking::panic_nounwind_fmt::runtime<'18>(move _3._0, move _3._1)
     ↳⚡ storage_dead(_3)
         storage_dead(force_no_backtrace)
         storage_dead(fmt)

--- a/charon/tests/ui/cross_compile_32_bit.out
+++ b/charon/tests/ui/cross_compile_32_bit.out
@@ -1,5 +1,19 @@
 # Final LLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
 // Full name: core::num::{usize}::MAX
 pub fn MAX() -> usize
 = <opaque>
@@ -15,6 +29,16 @@ pub opaque type NonNull<T>
 #[track_caller]
 pub unsafe fn new_unchecked<T>(_1: *mut T) -> NonNull<T>
 = <opaque>
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
 
 // Full name: test_crate::HasPointerNiche
 enum HasPointerNiche {

--- a/charon/tests/ui/cross_compile_big_endian.out
+++ b/charon/tests/ui/cross_compile_big_endian.out
@@ -1,5 +1,19 @@
 # Final LLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
 // Full name: core::num::{usize}::MAX
 pub fn MAX() -> usize
 = <opaque>
@@ -10,6 +24,16 @@ pub const MAX: usize = MAX()
 // Full name: core::num::{u128}::to_ne_bytes
 pub fn to_ne_bytes(_1: u128) -> [u8; 16usize]
 = <opaque>
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
 
 // Full name: test_crate::S
 fn S() -> [u8; 16usize]

--- a/charon/tests/ui/deallocate-all-locals.out
+++ b/charon/tests/ui/deallocate-all-locals.out
@@ -1,5 +1,29 @@
 # Final ULLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::sum
 fn sum(x: u32, y: u32) -> u32
 {
@@ -23,7 +47,7 @@ fn sum(x: u32, y: u32) -> u32
         storage_live(_5);
         _5 = copy y;
         _6 = copy _4 checked.+ copy _5;
-        assert assert(move _6.1 == false) (overflow) -> bb2 (unwind: bb1);
+        assert assert(move _6._1 == false) (overflow) -> bb2 (unwind: bb1);
     }
 
     bb1: {
@@ -35,18 +59,18 @@ fn sum(x: u32, y: u32) -> u32
     }
 
     bb2: {
-        z = move _6.0;
+        z = move _6._0;
         storage_dead(_5);
         storage_dead(_4);
         fake_read(z);
         storage_live(_7);
         _7 = copy z;
         _8 = copy _7 checked.+ const 1u32;
-        assert assert(move _8.1 == false) (overflow) -> bb3 (unwind: bb1);
+        assert assert(move _8._1 == false) (overflow) -> bb3 (unwind: bb1);
     }
 
     bb3: {
-        _0 = move _8.0;
+        _0 = move _8._0;
         storage_dead(_7);
         storage_dead(z);
         storage_dead(_8);

--- a/charon/tests/ui/demo.out
+++ b/charon/tests/ui/demo.out
@@ -18,6 +18,24 @@ pub trait Sized<Self>
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::choose
 pub fn choose<'a, T>(b: bool, x: &'a mut T, y: &'a mut T) -> &'a mut T
 where
@@ -200,7 +218,7 @@ pub enum CList<T>
 where
     TraitClause0: (T: Sized),
 {
-  CCons { _0: T, _1: alloc::boxed::Box<CList<T>[TraitClause0]>[{built_in impl MetaSized for CList<T>[TraitClause0]}, {built_in impl Sized for Global}] },
+  CCons { _0: T, _1: Box<CList<T>[TraitClause0]>[{built_in impl MetaSized for CList<T>[TraitClause0]}, {built_in impl Sized for Global}] },
   CNil,
 }
 
@@ -214,7 +232,7 @@ where
     let l: &'3 CList<T>[TraitClause0]; // arg #1
     let i: u32; // arg #2
     let x: &'4 T; // local
-    let tl: &'6 alloc::boxed::Box<CList<T>[TraitClause0]>[{built_in impl MetaSized for CList<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
+    let tl: &'6 Box<CList<T>[TraitClause0]>[{built_in impl MetaSized for CList<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
     let _5: bool; // anonymous local
     let _6: u32; // anonymous local
     let _7: &'7 T; // anonymous local
@@ -295,7 +313,7 @@ where
     let _3: &'4 mut T; // anonymous local
     let _4: &'5 mut T; // anonymous local
     let x: &'6 mut T; // local
-    let tl: &'8 mut alloc::boxed::Box<CList<T>[TraitClause0]>[{built_in impl MetaSized for CList<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
+    let tl: &'8 mut Box<CList<T>[TraitClause0]>[{built_in impl MetaSized for CList<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
     let _7: &'9 mut T; // anonymous local
     let _8: &'10 mut T; // anonymous local
     let _9: bool; // anonymous local
@@ -385,7 +403,7 @@ where
     let l: &'3 mut CList<T>[TraitClause0]; // arg #1
     let i: u32; // arg #2
     let x: &'4 mut T; // local
-    let tl: &'6 mut alloc::boxed::Box<CList<T>[TraitClause0]>[{built_in impl MetaSized for CList<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
+    let tl: &'6 mut Box<CList<T>[TraitClause0]>[{built_in impl MetaSized for CList<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
     let _5: bool; // anonymous local
     let _6: u32; // anonymous local
     let _7: u32; // anonymous local
@@ -503,7 +521,7 @@ where
     let l: &'2 mut CList<T>[TraitClause0]; // arg #1
     let _2: &'3 mut CList<T>[TraitClause0]; // anonymous local
     let _3: &'4 mut CList<T>[TraitClause0]; // anonymous local
-    let tl: &'6 mut alloc::boxed::Box<CList<T>[TraitClause0]>[{built_in impl MetaSized for CList<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
+    let tl: &'6 mut Box<CList<T>[TraitClause0]>[{built_in impl MetaSized for CList<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
     let _5: &'7 mut CList<T>[TraitClause0]; // anonymous local
     let _6: &'8 mut CList<T>[TraitClause0]; // anonymous local
 

--- a/charon/tests/ui/desugar_drops_to_calls.out
+++ b/charon/tests/ui/desugar_drops_to_calls.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -56,8 +58,18 @@ impl "impl_Destruct_for_Global" Destruct for Global {
     non-dyn-compatible
 }
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (type_error("removed allocator parameter"): Destruct),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -67,10 +79,10 @@ where
     TypeOutlives1: A: '_0,
 = <opaque>
 
-// Full name: alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, TraitClause1, impl_Destruct_for_Global]}::new
+// Full name: alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, TraitClause1, impl_Destruct_for_Global]}::new
 #[track_caller]
 #[diagnostic_item("box_new")]
-pub fn new<T>(_1: T) -> alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, TraitClause1, impl_Destruct_for_Global]
+pub fn new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, TraitClause1, impl_Destruct_for_Global]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Destruct),
@@ -103,6 +115,10 @@ where
     TypeOutlives0: T: '_0,
     TypeOutlives1: A: '_0,
 = <opaque>
+
+struct str {
+  _0: [u8],
+}
 
 // Full name: test_crate::use_string
 fn use_string(_1: String)
@@ -191,8 +207,8 @@ fn skip_drop_scalar(_1: i32)
 
 // Full name: test_crate::Point
 struct Point {
-  x: alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global],
-  y: alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global],
+  x: Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global],
+  y: Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global],
 }
 
 // Full name: test_crate::{impl Drop for Point}::drop
@@ -227,13 +243,13 @@ unsafe fn impl_Destruct_for_Point::drop_glue<'_0>(_1: &'_0 mut Point)
     let _1: &'1 mut Point; // arg #1
     let _2: &'2 mut Point; // anonymous local
     let _3: (); // anonymous local
-    let drop_arg_4: &'_ mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
+    let drop_arg_4: &'_ mut Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
     let drop_ret_5: (); // local
-    let drop_arg_6: &'_ mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
+    let drop_arg_6: &'_ mut Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
     let drop_ret_7: (); // local
-    let drop_arg_8: &'_ mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
+    let drop_arg_8: &'_ mut Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
     let drop_ret_9: (); // local
-    let drop_arg_10: &'_ mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
+    let drop_arg_10: &'_ mut Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
     let drop_ret_11: (); // local
 
     storage_live(_0)
@@ -343,9 +359,9 @@ fn main()
 {
     let _0: (); // return
     let p: Point; // local
-    let _2: alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
-    let _3: alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
-    let drop_arg_4: &'_ mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
+    let _2: Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
+    let _3: Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
+    let drop_arg_4: &'_ mut Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
     let drop_ret_5: (); // local
     let drop_arg_6: &'_ mut Point; // local
     let drop_ret_7: (); // local

--- a/charon/tests/ui/desugar_drops_to_calls_mono.out
+++ b/charon/tests/ui/desugar_drops_to_calls_mono.out
@@ -7,14 +7,7 @@ opaque type core::marker::MetaSized::{vtable}
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
-// Full name: core::marker::Sized
-#[fundamental]
-#[lang_item(Sized)]
-pub trait Sized<Self>
-{
-    proof ImpliedClause0: (Self: MetaSized)
-    non-dyn-compatible
-}
+struct () {}
 
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
@@ -39,28 +32,19 @@ pub trait Drop<Self>
 pub fn _print<'_0>(_1: Arguments::<'_>)
 = <opaque>
 
-// Full name: alloc::alloc::Global
-#[lang_item(GlobalAlloc)]
-pub struct Global {}
+// Full name: alloc::boxed::Box::<i32>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<i32, Global>
 
-// Full name: alloc::alloc::Global::{impl Destruct for Global}::drop_glue
-unsafe fn impl_Destruct_for_Global::drop_glue<'_0>(_1: &'_0 mut Global)
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<i32, Global>}::drop_glue::<i32, Global>
+unsafe fn {impl Destruct for Box::<i32, Global>}::drop_glue::<i32, Global><'_0>(_1: &'_0 mut Box::<i32, Global>)
 = <opaque>
 
-// Full name: alloc::alloc::Global::{impl Destruct for Global}
-impl "impl_Destruct_for_Global" Destruct for Global {
-    fn drop_glue<'_0_1> = impl_Destruct_for_Global::drop_glue<'_0_1>
-    non-dyn-compatible
-}
-
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}::drop_glue::<i32, Global>
-unsafe fn impl_Destruct_for_Box_i32_Global::drop_glue::<i32, Global><'_0>(_1: &'_0 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global])
-= <opaque>
-
-// Full name: alloc::boxed::{alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}::new::<i32>
+// Full name: alloc::boxed::{Box::<i32, Global>}::new::<i32>
 #[track_caller]
 #[diagnostic_item("box_new")]
-pub fn new::<i32>(_1: i32) -> alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]
+pub fn new::<i32>(_1: i32) -> Box::<i32, Global>
 = <opaque>
 
 // Full name: alloc::string::String
@@ -78,6 +62,10 @@ pub opaque type Vec::<i32, Global>
 // Full name: alloc::vec::Vec::{impl Destruct for Vec::<i32, Global>}::drop_glue::<i32, Global>
 unsafe fn {impl Destruct for Vec::<i32, Global>}::drop_glue::<i32, Global><'_0>(_1: &'_0 mut Vec::<i32, Global>)
 = <opaque>
+
+struct str {
+  _0: [u8],
+}
 
 // Full name: test_crate::use_string
 fn use_string(_1: String)
@@ -140,8 +128,8 @@ fn skip_drop_scalar(_1: i32)
 
 // Full name: test_crate::Point
 struct Point {
-  x: alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global],
-  y: alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global],
+  x: Box::<i32, Global>,
+  y: Box::<i32, Global>,
 }
 
 // Full name: test_crate::{impl Drop for Point}::drop
@@ -176,13 +164,13 @@ unsafe fn impl_Destruct_for_Point::drop_glue<'_0>(_1: &'_0 mut Point)
     let _1: &'1 mut Point; // arg #1
     let _2: &'2 mut Point; // anonymous local
     let _3: (); // anonymous local
-    let drop_arg_4: &'_ mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
+    let drop_arg_4: &'_ mut Box::<i32, Global>; // local
     let drop_ret_5: (); // local
-    let drop_arg_6: &'_ mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
+    let drop_arg_6: &'_ mut Box::<i32, Global>; // local
     let drop_ret_7: (); // local
-    let drop_arg_8: &'_ mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
+    let drop_arg_8: &'_ mut Box::<i32, Global>; // local
     let drop_ret_9: (); // local
-    let drop_arg_10: &'_ mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
+    let drop_arg_10: &'_ mut Box::<i32, Global>; // local
     let drop_ret_11: (); // local
 
     storage_live(_0)
@@ -194,7 +182,7 @@ unsafe fn impl_Destruct_for_Point::drop_glue<'_0>(_1: &'_0 mut Point)
     ↳⚡ storage_live(drop_arg_4)
         drop_arg_4 = &mut (*_1).x
         storage_live(drop_ret_5)
-        drop_ret_5 = impl_Destruct_for_Box_i32_Global::drop_glue::<i32, Global><'5>(move drop_arg_4)
+        drop_ret_5 = {impl Destruct for Box::<i32, Global>}::drop_glue::<i32, Global><'5>(move drop_arg_4)
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -210,7 +198,7 @@ unsafe fn impl_Destruct_for_Point::drop_glue<'_0>(_1: &'_0 mut Point)
         storage_live(drop_arg_8)
         drop_arg_8 = &mut (*_1).y
         storage_live(drop_ret_9)
-        drop_ret_9 = impl_Destruct_for_Box_i32_Global::drop_glue::<i32, Global><'7>(move drop_arg_8)
+        drop_ret_9 = {impl Destruct for Box::<i32, Global>}::drop_glue::<i32, Global><'7>(move drop_arg_8)
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -230,11 +218,11 @@ unsafe fn impl_Destruct_for_Point::drop_glue<'_0>(_1: &'_0 mut Point)
     storage_live(drop_arg_6)
     drop_arg_6 = &mut (*_1).x
     storage_live(drop_ret_7)
-    drop_ret_7 = impl_Destruct_for_Box_i32_Global::drop_glue::<i32, Global><'6>(move drop_arg_6)
+    drop_ret_7 = {impl Destruct for Box::<i32, Global>}::drop_glue::<i32, Global><'6>(move drop_arg_6)
     ↳⚡ storage_live(drop_arg_8)
         drop_arg_8 = &mut (*_1).y
         storage_live(drop_ret_9)
-        drop_ret_9 = impl_Destruct_for_Box_i32_Global::drop_glue::<i32, Global><'7>(move drop_arg_8)
+        drop_ret_9 = {impl Destruct for Box::<i32, Global>}::drop_glue::<i32, Global><'7>(move drop_arg_8)
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -254,7 +242,7 @@ unsafe fn impl_Destruct_for_Point::drop_glue<'_0>(_1: &'_0 mut Point)
     storage_live(drop_arg_10)
     drop_arg_10 = &mut (*_1).y
     storage_live(drop_ret_11)
-    drop_ret_11 = impl_Destruct_for_Box_i32_Global::drop_glue::<i32, Global><'8>(move drop_arg_10)
+    drop_ret_11 = {impl Destruct for Box::<i32, Global>}::drop_glue::<i32, Global><'8>(move drop_arg_10)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -291,9 +279,9 @@ fn main()
 {
     let _0: (); // return
     let p: Point; // local
-    let _2: alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
-    let _3: alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
-    let drop_arg_4: &'_ mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
+    let _2: Box::<i32, Global>; // anonymous local
+    let _3: Box::<i32, Global>; // anonymous local
+    let drop_arg_4: &'_ mut Box::<i32, Global>; // local
     let drop_ret_5: (); // local
     let drop_arg_6: &'_ mut Point; // local
     let drop_ret_7: (); // local
@@ -309,7 +297,7 @@ fn main()
     ↳⚡ storage_live(drop_arg_4)
         drop_arg_4 = &mut _2
         storage_live(drop_ret_5)
-        drop_ret_5 = impl_Destruct_for_Box_i32_Global::drop_glue::<i32, Global><'0>(move drop_arg_4)
+        drop_ret_5 = {impl Destruct for Box::<i32, Global>}::drop_glue::<i32, Global><'0>(move drop_arg_4)
         ↳⚡ storage_dead(drop_ret_7)
             storage_dead(drop_arg_6)
             storage_dead(drop_ret_5)

--- a/charon/tests/ui/disambiguator.out
+++ b/charon/tests/ui/disambiguator.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 fn test_crate::nonzero_disambiguator::my_function#1()
 {
     let _0: (); // return

--- a/charon/tests/ui/diverging.out
+++ b/charon/tests/ui/diverging.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::my_panic
 fn my_panic(_x: u32) -> !
 {

--- a/charon/tests/ui/drop_after_overflow.out
+++ b/charon/tests/ui/drop_after_overflow.out
@@ -4,6 +4,10 @@
 #[lang_item(FormatArguments)]
 pub opaque type Arguments<'a>
 
+struct str {
+  _0: [u8],
+}
+
 // Full name: core::fmt::{Arguments<'a>}::from_str
 pub fn from_str<'a>(_1: &'static str) -> Arguments<'a>
 = <opaque>
@@ -12,6 +16,17 @@ pub fn from_str<'a>(_1: &'static str) -> Arguments<'a>
 #[fundamental]
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
 
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
@@ -39,6 +54,14 @@ where
 // Full name: std::io::stdio::_print
 pub fn _print<'_0>(_1: Arguments<'_0>)
 = <opaque>
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
 
 // Full name: test_crate::Foo
 struct Foo {}
@@ -132,7 +155,7 @@ fn main()
         fake_read(f);
         storage_live(_2);
         _3 = const 255u8 checked.+ const 1u8;
-        assert assert(move _3.1 == false) (overflow) -> bb2 (unwind: bb1);
+        assert assert(move _3._1 == false) (overflow) -> bb2 (unwind: bb1);
     }
 
     bb1: {
@@ -140,7 +163,7 @@ fn main()
     }
 
     bb2: {
-        _2 = move _3.0;
+        _2 = move _3._0;
         storage_dead(_2);
         storage_live(f_ref);
         f_ref = &f;

--- a/charon/tests/ui/dyn/box-dyn-fnonce-raw.out
+++ b/charon/tests/ui/dyn/box-dyn-fnonce-raw.out
@@ -24,6 +24,8 @@ where
 // Full name: core::alloc::AllocError
 pub struct AllocError {}
 
+struct () {}
+
 // Full name: core::marker::Sized
 #[fundamental]
 #[lang_item(Sized)]

--- a/charon/tests/ui/dyn/builtin-vtables.out
+++ b/charon/tests/ui/dyn/builtin-vtables.out
@@ -16,6 +16,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -99,6 +101,10 @@ pub trait Fn<Self, Args>
     vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: test_crate::takes_fn
 fn takes_fn<'_0>(_1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '_0))
 {
@@ -132,7 +138,7 @@ fn {impl Fn<(u32,)> for some_fn}::call<'_0>(state: &'_0 some_fn, args: (u32,)) -
     let args: (u32,); // arg #2
 
     storage_live(_0)
-    _0 = some_fn(move args.0)
+    _0 = some_fn(move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -149,7 +155,7 @@ fn {impl FnMut<(u32,)> for some_fn}::call_mut<'_0>(state: &'_0 mut some_fn, args
     let args: (u32,); // arg #2
 
     storage_live(_0)
-    _0 = some_fn(move args.0)
+    _0 = some_fn(move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -166,7 +172,7 @@ fn {impl FnOnce<(u32,)> for some_fn}::call_once(state: some_fn, args: (u32,)) ->
     let args: (u32,); // arg #2
 
     storage_live(_0)
-    _0 = some_fn(move args.0)
+    _0 = some_fn(move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -219,7 +225,7 @@ fn impl_Fn_tuple_for_closure::call<'_0>(_1: &'_0 closure, tupled_args: (u32,)) -
 
     storage_live(_0)
     storage_live(_3)
-    _3 = move tupled_args.0
+    _3 = move tupled_args._0
     _0 = const 42u32
     storage_dead(_3)
     storage_dead(tupled_args)

--- a/charon/tests/ui/dyn/dyn-broken-assoc-type-constraint.out
+++ b/charon/tests/ui/dyn/dyn-broken-assoc-type-constraint.out
@@ -16,6 +16,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/dyn/dyn-cast-to-supertrait.out
+++ b/charon/tests/ui/dyn/dyn-cast-to-supertrait.out
@@ -12,6 +12,8 @@ fn core::marker::MetaSized::{vtable}<Self>() -> core::marker::MetaSized::{vtable
 
 static core::marker::MetaSized::{vtable}<Self>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}<Self>()
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/dyn/dyn-fn.out
+++ b/charon/tests/ui/dyn/dyn-fn.out
@@ -16,6 +16,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -82,6 +84,18 @@ pub trait Fn<Self, Args>
     proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1>;
     vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
+}
+
+struct (_,)<A> {
+  _0: A,
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
 }
 
 // Full name: test_crate::takes_fn
@@ -151,7 +165,7 @@ fn call<'_0, '_1>(_1: &'_1 closure, tupled_args: (&'_0 mut u32,)) -> bool
     storage_live(_0)
     storage_live(counter)
     storage_live(_4)
-    counter = move tupled_args.0
+    counter = move tupled_args._0
     _4 = copy (*counter) panic.+ const 1u32
     (*counter) = move _4
     _0 = const true

--- a/charon/tests/ui/dyn/dyn-method-with-early-bound-lifetimes.out
+++ b/charon/tests/ui/dyn/dyn-method-with-early-bound-lifetimes.out
@@ -7,6 +7,8 @@ opaque type core::marker::MetaSized::{vtable}
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct () {}
+
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/dyn/dyn-trait.out
+++ b/charon/tests/ui/dyn/dyn-trait.out
@@ -91,6 +91,14 @@ where
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
 // Full name: alloc::string::String
 #[lang_item(String)]
 pub opaque type String
@@ -103,9 +111,15 @@ where
     TypeOutlives0: T: '_0,
 = <opaque>
 
+struct () {}
+
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: test_crate::construct
 #[charon::opaque]
-fn construct<T>(_1: T) -> alloc::boxed::Box<(dyn Display + 'static)>[{built_in impl MetaSized for (dyn Display + 'static)}, {built_in impl Sized for Global}]
+fn construct<T>(_1: T) -> Box<(dyn Display + 'static)>[{built_in impl MetaSized for (dyn Display + 'static)}, {built_in impl Sized for Global}]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Display),

--- a/charon/tests/ui/dyn/dyn-with-diamond-supertraits.out
+++ b/charon/tests/ui/dyn/dyn-with-diamond-supertraits.out
@@ -26,6 +26,16 @@ fn core::marker::MetaSized::{vtable}<Self>() -> core::marker::MetaSized::{vtable
 
 static core::marker::MetaSized::{vtable}<Self>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}<Self>()
 
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 struct test_crate::Super::{vtable}<T> {
   size: usize,
   align: usize,

--- a/charon/tests/ui/dyn/issue-1074-vtable-supertrait.out
+++ b/charon/tests/ui/dyn/issue-1074-vtable-supertrait.out
@@ -23,6 +23,8 @@ fn core::marker::MetaSized::{vtable}<Self>() -> core::marker::MetaSized::{vtable
 
 static core::marker::MetaSized::{vtable}<Self>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}<Self>()
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/dyn/issue-1236-vtable-fn-ptr.out
+++ b/charon/tests/ui/dyn/issue-1236-vtable-fn-ptr.out
@@ -12,6 +12,8 @@ fn core::marker::MetaSized::{vtable}::<Bar>() -> core::marker::MetaSized::{vtabl
 
 static core::marker::MetaSized::{vtable}::<Bar>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<Bar>()
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/dyn/issue-1264-builtin-vtable-poly.out
+++ b/charon/tests/ui/dyn/issue-1264-builtin-vtable-poly.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: core::marker::Send::{vtable}
 struct {vtable} {
   size: usize,

--- a/charon/tests/ui/dyn/issue-1264-builtin-vtable.out
+++ b/charon/tests/ui/dyn/issue-1264-builtin-vtable.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: core::marker::Send::{vtable}
 struct {vtable} {
   size: usize,

--- a/charon/tests/ui/dyn/mono-vtable-blanket-impl.out
+++ b/charon/tests/ui/dyn/mono-vtable-blanket-impl.out
@@ -12,6 +12,8 @@ fn core::marker::MetaSized::{vtable}::<()>() -> core::marker::MetaSized::{vtable
 
 static core::marker::MetaSized::{vtable}::<()>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<()>()
 
+struct () {}
+
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/dyn/mono-vtable-lifetime-impl.out
+++ b/charon/tests/ui/dyn/mono-vtable-lifetime-impl.out
@@ -12,12 +12,18 @@ fn core::marker::MetaSized::{vtable}::<Pattern::<'_>>() -> core::marker::MetaSiz
 
 static core::marker::MetaSized::{vtable}::<Pattern::<'_>>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<Pattern::<'_>>()
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
 {
     fn drop_glue<'_0_1>;
     non-dyn-compatible
+}
+
+struct str {
+  _0: [u8],
 }
 
 struct test_crate::Trait::{vtable} {

--- a/charon/tests/ui/dyn/mono-vtable-ref-impl.out
+++ b/charon/tests/ui/dyn/mono-vtable-ref-impl.out
@@ -12,6 +12,8 @@ fn core::marker::MetaSized::{vtable}::<&'_ u32>() -> core::marker::MetaSized::{v
 
 static core::marker::MetaSized::{vtable}::<&'_ u32>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<&'_ u32>()
 
+struct () {}
+
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/dyn/opaque-vtable.out
+++ b/charon/tests/ui/dyn/opaque-vtable.out
@@ -5,6 +5,8 @@
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct () {}
+
 opaque type test_crate::x::Trait::{vtable}
 
 // Full name: test_crate::x::Trait

--- a/charon/tests/ui/dyn/vtable-simple.out
+++ b/charon/tests/ui/dyn/vtable-simple.out
@@ -42,6 +42,16 @@ impl "impl_Clone_for_i32" Clone for i32 {
     non-dyn-compatible
 }
 
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 struct test_crate::Modifiable::{vtable}<T> {
   size: usize,
   align: usize,

--- a/charon/tests/ui/dyn/vtable_drop.out
+++ b/charon/tests/ui/dyn/vtable_drop.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -66,8 +68,18 @@ impl "impl_Destruct_for_Global" Destruct for Global {
     non-dyn-compatible
 }
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (type_error("removed allocator parameter"): Destruct),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -77,8 +89,8 @@ where
     TypeOutlives1: A: '_0,
 = <opaque>
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}
-impl<T, A> "impl_Destruct_for_Box" Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}
+impl<T, A> "impl_Destruct_for_Box" Destruct for Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -89,14 +101,24 @@ where
     non-dyn-compatible
 }
 
-// Full name: alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, TraitClause1, impl_Destruct_for_Global]}::new
+// Full name: alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, TraitClause1, impl_Destruct_for_Global]}::new
 #[track_caller]
 #[diagnostic_item("box_new")]
-pub fn new<T>(_1: T) -> alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, TraitClause1, impl_Destruct_for_Global]
+pub fn new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, TraitClause1, impl_Destruct_for_Global]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Destruct),
 = <opaque>
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: Destruct),
+    TraitClause2: (B: Destruct),
+{
+  _0: A,
+  _1: B,
+}
 
 struct test_crate::Modifiable::{vtable}<T> {
   size: usize,
@@ -117,8 +139,8 @@ trait Modifiable<Self, T>
     vtable: test_crate::Modifiable::{vtable}<T>
 }
 
-// Full name: test_crate::{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}::modify
-fn modify<'_0, '_1, T>(self: &'_0 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global], arg: &'_1 T) -> T
+// Full name: test_crate::{impl Modifiable<T> for Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}::modify
+fn modify<'_0, '_1, T>(self: &'_0 mut Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global], arg: &'_1 T) -> T
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
@@ -126,13 +148,13 @@ where
     TypeOutlives0: T: '_1,
 {
     let _0: T; // return
-    let self: &'1 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // arg #1
+    let self: &'1 mut Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // arg #1
     let arg: &'3 T; // arg #2
     let _3: (i32, bool); // anonymous local
     let _4: &'4 T; // anonymous local
-    let _5: alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
-    let _6: alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
-    let _7: alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
+    let _5: Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
+    let _6: Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
+    let _7: Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
@@ -142,10 +164,10 @@ where
     _5 = copy (*self)
     _3 = copy (*_5) checked.+ const 1i32
     _6 = copy (*self)
-    assert(move _3.1 == false) (overflow) else panic
+    assert(move _3._1 == false) (overflow) else panic
     ↳⚡ unwind_continue
     _7 = copy (*self)
-    (*_7) = move _3.0
+    (*_7) = move _3._0
     storage_live(_4)
     _4 = &(*arg)
     _0 = TraitClause1::clone<'5>(move _4)
@@ -166,7 +188,7 @@ where
     return
 }
 
-// Full name: test_crate::{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}::modify::{vtable_method}
+// Full name: test_crate::{impl Modifiable<T> for Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}::modify::{vtable_method}
 fn {vtable_method}<'_0, '_1, T>(_1: &'_0 mut (dyn Modifiable<T>), _2: &'_1 T) -> T
 where
     TraitClause0: (T: Sized),
@@ -178,11 +200,11 @@ where
     let _0: T; // return
     let _1: &'_0 mut (dyn Modifiable<T> + '0); // arg #1
     let _2: &'_1 T; // arg #2
-    let _3: &'_0 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
+    let _3: &'_0 mut Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
-    _3 = concretize<&'_0 mut (dyn Modifiable<T> + '1), &'_0 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]>(move _1)
+    _3 = concretize<&'_0 mut (dyn Modifiable<T> + '1), &'_0 mut Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]>(move _1)
     _0 = modify<'_0, '_1, T>[TraitClause0, TraitClause1, TraitClause2](move _3, move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
@@ -194,7 +216,7 @@ where
     return
 }
 
-// Full name: test_crate::{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}::{vtable_drop_shim}
+// Full name: test_crate::{impl Modifiable<T> for Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}::{vtable_drop_shim}
 unsafe fn {vtable_drop_shim}<'_0, T>(dyn_self: &'_0 mut (dyn Modifiable<T>))
 where
     TraitClause0: (T: Sized),
@@ -204,12 +226,12 @@ where
 {
     let ret: (); // return
     let dyn_self: &'_0 mut (dyn Modifiable<T> + '0); // arg #1
-    let target_self: &'_0 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
+    let target_self: &'_0 mut Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // local
 
     storage_live(ret)
     ret = ()
     storage_live(target_self)
-    target_self = concretize<&'_0 mut (dyn Modifiable<T> + '1), &'_0 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]>(move dyn_self)
+    target_self = concretize<&'_0 mut (dyn Modifiable<T> + '1), &'_0 mut Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]>(move dyn_self)
     drop[impl_Destruct_for_Box::drop_glue<'3, i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]] (*target_self)
     ↳⚡ storage_dead(target_self)
         storage_dead(dyn_self)
@@ -219,7 +241,7 @@ where
     return
 }
 
-// Full name: test_crate::{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}::{vtable}
+// Full name: test_crate::{impl Modifiable<T> for Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}::{vtable}
 fn impl_Modifiable_for_Box_i32_Global::{vtable}<T>() -> test_crate::Modifiable::{vtable}<T>
 where
     TraitClause0: (T: Sized),
@@ -235,20 +257,20 @@ where
 
     storage_live(ret)
     storage_live(size)
-    size = size_of<alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]>
+    size = size_of<Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]>
     storage_live(align)
-    align = align_of<alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]>
+    align = align_of<Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]>
     storage_live(_3)
     _3 = cast<for<'_0_1> {vtable_drop_shim}<'0, T>[TraitClause0, TraitClause1, TraitClause2], unsafe fn<'_0_1>(&'_0_1 mut (dyn Modifiable<T> + '1))>(const {vtable_drop_shim}<'0, T>[TraitClause0, TraitClause1, TraitClause2])
     storage_live(_4)
     _4 = cast<for<'_0_1, '_1_1> {vtable_method}<'2, '3, T>[TraitClause0, TraitClause1, TraitClause2], fn<'_0_1, '_1_1>(&'_0_1 mut (dyn Modifiable<T> + '4), &'_1_1 T) -> T>(const {vtable_method}<'2, '3, T>[TraitClause0, TraitClause1, TraitClause2])
     storage_live(_5)
-    _5 = &core::marker::MetaSized::{vtable}<alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]>
+    _5 = &core::marker::MetaSized::{vtable}<Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]>
     ret = test_crate::Modifiable::{vtable} { size: move size, align: move align, drop: move _3, method_modify: move _4, super_trait_0: move _5 }
     return
 }
 
-// Full name: test_crate::{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}::{vtable}
+// Full name: test_crate::{impl Modifiable<T> for Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}::{vtable}
 static impl_Modifiable_for_Box_i32_Global::{vtable}<T>: test_crate::Modifiable::{vtable}<T>
 where
     TraitClause0: (T: Sized),
@@ -256,16 +278,16 @@ where
     TraitClause2: (T: Destruct),
  = impl_Modifiable_for_Box_i32_Global::{vtable}<T>[TraitClause0, TraitClause1, TraitClause2]()
 
-// Full name: test_crate::{impl Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}
-impl<T> "impl_Modifiable_for_Box_i32_Global" Modifiable<T> for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]
+// Full name: test_crate::{impl Modifiable<T> for Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}
+impl<T> "impl_Modifiable_for_Box_i32_Global" Modifiable<T> for Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
     TraitClause2: (T: Destruct),
 {
-    proof ImpliedClause0: (alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]: MetaSized) = {built_in impl MetaSized for alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}
+    proof ImpliedClause0: (Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]: MetaSized) = {built_in impl MetaSized for Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]}
     proof ImpliedClause1: (T: Sized) = TraitClause0
-    proof ImpliedClause2: (alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]: Destruct) = impl_Destruct_for_Box<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]
+    proof ImpliedClause2: (Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]: Destruct) = impl_Destruct_for_Box<i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]
     proof ImpliedClause3: (T: Destruct) = TraitClause2
     fn modify<'_0_1, '_1_1> = modify<'_0_1, '_1_1, T>[TraitClause0, TraitClause1, TraitClause2]
     vtable: impl_Modifiable_for_Box_i32_Global::{vtable}<T>[TraitClause0, TraitClause1, TraitClause2]
@@ -282,9 +304,9 @@ where
     let _0: T; // return
     let arg: &'1 T; // arg #1
     let x: &'5 mut (dyn Modifiable<T> + '6); // local
-    let _3: &'8 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
-    let _4: &'9 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
-    let _5: alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
+    let _3: &'8 mut Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
+    let _4: &'9 mut Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
+    let _5: Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global]; // anonymous local
     let _6: &'10 mut (dyn Modifiable<T> + '11); // anonymous local
     let _7: &'12 T; // anonymous local
 
@@ -298,7 +320,7 @@ where
         unwind_continue
     _4 = &mut _5
     _3 = &mut (*_4)
-    x = unsize_cast<&'8 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global], &'13 mut (dyn Modifiable<T> + '14), &impl_Modifiable_for_Box_i32_Global::{vtable}<T>[TraitClause0, TraitClause1, TraitClause2]>(move _3)
+    x = unsize_cast<&'8 mut Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}, {built_in impl Destruct for i32}, impl_Destruct_for_Global], &'13 mut (dyn Modifiable<T> + '14), &impl_Modifiable_for_Box_i32_Global::{vtable}<T>[TraitClause0, TraitClause1, TraitClause2]>(move _3)
     storage_dead(_3)
     storage_dead(_4)
     storage_live(_6)

--- a/charon/tests/ui/dyn/vtables.out
+++ b/charon/tests/ui/dyn/vtables.out
@@ -64,6 +64,8 @@ pub enum AssertKind {
 #[lang_item(String)]
 pub opaque type String
 
+struct () {}
+
 // Full name: alloc::string::String::{impl Destruct for String}::drop_glue
 unsafe fn drop_glue<'_0>(_1: &'_0 mut String)
 = <opaque>
@@ -90,6 +92,18 @@ where
     TraitClause1: (T: Display),
     TypeOutlives0: T: '_0,
 = <opaque>
+
+struct str {
+  _0: [u8],
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
 
 struct test_crate::Super::{vtable}<T> {
   size: usize,
@@ -1241,100 +1255,100 @@ fn main()
     let _15: String; // anonymous local
     let _16: &'23 str; // anonymous local
     let _17: &'24 str; // anonymous local
-    let _18: (&'27 i32, &'28 i32); // anonymous local
-    let _19: &'29 i32; // anonymous local
+    let _18: (&'32 i32, &'33 i32); // anonymous local
+    let _19: &'37 i32; // anonymous local
     let _20: i32; // anonymous local
-    let _21: &'30 mut (dyn Modifiable<i32> + '31); // anonymous local
-    let _22: &'32 i32; // anonymous local
-    let _23: &'33 mut i32; // anonymous local
+    let _21: &'38 mut (dyn Modifiable<i32> + '39); // anonymous local
+    let _22: &'40 i32; // anonymous local
+    let _23: &'41 mut i32; // anonymous local
     let _24: i32; // anonymous local
-    let _25: &'34 i32; // anonymous local
-    let left_val_26: &'35 i32; // local
-    let right_val_27: &'36 i32; // local
+    let _25: &'42 i32; // anonymous local
+    let left_val_26: &'43 i32; // local
+    let right_val_27: &'44 i32; // local
     let _28: bool; // anonymous local
     let _29: i32; // anonymous local
     let _30: i32; // anonymous local
     let kind_31: AssertKind; // local
     let _32: AssertKind; // anonymous local
-    let _33: &'37 i32; // anonymous local
-    let _34: &'38 i32; // anonymous local
-    let _35: &'39 i32; // anonymous local
-    let _36: &'40 i32; // anonymous local
-    let _37: Option<Arguments<'48>>[{built_in impl Sized for Arguments<'48>}]; // anonymous local
-    let z: &'55 (dyn NoParam + '56); // local
-    let _39: &'57 (dyn NoParam + '58); // anonymous local
-    let _40: &'59 (dyn NoParam + '60); // anonymous local
-    let _41: &'61 i32; // anonymous local
-    let _42: &'62 i32; // anonymous local
+    let _33: &'45 i32; // anonymous local
+    let _34: &'46 i32; // anonymous local
+    let _35: &'47 i32; // anonymous local
+    let _36: &'48 i32; // anonymous local
+    let _37: Option<Arguments<'56>>[{built_in impl Sized for Arguments<'56>}]; // anonymous local
+    let z: &'63 (dyn NoParam + '64); // local
+    let _39: &'65 (dyn NoParam + '66); // anonymous local
+    let _40: &'67 (dyn NoParam + '68); // anonymous local
+    let _41: &'69 i32; // anonymous local
+    let _42: &'70 i32; // anonymous local
     let _43: (); // anonymous local
-    let _44: &'63 (dyn NoParam + '64); // anonymous local
-    let a: &'68 (dyn Both32And64 + '69); // local
-    let _46: &'70 i32; // anonymous local
-    let _47: &'71 i32; // anonymous local
+    let _44: &'71 (dyn NoParam + '72); // anonymous local
+    let a: &'76 (dyn Both32And64 + '77); // local
+    let _46: &'78 i32; // anonymous local
+    let _47: &'79 i32; // anonymous local
     let _48: (); // anonymous local
-    let _49: &'72 (dyn Both32And64 + '73); // anonymous local
-    let _50: &'74 i32; // anonymous local
-    let _51: &'75 i32; // anonymous local
-    let _52: &'77 i64; // anonymous local
-    let _53: &'78 i64; // anonymous local
-    let b: &'82 (dyn LifetimeTrait<Ty = i32> + '83); // local
-    let _55: &'84 i32; // anonymous local
-    let _56: &'85 i32; // anonymous local
-    let _57: (&'86 i32, &'87 i32); // anonymous local
-    let _58: &'88 i32; // anonymous local
-    let _59: &'89 i32; // anonymous local
-    let _60: &'90 (dyn LifetimeTrait<Ty = i32> + '91); // anonymous local
-    let _61: &'92 (dyn LifetimeTrait<Ty = i32> + '93); // anonymous local
-    let _62: &'94 i32; // anonymous local
-    let _63: &'95 i32; // anonymous local
-    let _64: &'96 i32; // anonymous local
-    let left_val_65: &'97 i32; // local
-    let right_val_66: &'98 i32; // local
+    let _49: &'80 (dyn Both32And64 + '81); // anonymous local
+    let _50: &'82 i32; // anonymous local
+    let _51: &'83 i32; // anonymous local
+    let _52: &'85 i64; // anonymous local
+    let _53: &'86 i64; // anonymous local
+    let b: &'90 (dyn LifetimeTrait<Ty = i32> + '91); // local
+    let _55: &'92 i32; // anonymous local
+    let _56: &'93 i32; // anonymous local
+    let _57: (&'94 i32, &'95 i32); // anonymous local
+    let _58: &'99 i32; // anonymous local
+    let _59: &'100 i32; // anonymous local
+    let _60: &'101 (dyn LifetimeTrait<Ty = i32> + '102); // anonymous local
+    let _61: &'103 (dyn LifetimeTrait<Ty = i32> + '104); // anonymous local
+    let _62: &'105 i32; // anonymous local
+    let _63: &'106 i32; // anonymous local
+    let _64: &'107 i32; // anonymous local
+    let left_val_65: &'108 i32; // local
+    let right_val_66: &'109 i32; // local
     let _67: bool; // anonymous local
     let _68: i32; // anonymous local
     let _69: i32; // anonymous local
     let kind_70: AssertKind; // local
     let _71: AssertKind; // anonymous local
-    let _72: &'99 i32; // anonymous local
-    let _73: &'100 i32; // anonymous local
-    let _74: &'101 i32; // anonymous local
-    let _75: &'102 i32; // anonymous local
-    let _76: Option<Arguments<'103>>[{built_in impl Sized for Arguments<'103>}]; // anonymous local
-    let _77: &'107 i32; // anonymous local
-    let _78: &'108 i32; // anonymous local
-    let _79: &'109 i32; // anonymous local
-    let _80: &'110 i64; // anonymous local
-    let _81: &'111 i32; // anonymous local
-    let _82: &'112 i32; // anonymous local
-    let _83: &'113 i32; // anonymous local
-    let _84: &'114 i32; // anonymous local
-    let _85: &'115 i32; // anonymous local
-    let _86: &'116 i32; // anonymous local
-    let _87: &'147 i32; // anonymous local
-    let _88: &'150 i32; // anonymous local
-    let _89: &'168 i32; // anonymous local
-    let _90: &'174 i32; // anonymous local
-    let _91: &'175 i64; // anonymous local
-    let _92: &'181 i32; // anonymous local
-    let _93: &'189 i32; // anonymous local
-    let _94: &'194 i32; // anonymous local
-    let _95: &'203 i32; // anonymous local
+    let _72: &'110 i32; // anonymous local
+    let _73: &'111 i32; // anonymous local
+    let _74: &'112 i32; // anonymous local
+    let _75: &'113 i32; // anonymous local
+    let _76: Option<Arguments<'114>>[{built_in impl Sized for Arguments<'114>}]; // anonymous local
+    let _77: &'118 i32; // anonymous local
+    let _78: &'119 i32; // anonymous local
+    let _79: &'120 i32; // anonymous local
+    let _80: &'121 i64; // anonymous local
+    let _81: &'122 i32; // anonymous local
+    let _82: &'123 i32; // anonymous local
+    let _83: &'124 i32; // anonymous local
+    let _84: &'125 i32; // anonymous local
+    let _85: &'126 i32; // anonymous local
+    let _86: &'127 i32; // anonymous local
+    let _87: &'158 i32; // anonymous local
+    let _88: &'166 i32; // anonymous local
+    let _89: &'184 i32; // anonymous local
+    let _90: &'190 i32; // anonymous local
+    let _91: &'191 i64; // anonymous local
+    let _92: &'197 i32; // anonymous local
+    let _93: &'205 i32; // anonymous local
+    let _94: &'210 i32; // anonymous local
+    let _95: &'224 i32; // anonymous local
     let _96: i32; // anonymous local
-    let _97: &'204 i32; // anonymous local
+    let _97: &'225 i32; // anonymous local
     let _98: i32; // anonymous local
-    let _99: &'205 i32; // anonymous local
+    let _99: &'226 i32; // anonymous local
     let _100: i32; // anonymous local
-    let _101: &'206 i32; // anonymous local
+    let _101: &'227 i32; // anonymous local
     let _102: i32; // anonymous local
-    let _103: &'207 i32; // anonymous local
+    let _103: &'228 i32; // anonymous local
     let _104: i32; // anonymous local
-    let _105: &'208 i64; // anonymous local
+    let _105: &'229 i64; // anonymous local
     let _106: i64; // anonymous local
-    let _107: &'209 i32; // anonymous local
+    let _107: &'230 i32; // anonymous local
     let _108: i32; // anonymous local
-    let _109: &'210 i32; // anonymous local
+    let _109: &'231 i32; // anonymous local
     let _110: i32; // anonymous local
-    let _111: &'211 i32; // anonymous local
+    let _111: &'232 i32; // anonymous local
     let _112: i32; // anonymous local
 
     storage_live(_86)
@@ -1360,10 +1374,10 @@ fn main()
     _85 = move _86
     _3 = &(*_85)
     _2 = &(*_3)
-    x = unsize_cast<&'6 i32, &'117 (dyn Checkable<i32> + '118), &impl_Checkable_i32_for_i32::{vtable}>(move _2)
+    x = unsize_cast<&'6 i32, &'128 (dyn Checkable<i32> + '129), &impl_Checkable_i32_for_i32::{vtable}>(move _2)
     storage_dead(_2)
     fake_read(x)
-    set_type(typeof(x) == &'119 (dyn Checkable<i32> + '120))
+    set_type(typeof(x) == &'130 (dyn Checkable<i32> + '131))
     storage_dead(_3)
     storage_live(_4)
     storage_live(_5)
@@ -1404,10 +1418,10 @@ fn main()
     _9 = const 99i32
     _8 = &mut _9
     _7 = &mut (*_8)
-    y = unsize_cast<&'16 mut i32, &'125 mut (dyn Modifiable<i32> + '126), &impl_Modifiable_for_i32::{vtable}<i32>[{built_in impl Sized for i32}, impl_Clone_for_i32]>(move _7)
+    y = unsize_cast<&'16 mut i32, &'136 mut (dyn Modifiable<i32> + '137), &impl_Modifiable_for_i32::{vtable}<i32>[{built_in impl Sized for i32}, impl_Clone_for_i32]>(move _7)
     storage_dead(_7)
     fake_read(y)
-    set_type(typeof(y) == &'127 mut (dyn Modifiable<i32> + '128))
+    set_type(typeof(y) == &'138 mut (dyn Modifiable<i32> + '139))
     storage_dead(_8)
     storage_live(_10)
     storage_live(_11)
@@ -1419,7 +1433,7 @@ fn main()
     storage_live(_17)
     _17 = const "Hello"
     _16 = &(*_17) with_metadata(copy _17.metadata)
-    _15 = to_string<'131, str>[{built_in impl MetaSized for str}, {impl#10}](move _16)
+    _15 = to_string<'142, str>[{built_in impl MetaSized for str}, {impl#10}](move _16)
     ↳⚡ storage_dead(_85)
         storage_dead(_84)
         storage_dead(_83)
@@ -1447,8 +1461,8 @@ fn main()
     storage_dead(_16)
     _14 = &_15
     _13 = &(*_14)
-    _12 = modify_trait_object<'133, String>[{built_in impl Sized for String}, impl_Clone_for_String](move _13)
-    ↳⚡ conditional_drop[drop_glue<'134>] _15
+    _12 = modify_trait_object<'144, String>[{built_in impl Sized for String}, impl_Clone_for_String](move _13)
+    ↳⚡ conditional_drop[drop_glue<'145>] _15
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -1526,8 +1540,8 @@ fn main()
         unwind_continue
     _11 = &_12
     storage_dead(_13)
-    _10 = is_empty<'136>(move _11)
-    ↳⚡ conditional_drop[drop_glue<'137>] _12
+    _10 = is_empty<'147>(move _11)
+    ↳⚡ conditional_drop[drop_glue<'148>] _12
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -1579,7 +1593,7 @@ fn main()
             storage_dead(_87)
             storage_dead(_86)
             unwind_terminate
-        conditional_drop[drop_glue<'134>] _15
+        conditional_drop[drop_glue<'145>] _15
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -1658,8 +1672,8 @@ fn main()
     if move _10 {
     } else {
         storage_dead(_11)
-        conditional_drop[drop_glue<'139>] _12
-        ↳⚡ conditional_drop[drop_glue<'134>] _15
+        conditional_drop[drop_glue<'150>] _12
+        ↳⚡ conditional_drop[drop_glue<'145>] _15
             ↳⚡ storage_dead(_85)
                 storage_dead(_84)
                 storage_dead(_83)
@@ -1735,7 +1749,7 @@ fn main()
             storage_dead(_32)
             storage_dead(kind_31)
             unwind_continue
-        conditional_drop[drop_glue<'141>] _15
+        conditional_drop[drop_glue<'152>] _15
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -1817,9 +1831,9 @@ fn main()
         storage_dead(_25)
         storage_dead(_19)
         storage_live(left_val_26)
-        left_val_26 = copy _18.0
+        left_val_26 = copy _18._0
         storage_live(right_val_27)
-        right_val_27 = copy _18.1
+        right_val_27 = copy _18._1
         storage_live(_28)
         storage_live(_29)
         _29 = copy (*left_val_26)
@@ -1920,7 +1934,7 @@ fn main()
         _83 = move _88
         _42 = &(*_83)
         _41 = &(*_42)
-        _40 = to_dyn_obj<'152, i32>[{built_in impl Sized for i32}, impl_NoParam_for_i32](move _41)
+        _40 = to_dyn_obj<'168, i32>[{built_in impl Sized for i32}, impl_NoParam_for_i32](move _41)
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -1946,11 +1960,11 @@ fn main()
             storage_dead(kind_31)
             unwind_continue
         _39 = &(*_40) with_metadata(copy _40.metadata)
-        z = unsize_cast<&'57 (dyn NoParam + '58), &'160 (dyn NoParam + '161),  at []>(move _39)
+        z = unsize_cast<&'65 (dyn NoParam + '66), &'176 (dyn NoParam + '177),  at []>(move _39)
         storage_dead(_41)
         storage_dead(_39)
         fake_read(z)
-        set_type(typeof(z) == &'162 (dyn NoParam + '163))
+        set_type(typeof(z) == &'178 (dyn NoParam + '179))
         storage_dead(_42)
         storage_dead(_40)
         storage_live(_43)
@@ -2007,10 +2021,10 @@ fn main()
         _82 = move _89
         _47 = &(*_82)
         _46 = &(*_47)
-        a = unsize_cast<&'70 i32, &'169 (dyn Both32And64 + '170), &impl_Both32And64_for_i32::{vtable}>(move _46)
+        a = unsize_cast<&'78 i32, &'185 (dyn Both32And64 + '186), &impl_Both32And64_for_i32::{vtable}>(move _46)
         storage_dead(_46)
         fake_read(a)
-        set_type(typeof(a) == &'171 (dyn Both32And64 + '172))
+        set_type(typeof(a) == &'187 (dyn Both32And64 + '188))
         storage_dead(_47)
         storage_live(_48)
         storage_live(_49)
@@ -2074,10 +2088,10 @@ fn main()
         _79 = move _92
         _56 = &(*_79)
         _55 = &(*_56)
-        b = unsize_cast<&'84 i32, &'182 (dyn LifetimeTrait<Ty = i32> + '183), &impl_LifetimeTrait_for_i32::{vtable}>(move _55)
+        b = unsize_cast<&'92 i32, &'198 (dyn LifetimeTrait<Ty = i32> + '199), &impl_LifetimeTrait_for_i32::{vtable}>(move _55)
         storage_dead(_55)
         fake_read(b)
-        set_type(typeof(b) == &'184 (dyn LifetimeTrait<Ty = i32> + '185))
+        set_type(typeof(b) == &'200 (dyn LifetimeTrait<Ty = i32> + '201))
         storage_dead(_56)
         storage_live(_57)
         storage_live(_58)
@@ -2085,14 +2099,14 @@ fn main()
         storage_live(_60)
         storage_live(_61)
         _61 = &(*b) with_metadata(copy b.metadata)
-        _60 = unsize_cast<&'92 (dyn LifetimeTrait<Ty = i32> + '93), &'187 (dyn LifetimeTrait<Ty = i32> + '188),  at []>(move _61)
+        _60 = unsize_cast<&'103 (dyn LifetimeTrait<Ty = i32> + '104), &'203 (dyn LifetimeTrait<Ty = i32> + '204),  at []>(move _61)
         storage_dead(_61)
         storage_live(_62)
         storage_live(_63)
         _78 = move _93
         _63 = &(*_78)
         _62 = &(*_63)
-        _59 = use_lifetime_trait<'192, '193>(move _60, move _62)
+        _59 = use_lifetime_trait<'208, '209>(move _60, move _62)
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -2133,9 +2147,9 @@ fn main()
         storage_dead(_64)
         storage_dead(_58)
         storage_live(left_val_65)
-        left_val_65 = copy _57.0
+        left_val_65 = copy _57._0
         storage_live(right_val_66)
-        right_val_66 = copy _57.1
+        right_val_66 = copy _57._1
         storage_live(_67)
         storage_live(_68)
         _68 = copy (*left_val_65)
@@ -2281,8 +2295,8 @@ fn main()
         return
     }
     storage_dead(_11)
-    conditional_drop[drop_glue<'138>] _12
-    ↳⚡ conditional_drop[drop_glue<'134>] _15
+    conditional_drop[drop_glue<'149>] _12
+    ↳⚡ conditional_drop[drop_glue<'145>] _15
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -2358,7 +2372,7 @@ fn main()
         storage_dead(_32)
         storage_dead(kind_31)
         unwind_continue
-    conditional_drop[drop_glue<'140>] _15
+    conditional_drop[drop_glue<'151>] _15
     ↳⚡ storage_dead(_85)
         storage_dead(_84)
         storage_dead(_83)

--- a/charon/tests/ui/explicit-drop-bounds.out
+++ b/charon/tests/ui/explicit-drop-bounds.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/external.out
+++ b/charon/tests/ui/external.out
@@ -73,6 +73,8 @@ impl "impl_Copy_for_u32" Copy for u32 {
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -208,6 +210,14 @@ where
     TypeOutlives0: T: '_0,
     TypeOutlives1: A: '_0,
 = <opaque>
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
 
 pub fn test_crate::swap<'a, T>(x: &'a mut T, y: &'a mut T)
 where

--- a/charon/tests/ui/filtering/inner-items.out
+++ b/charon/tests/ui/filtering/inner-items.out
@@ -5,6 +5,8 @@
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct () {}
+
 // Full name: test_crate::foo
 fn foo()
 {

--- a/charon/tests/ui/filtering/opacity.out
+++ b/charon/tests/ui/filtering/opacity.out
@@ -170,6 +170,8 @@ where
     return
 }
 
+struct () {}
+
 // Full name: test_crate::foo
 fn foo()
 {

--- a/charon/tests/ui/filtering/opaque-trait.out
+++ b/charon/tests/ui/filtering/opaque-trait.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Trait
 #[charon::opaque]
 trait Trait<Self>

--- a/charon/tests/ui/filtering/opaque_attribute.out
+++ b/charon/tests/ui/filtering/opaque_attribute.out
@@ -25,6 +25,8 @@ where
   Some { _0: T },
 }
 
+struct () {}
+
 // Full name: test_crate::BoolTrait
 #[charon::opaque]
 pub trait BoolTrait<Self>

--- a/charon/tests/ui/filtering/start-from-if-exists.out
+++ b/charon/tests/ui/filtering/start-from-if-exists.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::bar
 fn bar()
 {

--- a/charon/tests/ui/filtering/start_from.out
+++ b/charon/tests/ui/filtering/start_from.out
@@ -5,6 +5,8 @@
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct () {}
+
 fn test_crate::module1::do_translate()
 {
     let _0: (); // return

--- a/charon/tests/ui/filtering/start_from_attribute.out
+++ b/charon/tests/ui/filtering/start_from_attribute.out
@@ -5,6 +5,8 @@
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct () {}
+
 // Full name: test_crate::module2::do_translate
 #[verify::start_from]
 fn do_translate()

--- a/charon/tests/ui/filtering/start_from_errors.out
+++ b/charon/tests/ui/filtering/start_from_errors.out
@@ -1,28 +1,54 @@
 error: failed to parse pattern `std::iter:once` (error Eof at: :once)
 
 error: failed to resolve item path `start_from_errors::module1`: path `start_from_errors` does not correspond to any item; did you mean `crate::start_from_errors`?
+  --> tests/ui/filtering/start_from_errors.rs:28:3
+   |
+28 | }
+   |  ^
 
 error: failed to resolve item path `module2`: path `module2` does not correspond to any item; did you mean `crate::module2`?
+  --> tests/ui/filtering/start_from_errors.rs:28:3
+   |
+28 | }
+   |  ^
 
 error: Cannot register item `core::ops::deref::Deref::Target` with kind `AssocTy`
  --> /rustc/library/core/src/ops/deref.rs:144:5
 
 error: failed to resolve item path `{impl crate::Type}`: `--start-from` does not support inherent impls
- --> /rustc/library/core/src/ops/deref.rs:0:1
+  --> tests/ui/filtering/start_from_errors.rs:28:3
+   |
+28 | }
+   |  ^
 
 error: failed to resolve item path `{impl crate::Trait for &crate::Type}`: `--start-from` only supports implementations on named types
- --> /rustc/library/core/src/ops/deref.rs:0:1
+  --> tests/ui/filtering/start_from_errors.rs:28:3
+   |
+28 | }
+   |  ^
 
 error: failed to resolve item path `{impl crate::Trait for crate::MissingType}`: path `crate::MissingType` does not correspond to any item
- --> /rustc/library/core/src/ops/deref.rs:0:1
+  --> tests/ui/filtering/start_from_errors.rs:28:3
+   |
+28 | }
+   |  ^
 
 error: failed to resolve item path `{impl crate::Trait<_> for _}`: `--start-from` does not support trait generics
- --> /rustc/library/core/src/ops/deref.rs:0:1
+  --> tests/ui/filtering/start_from_errors.rs:28:3
+   |
+28 | }
+   |  ^
 
 error: failed to resolve item path `{impl crate::Trait for crate::Type}::missing_method`: path `{impl crate::Trait for crate::Type}::missing_method` does not correspond to any item
- --> /rustc/library/core/src/ops/deref.rs:0:1
+  --> tests/ui/filtering/start_from_errors.rs:28:3
+   |
+28 | }
+   |  ^
 
 error: failed to resolve item path `crate::{impl crate::Trait for crate::Type}`: `--start-from` only supports impl patterns if they're the first element of the path
- --> /rustc/library/core/src/ops/deref.rs:0:1
+  --> tests/ui/filtering/start_from_errors.rs:28:3
+   |
+28 | }
+   |  ^
 
 ERROR Code failed to compile

--- a/charon/tests/ui/filtering/start_from_pub.out
+++ b/charon/tests/ui/filtering/start_from_pub.out
@@ -5,9 +5,15 @@
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct () {}
+
 // Full name: std::io::stdio::_print
 pub fn _print<'_0>(_1: Arguments<'_0>)
 = <opaque>
+
+struct str {
+  _0: [u8],
+}
 
 pub fn test_crate::module1::do_translate()
 {

--- a/charon/tests/ui/foreign-type-alias.out
+++ b/charon/tests/ui/foreign-type-alias.out
@@ -113,6 +113,8 @@ where
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: type_alias::Usize
 pub type Usize = usize
 

--- a/charon/tests/ui/gosim-demo.out
+++ b/charon/tests/ui/gosim-demo.out
@@ -49,9 +49,23 @@ where
     TypeOutlives0: T: 'a,
 = <opaque>
 
+struct () {}
+
 // Full name: std::io::stdio::_eprint
 pub fn _eprint<'_0>(_1: Arguments<'_0>)
 = <opaque>
+
+struct (_,)<A> {
+  _0: A,
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
 
 // Full name: test_crate::debug_slice
 fn debug_slice<'_0, T>(slice: &'_0 [T])
@@ -81,7 +95,7 @@ where
     let _18: &'45 [Argument<'46>; 1usize]; // anonymous local
     let _19: &'47 [Argument<'48>; 1usize]; // anonymous local
     let _20: [u8; 7usize]; // anonymous local
-    let _21: &'76 [u8; 7usize]; // anonymous local
+    let _21: &'78 [u8; 7usize]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -124,8 +138,8 @@ where
         storage_live(args_13)
         storage_live(_14)
         storage_live(_15)
-        _15 = &(*args_11.0)
-        _14 = new_debug<'62, '74, &'64 T>[{built_in impl Sized for &'66 T}, {impl#2}<'72, T>[TraitClause1]](move _15)
+        _15 = &(*args_11._0)
+        _14 = new_debug<'64, '76, &'66 T>[{built_in impl Sized for &'68 T}, {impl#2}<'74, T>[TraitClause1]](move _15)
         ↳⚡ storage_dead(slice)
             unwind_continue
         storage_dead(_15)
@@ -144,14 +158,14 @@ where
         storage_live(_19)
         _19 = &args_13
         _18 = &(*_19)
-        _10 = new<'78, 7usize, 1usize>(move _16, move _18)
+        _10 = new<'80, 7usize, 1usize>(move _16, move _18)
         ↳⚡ storage_dead(slice)
             unwind_continue
         storage_dead(_19)
         storage_dead(_18)
         storage_dead(_17)
         storage_dead(_16)
-        _9 = _eprint<'80>(move _10)
+        _9 = _eprint<'82>(move _10)
         ↳⚡ storage_dead(slice)
             unwind_continue
         storage_dead(_10)

--- a/charon/tests/ui/hide-marker-traits.out
+++ b/charon/tests/ui/hide-marker-traits.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/impl-trait.out
+++ b/charon/tests/ui/impl-trait.out
@@ -53,6 +53,8 @@ where
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -82,6 +84,10 @@ pub trait FnOnce<Self, Args>
     type Output
     fn call_once;
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
+}
+
+struct (_,)<A> {
+  _0: A,
 }
 
 // Full name: test_crate::Foo
@@ -316,7 +322,7 @@ where
 
     storage_live(_0)
     storage_live(x)
-    x = move tupled_args.0
+    x = move tupled_args._0
     storage_live(_4)
     _4 = &(*x)
     _0 = WrapClone { _0: move _4 }
@@ -377,7 +383,7 @@ pub fn use_wrap()
     let _6: &'19 u32; // anonymous local
     let _7: &'20 u32; // anonymous local
     let _8: &'21 u32; // anonymous local
-    let _9: &'35 u32; // anonymous local
+    let _9: &'36 u32; // anonymous local
     let _10: u32; // anonymous local
 
     storage_live(_0)
@@ -404,14 +410,14 @@ pub fn use_wrap()
     _6 = &(*_7)
     _5 = &(*_6)
     _4 = (move _5,)
-    _2 = call_once<'25, u32>[{built_in impl Sized for u32}](move _3, move _4)
-    ↳⚡ conditional_drop[drop_glue<'26, u32>[{built_in impl Sized for u32}]] _3
+    _2 = call_once<'26, u32>[{built_in impl Sized for u32}](move _3, move _4)
+    ↳⚡ conditional_drop[drop_glue<'27, u32>[{built_in impl Sized for u32}]] _3
         ↳⚡ storage_dead(_7)
             storage_dead(_10)
             storage_dead(_9)
             storage_dead(_8)
             unwind_terminate
-        conditional_drop[drop_glue<'34, u32>[{built_in impl Sized for u32}]] f
+        conditional_drop[drop_glue<'35, u32>[{built_in impl Sized for u32}]] f
         ↳⚡ storage_dead(_7)
             storage_dead(_10)
             storage_dead(_9)
@@ -422,11 +428,11 @@ pub fn use_wrap()
     storage_dead(_5)
     storage_dead(_4)
     storage_dead(_3)
-    set_type(typeof(_2) <= WrapClone<&'27 u32>[{built_in impl Sized for &'27 u32}, {impl Clone for &'_0 T}<'27, u32>])
+    set_type(typeof(_2) <= WrapClone<&'28 u32>[{built_in impl Sized for &'28 u32}, {impl Clone for &'_0 T}<'28, u32>])
     storage_dead(_6)
     storage_dead(_2)
     _0 = ()
-    conditional_drop[drop_glue<'33, u32>[{built_in impl Sized for u32}]] f
+    conditional_drop[drop_glue<'34, u32>[{built_in impl Sized for u32}]] f
     ↳⚡ storage_dead(_7)
         unwind_continue
     storage_dead(f)

--- a/charon/tests/ui/issue-1041-shift-through-index-mut.out
+++ b/charon/tests/ui/issue-1041-shift-through-index-mut.out
@@ -30,6 +30,8 @@ pub trait IndexMut<Self, Idx>
     vtable: core::ops::index::IndexMut::{vtable}<Idx, Self::ImpliedClause1::Output>
 }
 
+struct () {}
+
 // Full name: test_crate::Wrap
 pub struct Wrap {
   _0: [u64; 2usize],

--- a/charon/tests/ui/issue-114-opaque-bodies.out
+++ b/charon/tests/ui/issue-114-opaque-bodies.out
@@ -25,6 +25,8 @@ where
   Some { _0: T },
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -372,6 +374,14 @@ where
     storage_live(_0)
     _0 = const 42u32
     return
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
 }
 
 // Full name: test_crate::use_inlines

--- a/charon/tests/ui/issue-118-generic-copy.out
+++ b/charon/tests/ui/issue-118-generic-copy.out
@@ -43,6 +43,8 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Foo
 struct Foo {}
 

--- a/charon/tests/ui/issue-120-bare-discriminant-read.out
+++ b/charon/tests/ui/issue-120-bare-discriminant-read.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/issue-165-vec-macro.out
+++ b/charon/tests/ui/issue-165-vec-macro.out
@@ -45,8 +45,18 @@ where
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+struct () {}
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -54,10 +64,10 @@ where
     TypeOutlives1: A: '_0,
 = <opaque>
 
-// Full name: alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
+// Full name: alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
 #[track_caller]
 #[diagnostic_item("box_new")]
-pub fn new<T>(_1: T) -> alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+pub fn new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
 where
     TraitClause0: (T: Sized),
 = <opaque>
@@ -70,7 +80,7 @@ where
     TraitClause1: (type_error("removed allocator parameter"): Sized),
 
 // Full name: alloc::slice::{[T]}::into_vec
-pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
+pub fn into_vec<T, A>(_1: Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (A: Sized),
@@ -98,13 +108,13 @@ fn foo()
 {
     let _0: (); // return
     let _v: Vec<i32>[{built_in impl Sized for i32}, {built_in impl Sized for Global}]; // local
-    let _2: alloc::boxed::Box<MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _2: Box<MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let _v2: Vec<i32>[{built_in impl Sized for i32}, {built_in impl Sized for Global}]; // local
     let ret: Vec<i32>[{built_in impl Sized for i32}, {built_in impl Sized for Global}]; // local
-    let x: alloc::boxed::Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}]; // local
-    let y: alloc::boxed::Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]; // local
+    let x: Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}]; // local
+    let y: Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]; // local
     let _7: [i32; 1usize]; // anonymous local
-    let _8: alloc::boxed::Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _8: Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -124,7 +134,7 @@ fn foo()
     storage_dead(_7)
     x = move _8
     storage_dead(_8)
-    y = unsize_cast<alloc::boxed::Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 1usize>(move x)
+    y = unsize_cast<Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}], Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 1usize>(move x)
     ret = into_vec<i32, Global>[{built_in impl Sized for i32}, {built_in impl Sized for Global}](move y)
     ↳⚡ storage_dead(y)
         storage_dead(x)
@@ -166,13 +176,13 @@ pub fn bar()
 {
     let _0: (); // return
     let _1: Vec<Foo>[{built_in impl Sized for Foo}, {built_in impl Sized for Global}]; // anonymous local
-    let _2: alloc::boxed::Box<MaybeUninit<[Foo; 1usize]>[{built_in impl Sized for [Foo; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[Foo; 1usize]>[{built_in impl Sized for [Foo; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _2: Box<MaybeUninit<[Foo; 1usize]>[{built_in impl Sized for [Foo; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[Foo; 1usize]>[{built_in impl Sized for [Foo; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let _3: Foo; // anonymous local
     let ret: Vec<Foo>[{built_in impl Sized for Foo}, {built_in impl Sized for Global}]; // local
-    let x: alloc::boxed::Box<[Foo; 1usize]>[{built_in impl MetaSized for [Foo; 1usize]}, {built_in impl Sized for Global}]; // local
-    let y: alloc::boxed::Box<[Foo]>[{built_in impl MetaSized for [Foo]}, {built_in impl Sized for Global}]; // local
+    let x: Box<[Foo; 1usize]>[{built_in impl MetaSized for [Foo; 1usize]}, {built_in impl Sized for Global}]; // local
+    let y: Box<[Foo]>[{built_in impl MetaSized for [Foo]}, {built_in impl Sized for Global}]; // local
     let _7: [Foo; 1usize]; // anonymous local
-    let _8: alloc::boxed::Box<[Foo; 1usize]>[{built_in impl MetaSized for [Foo; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _8: Box<[Foo; 1usize]>[{built_in impl MetaSized for [Foo; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -195,7 +205,7 @@ pub fn bar()
     storage_dead(_7)
     x = move _8
     storage_dead(_8)
-    y = unsize_cast<alloc::boxed::Box<[Foo; 1usize]>[{built_in impl MetaSized for [Foo; 1usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[Foo]>[{built_in impl MetaSized for [Foo]}, {built_in impl Sized for Global}], 1usize>(move x)
+    y = unsize_cast<Box<[Foo; 1usize]>[{built_in impl MetaSized for [Foo; 1usize]}, {built_in impl Sized for Global}], Box<[Foo]>[{built_in impl MetaSized for [Foo]}, {built_in impl Sized for Global}], 1usize>(move x)
     ret = into_vec<Foo, Global>[{built_in impl Sized for Foo}, {built_in impl Sized for Global}](move y)
     ↳⚡ storage_dead(y)
         storage_dead(x)

--- a/charon/tests/ui/issue-320-slice-pattern.out
+++ b/charon/tests/ui/issue-320-slice-pattern.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::slice_pat1
 fn slice_pat1()
 {

--- a/charon/tests/ui/issue-322-macro-disambiguator.out
+++ b/charon/tests/ui/issue-322-macro-disambiguator.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 struct test_crate::main::AssertIsAsBytes {}
 
 struct test_crate::main::AssertIsAsBytes#1 {}

--- a/charon/tests/ui/issue-323-closure-borrow.out
+++ b/charon/tests/ui/issue-323-closure-borrow.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/issue-369-mismatched-genericparams.out
+++ b/charon/tests/ui/issue-369-mismatched-genericparams.out
@@ -25,6 +25,8 @@ where
   Some { _0: T },
 }
 
+struct () {}
+
 // Full name: test_crate::FromResidual
 pub trait FromResidual<Self, R>
 {

--- a/charon/tests/ui/issue-372-type-param-out-of-range.out
+++ b/charon/tests/ui/issue-372-type-param-out-of-range.out
@@ -50,6 +50,12 @@ pub trait FnMut<Self, Args>
     vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
+struct () {}
+
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: test_crate::S
 pub struct S<'a, K>
 where

--- a/charon/tests/ui/issue-378-ctor-as-fn.out
+++ b/charon/tests/ui/issue-378-ctor-as-fn.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/issue-394-rpit-with-lifetime.out
+++ b/charon/tests/ui/issue-394-rpit-with-lifetime.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: core::marker::MetaSized
 #[fundamental]
 #[lang_item(MetaSized)]

--- a/charon/tests/ui/issue-395-failed-to-normalize.out
+++ b/charon/tests/ui/issue-395-failed-to-normalize.out
@@ -37,6 +37,20 @@ pub trait Iterator<Self>
     vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: test_crate::Trait
 pub trait Trait<Self>
 {

--- a/charon/tests/ui/issue-4-slice-try-into-array.out
+++ b/charon/tests/ui/issue-4-slice-try-into-array.out
@@ -123,6 +123,8 @@ where
     TraitClause2: (E: Debug),
 = <opaque>
 
+struct () {}
+
 // Full name: test_crate::trait_error
 pub fn trait_error<'_0>(s: &'_0 [u8])
 {

--- a/charon/tests/ui/issue-4-traits.out
+++ b/charon/tests/ui/issue-4-traits.out
@@ -123,6 +123,8 @@ where
     TraitClause2: (E: Debug),
 = <opaque>
 
+struct () {}
+
 // Full name: test_crate::trait_error
 fn trait_error<'_0>(s: &'_0 [u8])
 {

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -1,5 +1,9 @@
 # Final LLBC before serialization:
 
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: core::marker::MetaSized
 #[fundamental]
 #[lang_item(MetaSized)]
@@ -49,6 +53,8 @@ pub trait FnMut<Self, Args>
     fn call_mut<'_0_1>;
     vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
+
+struct () {}
 
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
@@ -148,6 +154,14 @@ impl "impl_PartialOrd_u8_for_u8" PartialOrd<u8> for u8 {
     proof ImpliedClause0: (u8: PartialEq<u8>) = impl_PartialEq_u8_for_u8
     fn partial_cmp<'_0_1, '_1_1> = impl_PartialOrd_u8_for_u8::partial_cmp<'_0_1, '_1_1>
     vtable: impl_PartialOrd_u8_for_u8::{vtable}
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
 }
 
 // Full name: core::iter::range::Step
@@ -293,7 +307,7 @@ fn call_mut<'_0>(_1: &'_0 mut closure, tupled_args: (i32,)) -> i32
 
     storage_live(_0)
     storage_live(v)
-    v = move tupled_args.0
+    v = move tupled_args._0
     _0 = copy v
     storage_dead(v)
     storage_dead(tupled_args)
@@ -469,25 +483,25 @@ fn select<'_0, '_1>(lhs: &'_0 [u8], rhs: &'_1 [u8])
     let lhs: &'1 [u8]; // arg #1
     let rhs: &'2 [u8]; // arg #2
     let _3: bool; // anonymous local
-    let _4: (&'6 usize, &'7 usize); // anonymous local
-    let _5: &'8 usize; // anonymous local
+    let _4: (&'11 usize, &'12 usize); // anonymous local
+    let _5: &'16 usize; // anonymous local
     let _6: usize; // anonymous local
-    let _7: &'9 [u8]; // anonymous local
-    let _8: &'10 usize; // anonymous local
+    let _7: &'17 [u8]; // anonymous local
+    let _8: &'18 usize; // anonymous local
     let _9: usize; // anonymous local
-    let _10: &'11 [u8]; // anonymous local
-    let left_val: &'12 usize; // local
-    let right_val: &'13 usize; // local
+    let _10: &'19 [u8]; // anonymous local
+    let left_val: &'20 usize; // local
+    let right_val: &'21 usize; // local
     let _13: bool; // anonymous local
     let _14: usize; // anonymous local
     let _15: usize; // anonymous local
     let kind: AssertKind; // local
     let _17: AssertKind; // anonymous local
-    let _18: &'14 usize; // anonymous local
-    let _19: &'15 usize; // anonymous local
-    let _20: &'16 usize; // anonymous local
-    let _21: &'17 usize; // anonymous local
-    let _22: Option<Arguments<'25>>[{built_in impl Sized for Arguments<'25>}]; // anonymous local
+    let _18: &'22 usize; // anonymous local
+    let _19: &'23 usize; // anonymous local
+    let _20: &'24 usize; // anonymous local
+    let _21: &'25 usize; // anonymous local
+    let _22: Option<Arguments<'33>>[{built_in impl Sized for Arguments<'33>}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -499,7 +513,7 @@ fn select<'_0, '_1>(lhs: &'_0 [u8], rhs: &'_1 [u8])
         storage_live(_6)
         storage_live(_7)
         _7 = &(*lhs) with_metadata(copy lhs.metadata)
-        _6 = core::slice::{[T]}::len<'30, u8>[{built_in impl Sized for u8}](move _7)
+        _6 = core::slice::{[T]}::len<'38, u8>[{built_in impl Sized for u8}](move _7)
         ↳⚡ storage_dead(_22)
             storage_dead(_21)
             storage_dead(_20)
@@ -516,7 +530,7 @@ fn select<'_0, '_1>(lhs: &'_0 [u8], rhs: &'_1 [u8])
         storage_live(_9)
         storage_live(_10)
         _10 = &(*rhs) with_metadata(copy rhs.metadata)
-        _9 = core::slice::{[T]}::len<'32, u8>[{built_in impl Sized for u8}](move _10)
+        _9 = core::slice::{[T]}::len<'40, u8>[{built_in impl Sized for u8}](move _10)
         ↳⚡ storage_dead(_22)
             storage_dead(_21)
             storage_dead(_20)
@@ -533,9 +547,9 @@ fn select<'_0, '_1>(lhs: &'_0 [u8], rhs: &'_1 [u8])
         storage_dead(_8)
         storage_dead(_5)
         storage_live(left_val)
-        left_val = copy _4.0
+        left_val = copy _4._0
         storage_live(right_val)
-        right_val = copy _4.1
+        right_val = copy _4._1
         storage_live(_13)
         storage_live(_14)
         _14 = copy (*left_val)

--- a/charon/tests/ui/issue-70-override-provided-method.2-nodup.out
+++ b/charon/tests/ui/issue-70-override-provided-method.2-nodup.out
@@ -5,6 +5,8 @@
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct () {}
+
 // Full name: test_crate::Trait
 trait Trait<Self>
 {

--- a/charon/tests/ui/issue-70-override-provided-method.2.out
+++ b/charon/tests/ui/issue-70-override-provided-method.2.out
@@ -5,6 +5,8 @@
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct () {}
+
 // Full name: test_crate::Trait
 trait Trait<Self>
 {

--- a/charon/tests/ui/issue-70-override-provided-method.3.out
+++ b/charon/tests/ui/issue-70-override-provided-method.3.out
@@ -43,6 +43,8 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/issue-70-override-provided-method.out
+++ b/charon/tests/ui/issue-70-override-provided-method.out
@@ -83,6 +83,8 @@ where
     TypeOutlives1: T: '_1,
 = <opaque>
 
+struct () {}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/issue-72-hash-missing-impl.out
+++ b/charon/tests/ui/issue-72-hash-missing-impl.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Hasher
 pub trait Hasher<Self>
 {

--- a/charon/tests/ui/issue-73-extern.out
+++ b/charon/tests/ui/issue-73-extern.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::foo
 unsafe extern "C" fn foo(_1: i32)
 = <extern:foo>

--- a/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
+++ b/charon/tests/ui/issue-91-enum-to-discriminant-cast.out
@@ -43,6 +43,8 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Foo
 enum Foo {
   A,

--- a/charon/tests/ui/issue-92-nonpositive-variant-indices.out
+++ b/charon/tests/ui/issue-92-nonpositive-variant-indices.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::Ordering
 enum Ordering {
   Less,

--- a/charon/tests/ui/issue-94-recursive-trait-defns.out
+++ b/charon/tests/ui/issue-94-recursive-trait-defns.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Trait1
 pub trait Trait1<Self>
 {

--- a/charon/tests/ui/issue-97-missing-parent-item-clause.out
+++ b/charon/tests/ui/issue-97-missing-parent-item-clause.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Ord
 pub trait Ord<Self>
 {

--- a/charon/tests/ui/iterator.out
+++ b/charon/tests/ui/iterator.out
@@ -20,6 +20,8 @@ pub opaque type IntoIter<T, const N : usize>
 where
     TraitClause0: (T: Sized),
 
+struct () {}
+
 // Full name: core::array::iter::IntoIter::{impl Destruct for IntoIter<T, N>[TraitClause0]}::drop_glue
 unsafe fn drop_glue<'_0, T, const N : usize>(_1: &'_0 mut IntoIter<T, N>[TraitClause0])
 where
@@ -32,6 +34,18 @@ pub fn impl_IntoIterator_for_array::into_iter<T, const N : usize>(_1: [T; N]) ->
 where
     TraitClause0: (T: Sized),
 = <opaque>
+
+struct (_,)<A> {
+  _0: A,
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
 
 // Full name: core::option::Option
 #[lang_item(Option)]
@@ -5486,21 +5500,21 @@ fn main()
     let _41: &'68 mut ChunksExact<'69, i32>[{built_in impl Sized for i32}]; // anonymous local
     let _42: i32; // anonymous local
     let expected: i32; // local
-    let _44: (&'72 i32, &'73 i32); // anonymous local
-    let _45: &'74 i32; // anonymous local
-    let _46: &'75 i32; // anonymous local
-    let left_val: &'76 i32; // local
-    let right_val: &'77 i32; // local
+    let _44: (&'77 i32, &'78 i32); // anonymous local
+    let _45: &'82 i32; // anonymous local
+    let _46: &'83 i32; // anonymous local
+    let left_val: &'84 i32; // local
+    let right_val: &'85 i32; // local
     let _49: bool; // anonymous local
     let _50: i32; // anonymous local
     let _51: i32; // anonymous local
     let kind: AssertKind; // local
     let _53: AssertKind; // anonymous local
-    let _54: &'78 i32; // anonymous local
-    let _55: &'79 i32; // anonymous local
-    let _56: &'80 i32; // anonymous local
-    let _57: &'81 i32; // anonymous local
-    let _58: Option<Arguments<'89>>[{built_in impl Sized for Arguments<'89>}]; // anonymous local
+    let _54: &'86 i32; // anonymous local
+    let _55: &'87 i32; // anonymous local
+    let _56: &'88 i32; // anonymous local
+    let _57: &'89 i32; // anonymous local
+    let _58: Option<Arguments<'97>>[{built_in impl Sized for Arguments<'97>}]; // anonymous local
 
     storage_live(_0)
     storage_live(_12)
@@ -5531,7 +5545,7 @@ fn main()
         unwind_continue
     storage_dead(_5)
     _3 = impl_IntoIterator_for_T::into_iter<IntoIter<i32, 7usize>[{built_in impl Sized for i32}]>[{built_in impl Sized for IntoIter<i32, 7usize>[{built_in impl Sized for i32}]}, impl_Iterator_for_IntoIter<i32, 7usize>[{built_in impl Sized for i32}]](move _4)
-    ↳⚡ conditional_drop[drop_glue<'93, i32, 7usize>[{built_in impl Sized for i32}]] _4
+    ↳⚡ conditional_drop[drop_glue<'101, i32, 7usize>[{built_in impl Sized for i32}]] _4
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5563,8 +5577,8 @@ fn main()
         storage_live(_9)
         _9 = &mut iter_6
         _8 = &two-phase-mut (*_9)
-        _7 = impl_Iterator_for_IntoIter::next<'95, i32, 7usize>[{built_in impl Sized for i32}](move _8)
-        ↳⚡ conditional_drop[drop_glue<'96, i32, 7usize>[{built_in impl Sized for i32}]] iter_6
+        _7 = impl_Iterator_for_IntoIter::next<'103, i32, 7usize>[{built_in impl Sized for i32}](move _8)
+        ↳⚡ conditional_drop[drop_glue<'104, i32, 7usize>[{built_in impl Sized for i32}]] iter_6
             ↳⚡ storage_dead(_58)
                 storage_dead(_57)
                 storage_dead(_56)
@@ -5576,7 +5590,7 @@ fn main()
                 storage_dead(_33)
                 storage_dead(_12)
                 unwind_terminate
-            conditional_drop[drop_glue<'97, i32, 7usize>[{built_in impl Sized for i32}]] _3
+            conditional_drop[drop_glue<'105, i32, 7usize>[{built_in impl Sized for i32}]] _3
             ↳⚡ storage_dead(_58)
                 storage_dead(_57)
                 storage_dead(_56)
@@ -5621,8 +5635,8 @@ fn main()
     }
     storage_dead(_9)
     storage_dead(_7)
-    conditional_drop[drop_glue<'98, i32, 7usize>[{built_in impl Sized for i32}]] iter_6
-    ↳⚡ conditional_drop[drop_glue<'97, i32, 7usize>[{built_in impl Sized for i32}]] _3
+    conditional_drop[drop_glue<'106, i32, 7usize>[{built_in impl Sized for i32}]] iter_6
+    ↳⚡ conditional_drop[drop_glue<'105, i32, 7usize>[{built_in impl Sized for i32}]] _3
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5646,7 +5660,7 @@ fn main()
         storage_dead(_12)
         unwind_continue
     storage_dead(iter_6)
-    conditional_drop[drop_glue<'99, i32, 7usize>[{built_in impl Sized for i32}]] _3
+    conditional_drop[drop_glue<'107, i32, 7usize>[{built_in impl Sized for i32}]] _3
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5667,7 +5681,7 @@ fn main()
     _15 = @ArrayToSliceShared<'_, i32, 7usize>(move _16)
     ↳⚡ undefined_behavior
     storage_dead(_16)
-    _14 = iter<'102, i32>[{built_in impl Sized for i32}](move _15)
+    _14 = iter<'110, i32>[{built_in impl Sized for i32}](move _15)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5680,7 +5694,7 @@ fn main()
         storage_dead(_12)
         unwind_continue
     storage_dead(_15)
-    _13 = impl_IntoIterator_for_T::into_iter<Iter<'104, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Iter<'104, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_Iter<'104, i32>[{built_in impl Sized for i32}]](move _14)
+    _13 = impl_IntoIterator_for_T::into_iter<Iter<'112, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Iter<'112, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_Iter<'112, i32>[{built_in impl Sized for i32}]](move _14)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5701,7 +5715,7 @@ fn main()
         storage_live(_20)
         _20 = &mut iter_17
         _19 = &two-phase-mut (*_20)
-        _18 = impl_Iterator_for_Iter::next<'114, '116, i32>[{built_in impl Sized for i32}](move _19)
+        _18 = impl_Iterator_for_Iter::next<'122, '124, i32>[{built_in impl Sized for i32}](move _19)
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5728,7 +5742,7 @@ fn main()
         _23 = &two-phase-mut i
         storage_live(_24)
         _24 = copy v_21
-        _22 = add_assign<'122, '124>(move _23, move _24)
+        _22 = add_assign<'130, '132>(move _23, move _24)
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5760,7 +5774,7 @@ fn main()
     _27 = @ArrayToSliceShared<'_, i32, 7usize>(move _28)
     ↳⚡ undefined_behavior
     storage_dead(_28)
-    _26 = chunks<'127, i32>[{built_in impl Sized for i32}](move _27, const 2usize)
+    _26 = chunks<'135, i32>[{built_in impl Sized for i32}](move _27, const 2usize)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5773,7 +5787,7 @@ fn main()
         storage_dead(_12)
         unwind_continue
     storage_dead(_27)
-    _25 = impl_IntoIterator_for_T::into_iter<Chunks<'129, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Chunks<'129, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_Chunks<'129, i32>[{built_in impl Sized for i32}]](move _26)
+    _25 = impl_IntoIterator_for_T::into_iter<Chunks<'137, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Chunks<'137, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_Chunks<'137, i32>[{built_in impl Sized for i32}]](move _26)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5794,7 +5808,7 @@ fn main()
         storage_live(_32)
         _32 = &mut iter_29
         _31 = &two-phase-mut (*_32)
-        _30 = impl_Iterator_for_Chunks::next<'139, '141, i32>[{built_in impl Sized for i32}](move _31)
+        _30 = impl_Iterator_for_Chunks::next<'147, '149, i32>[{built_in impl Sized for i32}](move _31)
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5832,7 +5846,7 @@ fn main()
     _36 = @ArrayToSliceShared<'_, i32, 7usize>(move _37)
     ↳⚡ undefined_behavior
     storage_dead(_37)
-    _35 = chunks_exact<'144, i32>[{built_in impl Sized for i32}](move _36, const 2usize)
+    _35 = chunks_exact<'152, i32>[{built_in impl Sized for i32}](move _36, const 2usize)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5845,7 +5859,7 @@ fn main()
         storage_dead(_12)
         unwind_continue
     storage_dead(_36)
-    _34 = impl_IntoIterator_for_T::into_iter<ChunksExact<'146, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for ChunksExact<'146, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_ChunksExact<'146, i32>[{built_in impl Sized for i32}]](move _35)
+    _34 = impl_IntoIterator_for_T::into_iter<ChunksExact<'154, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for ChunksExact<'154, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_ChunksExact<'154, i32>[{built_in impl Sized for i32}]](move _35)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5866,7 +5880,7 @@ fn main()
         storage_live(_41)
         _41 = &mut iter_38
         _40 = &two-phase-mut (*_41)
-        _39 = impl_Iterator_for_ChunksExact::next<'156, '158, i32>[{built_in impl Sized for i32}](move _40)
+        _39 = impl_Iterator_for_ChunksExact::next<'164, '166, i32>[{built_in impl Sized for i32}](move _40)
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5908,9 +5922,9 @@ fn main()
     storage_dead(_46)
     storage_dead(_45)
     storage_live(left_val)
-    left_val = copy _44.0
+    left_val = copy _44._0
     storage_live(right_val)
-    right_val = copy _44.1
+    right_val = copy _44._1
     storage_live(_49)
     storage_live(_50)
     _50 = copy (*left_val)

--- a/charon/tests/ui/lifetime-mutability.out
+++ b/charon/tests/ui/lifetime-mutability.out
@@ -18,11 +18,19 @@ pub trait Sized<Self>
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
 // Full name: test_crate::A
 struct A<mut 'a, mut 'b> {
   x: &'a mut u32,
   y: &'b u32,
-  z: alloc::boxed::Box<&'b mut u32>[{built_in impl MetaSized for &'b mut u32}, {built_in impl Sized for Global}],
+  z: Box<&'b mut u32>[{built_in impl MetaSized for &'b mut u32}, {built_in impl Sized for Global}],
 }
 
 // Full name: test_crate::B

--- a/charon/tests/ui/matches.out
+++ b/charon/tests/ui/matches.out
@@ -14,12 +14,22 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
 {
     fn drop_glue<'_0_1>;
     non-dyn-compatible
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
 }
 
 // Full name: test_crate::E1

--- a/charon/tests/ui/max_char.out
+++ b/charon/tests/ui/max_char.out
@@ -15,6 +15,8 @@ pub fn MAX() -> char
 #[deprecated(since = "future", note = "replaced by the `MAX` associated constant on `char`")]
 pub const MAX: char = MAX()
 
+struct () {}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/method-impl-generalization.out
+++ b/charon/tests/ui/method-impl-generalization.out
@@ -34,6 +34,8 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/method-ref.out
+++ b/charon/tests/ui/method-ref.out
@@ -22,6 +22,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -53,6 +55,14 @@ pub trait FnOnce<Self, Args>
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
 }
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::Ord
 trait Ord<Self>
 {
@@ -73,7 +83,7 @@ where
     let args: (&'_0 Self, &'_1 Self); // arg #2
 
     storage_live(_0)
-    _0 = TraitClause0::cmp<'_0, '_1>(move args.0, move args.1)
+    _0 = TraitClause0::cmp<'_0, '_1>(move args._0, move args._1)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -135,7 +145,7 @@ where
     _1 = const TraitClause1::cmp<'0, '1>
     storage_dead(_1)
     storage_live(_2)
-    _2 = use_fn<T, for<'_0_1, '_1_1> TraitClause1::cmp<'_0_1, '_1_1>>[TraitClause0, {built_in impl Sized for for<'_0_2, '_1_2> TraitClause1::cmp<'_0_2, '_1_2>}, {impl FnOnce<(&'_0 Self, &'_1 Self)> for for<'_0_1, '_1_1> TraitClause0::cmp<'_0_1, '_1_1>}<'2, '3, T>[TraitClause1]](const TraitClause1::cmp<'6, '7>)
+    _2 = use_fn<T, for<'_0_1, '_1_1> TraitClause1::cmp<'_0_1, '_1_1>>[TraitClause0, {built_in impl Sized for for<'_0_2, '_1_2> TraitClause1::cmp<'_0_2, '_1_2>}, {impl FnOnce<(&'_0 Self, &'_1 Self)> for for<'_0_1, '_1_1> TraitClause0::cmp<'_0_1, '_1_1>}<'8, '9, T>[TraitClause1]](const TraitClause1::cmp<'12, '13>)
     ↳⚡ unwind_continue
     storage_dead(_2)
     _0 = ()

--- a/charon/tests/ui/ml-mono-name-matcher-tests.out
+++ b/charon/tests/ui/ml-mono-name-matcher-tests.out
@@ -22,6 +22,12 @@ pub fn is_some::<i32><'_0>(_1: &'_0 Option::<i32>) -> bool
 pub fn index::<bool, RangeFrom::<usize>><'_0>(_1: &'_0 [bool], _2: RangeFrom::<usize>) -> &'_0 [bool]
 = <opaque>
 
+struct () {}
+
+struct str {
+  _0: [u8],
+}
+
 // Full name: test_crate::foo::bar
 #[pattern::pass("test_crate::foo::bar")]
 #[pattern::fail("crate::foo::bar")]

--- a/charon/tests/ui/ml-name-matcher-tests.out
+++ b/charon/tests/ui/ml-name-matcher-tests.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -190,6 +192,30 @@ where
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct (_,)<A> {
+  _0: A,
+}
+
+struct str {
+  _0: [u8],
+}
+
 // Full name: test_crate::foo::bar
 #[pattern::pass("test_crate::foo::bar")]
 #[pattern::fail("crate::foo::bar")]
@@ -213,7 +239,7 @@ trait Trait<Self, T>
     non-dyn-compatible
 }
 
-// Full name: test_crate::{impl Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::method
+// Full name: test_crate::{impl Trait<Option<T>[TraitClause0]> for Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::method
 #[pattern::pass("test_crate::{test_crate::Trait<alloc::boxed::Box<@T>, core::option::Option<@T>>}::method<@T, @U>")]
 #[pattern::pass("test_crate::{test_crate::Trait<Box<@T>, core::option::Option<@T>>}::method<@T, @U>")]
 #[pattern::fail("test_crate::{test_crate::Trait<Box<@T>, Option<@T>>}::method<@T, @U>")]
@@ -233,18 +259,18 @@ where
     return
 }
 
-// Full name: test_crate::{impl Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}
-impl<T> "impl_Trait_Option_for_Box_Global" Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+// Full name: test_crate::{impl Trait<Option<T>[TraitClause0]> for Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}
+impl<T> "impl_Trait_Option_for_Box_Global" Trait<Option<T>[TraitClause0]> for Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
 where
     TraitClause0: (T: Sized),
 {
-    proof ImpliedClause0: (alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]: MetaSized) = {built_in impl MetaSized for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}
+    proof ImpliedClause0: (Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]: MetaSized) = {built_in impl MetaSized for Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}
     proof ImpliedClause1: (Option<T>[TraitClause0]: Sized) = {built_in impl Sized for Option<T>[TraitClause0]}
     fn method<U, TraitClause0_1: (U: Sized)> = impl_Trait_Option_for_Box_Global::method<T, U>[TraitClause0, TraitClause0_1]
     non-dyn-compatible
 }
 
-// Full name: test_crate::{impl Trait<alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]> for Option<U>[TraitClause1]}::method
+// Full name: test_crate::{impl Trait<Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]> for Option<U>[TraitClause1]}::method
 #[pattern::pass("test_crate::{test_crate::Trait<core::option::Option<@T>, alloc::boxed::Box<@T>>}::method<@T, @U, @V>")]
 #[pattern::pass("test_crate::{test_crate::Trait<core::option::Option<@U>, alloc::boxed::Box<@T>>}::method<@T, @U, @V>")]
 fn impl_Trait_Box_for_Option::method<T, U, V>()
@@ -261,15 +287,41 @@ where
     return
 }
 
-// Full name: test_crate::{impl Trait<alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]> for Option<U>[TraitClause1]}
-impl<T, U> "impl_Trait_Box_for_Option" Trait<alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]> for Option<U>[TraitClause1]
+// Full name: test_crate::{impl Trait<Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]> for Option<U>[TraitClause1]}
+impl<T, U> "impl_Trait_Box_for_Option" Trait<Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]> for Option<U>[TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (U: Sized),
 {
     proof ImpliedClause0: (Option<U>[TraitClause1]: MetaSized) = {built_in impl MetaSized for Option<U>[TraitClause1]}
-    proof ImpliedClause1: (alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]: Sized) = {built_in impl Sized for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}
+    proof ImpliedClause1: (Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]: Sized) = {built_in impl Sized for Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}
     fn method<U, TraitClause0_1: (U: Sized)> = impl_Trait_Box_for_Option::method<T, U, U>[TraitClause0, TraitClause1, TraitClause0_1]
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl Trait<u32> for (u8, bool)}::method
+#[pattern::pass("test_crate::{test_crate::Trait<(u8, bool), u32>}::method<@U>")]
+#[pattern::pass("test_crate::{test_crate::Trait<(@T, @U), u32>}::method<@V>")]
+#[pattern::fail("test_crate::{test_crate::Trait<(u8, u8), u32>}::method<@U>")]
+#[pattern::fail("test_crate::{test_crate::Trait<(u8), u32>}::method<@U>")]
+#[pattern::fail("test_crate::{test_crate::Trait<(u8, bool, bool), u32>}::method<@U>")]
+fn impl_Trait_u32_for_tuple_u8_bool::method<U>()
+where
+    TraitClause0: (U: Sized),
+{
+    let _0: (); // return
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::{impl Trait<u32> for (u8, bool)}
+impl "impl_Trait_u32_for_tuple_u8_bool" Trait<u32> for (u8, bool) {
+    proof ImpliedClause0: ((u8, bool): MetaSized) = {built_in impl MetaSized for (u8, bool)}
+    proof ImpliedClause1: (u32: Sized) = {built_in impl Sized for u32}
+    fn method<U, TraitClause0_1: (U: Sized)> = impl_Trait_u32_for_tuple_u8_bool::method<U>[TraitClause0_1]
     non-dyn-compatible
 }
 
@@ -372,7 +424,7 @@ fn call<'_0>(_1: &'_0 closure, tupled_args: (usize,)) -> usize
 
     storage_live(_0)
     storage_live(x)
-    x = move tupled_args.0
+    x = move tupled_args._0
     _0 = copy x
     return
 }

--- a/charon/tests/ui/ml-name-matcher-tests.rs
+++ b/charon/tests/ui/ml-name-matcher-tests.rs
@@ -26,7 +26,9 @@ impl<T> Trait<Option<T>> for Box<T> {
         "test_crate::{test_crate::Trait<alloc::boxed::Box<@T>, core::option::Option<@T>>}::method<@T, @U>"
     )]
     // `Box` is special: it can be abbreviated.
-    #[pattern::pass("test_crate::{test_crate::Trait<Box<@T>, core::option::Option<@T>>}::method<@T, @U>")]
+    #[pattern::pass(
+        "test_crate::{test_crate::Trait<Box<@T>, core::option::Option<@T>>}::method<@T, @U>"
+    )]
     // Can't abbreviate `Option`, only `Box` is special like that.
     #[pattern::fail("test_crate::{test_crate::Trait<Box<@T>, Option<@T>>}::method<@T, @U>")]
     // More general patterns work too.
@@ -50,6 +52,16 @@ impl<T, U> Trait<Box<T>> for Option<U> {
         "test_crate::{test_crate::Trait<core::option::Option<@U>, alloc::boxed::Box<@T>>}::method<@T, @U, @V>"
     )]
     fn method<V>() {}
+}
+
+// Tuples are spelled like in Rust.
+impl Trait<u32> for (u8, bool) {
+    #[pattern::pass("test_crate::{test_crate::Trait<(u8, bool), u32>}::method<@U>")]
+    #[pattern::pass("test_crate::{test_crate::Trait<(@T, @U), u32>}::method<@V>")]
+    #[pattern::fail("test_crate::{test_crate::Trait<(u8, u8), u32>}::method<@U>")]
+    #[pattern::fail("test_crate::{test_crate::Trait<(u8), u32>}::method<@U>")]
+    #[pattern::fail("test_crate::{test_crate::Trait<(u8, bool, bool), u32>}::method<@U>")]
+    fn method<U>() {}
 }
 
 // `call[i]` is a hack to be able to refer to `Call` statements inside the function body.

--- a/charon/tests/ui/ml-partial-mono-name-matcher-tests.out
+++ b/charon/tests/ui/ml-partial-mono-name-matcher-tests.out
@@ -38,6 +38,8 @@ pub trait core::marker::Sized::<Option<&_ mut _>><'_0, T0>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/monomorphization/adt_proj.out
+++ b/charon/tests/ui/monomorphization/adt_proj.out
@@ -7,6 +7,8 @@ pub enum Result::<u32, u32> {
   Err { _0: u32 },
 }
 
+struct () {}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/monomorphization/bound_lifetime.out
+++ b/charon/tests/ui/monomorphization/bound_lifetime.out
@@ -8,6 +8,8 @@ pub enum Option::<&'_ u32> {
   Some { _0: &'_ u32 },
 }
 
+struct () {}
+
 // Full name: test_crate::foo
 fn foo<'_0>(x: &'_0 u32) -> Option::<&'_ u32>
 {

--- a/charon/tests/ui/monomorphization/closure-fn.out
+++ b/charon/tests/ui/monomorphization/closure-fn.out
@@ -16,6 +16,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -74,6 +76,16 @@ pub trait Fn<Self, Args>
     vtable: core::ops::function::Fn::{vtable}
 }
 
+struct (_, _)::<u8, u8> {
+  _0: u8,
+  _1: u8,
+}
+
+struct (_, _)::<u8, bool> {
+  _0: u8,
+  _1: bool,
+}
+
 // Full name: test_crate::main::closure
 struct closure<'_0, '_1> {
   _0: &'_0 u8,
@@ -81,29 +93,29 @@ struct closure<'_0, '_1> {
 }
 
 // Full name: test_crate::main::{impl FnOnce<(u8, u8)> for closure<'_0, '_1>}
-impl<'_0, '_1> "impl_FnOnce_tuple_for_closure" FnOnce<(u8, u8)> for closure<'_0, '_1> {
+impl<'_0, '_1> "impl_FnOnce_for_closure" FnOnce<(u8, u8)> for closure<'_0, '_1> {
     proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
     proof ImpliedClause1: ((u8, u8): Sized) = {built_in impl Sized for (u8, u8)}
     proof ImpliedClause2: ((u8, u8): Tuple) = {built_in impl Tuple for (u8, u8)}
-    vtable: impl_FnOnce_tuple_for_closure::{vtable}<'_0, '_1>
+    vtable: impl_FnOnce_for_closure::{vtable}<'_0, '_1>
 }
 
 // Full name: test_crate::main::{impl FnMut<(u8, u8)> for closure<'_0, '_1>}
-impl<'_0, '_1> "impl_FnMut_tuple_for_closure" FnMut<(u8, u8)> for closure<'_0, '_1> {
+impl<'_0, '_1> "impl_FnMut_for_closure" FnMut<(u8, u8)> for closure<'_0, '_1> {
     proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
-    proof ImpliedClause1: (closure<'_0, '_1>: FnOnce<(u8, u8)>) = impl_FnOnce_tuple_for_closure<'_0, '_1>
+    proof ImpliedClause1: (closure<'_0, '_1>: FnOnce<(u8, u8)>) = impl_FnOnce_for_closure<'_0, '_1>
     proof ImpliedClause2: ((u8, u8): Sized) = {built_in impl Sized for (u8, u8)}
     proof ImpliedClause3: ((u8, u8): Tuple) = {built_in impl Tuple for (u8, u8)}
-    vtable: impl_FnMut_tuple_for_closure::{vtable}<'_0, '_1>
+    vtable: impl_FnMut_for_closure::{vtable}<'_0, '_1>
 }
 
 // Full name: test_crate::main::{impl Fn<(u8, u8)> for closure<'_0, '_1>}
-impl<'_0, '_1> "impl_Fn_tuple_for_closure" Fn<(u8, u8)> for closure<'_0, '_1> {
+impl<'_0, '_1> "impl_Fn_for_closure" Fn<(u8, u8)> for closure<'_0, '_1> {
     proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
-    proof ImpliedClause1: (closure<'_0, '_1>: FnMut<(u8, u8)>) = impl_FnMut_tuple_for_closure<'_0, '_1>
+    proof ImpliedClause1: (closure<'_0, '_1>: FnMut<(u8, u8)>) = impl_FnMut_for_closure<'_0, '_1>
     proof ImpliedClause2: ((u8, u8): Sized) = {built_in impl Sized for (u8, u8)}
     proof ImpliedClause3: ((u8, u8): Tuple) = {built_in impl Tuple for (u8, u8)}
-    vtable: impl_Fn_tuple_for_closure::{vtable}<'_0, '_1>
+    vtable: impl_Fn_for_closure::{vtable}<'_0, '_1>
 }
 
 // Full name: test_crate::apply_to::<closure<'_, '_>>
@@ -119,7 +131,7 @@ fn apply_to::<closure<'_, '_>><'_0>(f: &'_0 closure<'_, '_>) -> u8
     _2 = &(*f)
     storage_live(_3)
     _3 = (const 10u8, const 20u8)
-    _0 = impl_Fn_tuple_for_closure<'15, '16>::call<'17>(move _2, move _3)
+    _0 = impl_Fn_for_closure<'15, '16>::call<'17>(move _2, move _3)
     ↳⚡ storage_dead(f)
         unwind_continue
     storage_dead(_3)
@@ -141,7 +153,7 @@ fn apply_to_mut::<closure<'_, '_>><'_0>(f: &'_0 mut closure<'_, '_>) -> u8
     _2 = &mut (*f)
     storage_live(_3)
     _3 = (const 10u8, const 20u8)
-    _0 = impl_FnMut_tuple_for_closure<'15, '16>::call_mut<'17>(move _2, move _3)
+    _0 = impl_FnMut_for_closure<'15, '16>::call_mut<'17>(move _2, move _3)
     ↳⚡ storage_dead(f)
         unwind_continue
     storage_dead(_3)
@@ -178,7 +190,7 @@ fn apply_to_once::<closure<'_, '_>>(f: closure<'_, '_>) -> u8
     _2 = move f
     storage_live(_3)
     _3 = (const 10u8, const 20u8)
-    _0 = impl_FnOnce_tuple_for_closure<'8, '9>::call_once(move _2, move _3)
+    _0 = impl_FnOnce_for_closure<'8, '9>::call_once(move _2, move _3)
     ↳⚡ conditional_drop[drop_glue<'14, '15, '16>] _2
         ↳⚡ storage_dead(f)
             unwind_terminate
@@ -239,7 +251,7 @@ fn main()
     _7 = &f
     storage_live(_8)
     _8 = (const 10u8, const 20u8)
-    _6 = impl_Fn_tuple_for_closure<'36, '37>::call<'38>(move _7, move _8)
+    _6 = impl_Fn_for_closure<'36, '37>::call<'38>(move _7, move _8)
     ↳⚡ unwind_continue
     storage_dead(_8)
     storage_dead(_7)
@@ -295,7 +307,7 @@ fn call_once<'_0, '_1>(_1: closure<'_0, '_1>, _2: (u8, u8)) -> u8
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = impl_FnMut_tuple_for_closure<'_0, '_1>::call_mut<'6>(move _3, move _2)
+    _0 = impl_FnMut_for_closure<'_0, '_1>::call_mut<'6>(move _3, move _2)
     ↳⚡ drop[drop_glue<'_0, '_1, '11>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
@@ -343,8 +355,8 @@ where
     storage_live(_9)
     storage_live(_11)
     storage_live(_13)
-    x = move tupled_args.0
-    y = move tupled_args.1
+    x = move tupled_args._0
+    y = move tupled_args._1
     storage_live(_5)
     storage_live(_6)
     storage_live(_7)

--- a/charon/tests/ui/monomorphization/closure-fnonce.out
+++ b/charon/tests/ui/monomorphization/closure-fnonce.out
@@ -16,6 +16,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -54,6 +56,15 @@ pub trait FnOnce<Self, Args>
     vtable: core::ops::function::FnOnce::{vtable}
 }
 
+struct (_,)::<u8> {
+  _0: u8,
+}
+
+struct (_, _)::<u8, bool> {
+  _0: u8,
+  _1: bool,
+}
+
 // Full name: test_crate::main::closure
 struct closure {
   _0: NotCopy,
@@ -72,11 +83,11 @@ unsafe fn drop_glue<'_0>(_1: &'_0 mut closure)
 }
 
 // Full name: test_crate::main::{impl FnOnce<(u8,)> for closure}
-impl "impl_FnOnce_tuple_for_closure" FnOnce<(u8,)> for closure {
+impl "impl_FnOnce_for_closure" FnOnce<(u8,)> for closure {
     proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
     proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
     proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
-    vtable: impl_FnOnce_tuple_for_closure::{vtable}
+    vtable: impl_FnOnce_for_closure::{vtable}
 }
 
 // Full name: test_crate::apply_to_zero_once::<closure>
@@ -92,7 +103,7 @@ fn apply_to_zero_once::<closure>(f: closure) -> u8
     _2 = move f
     storage_live(_3)
     _3 = (const 0u8,)
-    _0 = impl_FnOnce_tuple_for_closure::call_once(move _2, move _3)
+    _0 = impl_FnOnce_for_closure::call_once(move _2, move _3)
     ↳⚡ conditional_drop[drop_glue<'0>] _2
         ↳⚡ storage_dead(f)
             unwind_terminate
@@ -156,7 +167,7 @@ fn call_once(_1: closure, tupled_args: (u8,)) -> u8
     storage_live(_0)
     storage_live(x)
     storage_live(_7)
-    x = move tupled_args.0
+    x = move tupled_args._0
     storage_live(_4)
     storage_live(_5)
     _5 = move _1._0

--- a/charon/tests/ui/monomorphization/closures.out
+++ b/charon/tests/ui/monomorphization/closures.out
@@ -16,6 +16,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -82,6 +84,15 @@ pub trait Fn<Self, Args>
     vtable: core::ops::function::Fn::{vtable}
 }
 
+struct (_,)::<u8> {
+  _0: u8,
+}
+
+struct (_, _)::<u8, bool> {
+  _0: u8,
+  _1: bool,
+}
+
 struct test_crate::main::closure<'_0> {
   _0: &'_0 u8,
 }
@@ -118,12 +129,12 @@ impl<'_0> FnMut<(u8,)> for test_crate::main::closure<'_0> {
 }
 
 // Full name: test_crate::main::{impl Fn<(u8,)> for test_crate::main::closure<'_0>}
-impl<'_0> "impl_Fn_tuple_for_closure" Fn<(u8,)> for test_crate::main::closure<'_0> {
+impl<'_0> "impl_Fn_for_closure" Fn<(u8,)> for test_crate::main::closure<'_0> {
     proof ImpliedClause0: (test_crate::main::closure<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure<'_0>}
     proof ImpliedClause1: (test_crate::main::closure<'_0>: FnMut<(u8,)>) = {impl FnMut<(u8,)> for test_crate::main::closure<'_0>}<'_0>
     proof ImpliedClause2: ((u8,): Sized) = {built_in impl Sized for (u8,)}
     proof ImpliedClause3: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
-    vtable: impl_Fn_tuple_for_closure::{vtable}<'_0>
+    vtable: impl_Fn_for_closure::{vtable}<'_0>
 }
 
 // Full name: test_crate::apply_to_zero::<test_crate::main::closure<'_>>
@@ -139,7 +150,7 @@ fn apply_to_zero::<test_crate::main::closure<'_>>(f: test_crate::main::closure<'
     _2 = &f
     storage_live(_3)
     _3 = (const 0u8,)
-    _0 = impl_Fn_tuple_for_closure<'7>::call<'8>(move _2, move _3)
+    _0 = impl_Fn_for_closure<'7>::call<'8>(move _2, move _3)
     ↳⚡ conditional_drop[{impl Destruct for test_crate::main::closure<'_0>}::drop_glue<'11, '12>] f
         ↳⚡ storage_dead(f)
             unwind_terminate
@@ -387,7 +398,7 @@ where
     storage_live(_0)
     storage_live(x)
     storage_live(_6)
-    x = move tupled_args.0
+    x = move tupled_args._0
     storage_live(_4)
     _4 = copy x
     storage_live(_5)
@@ -483,7 +494,7 @@ where
     storage_live(x)
     storage_live(_4)
     storage_live(_7)
-    x = move tupled_args.0
+    x = move tupled_args._0
     _4 = copy (*(*_1)._0) panic.+ const 1u8
     (*(*_1)._0) = move _4
     storage_live(_5)
@@ -523,7 +534,7 @@ fn {impl FnOnce<(u8,)> for test_crate::main::closure#2}::call_once(_1: test_crat
     storage_live(_0)
     storage_live(x)
     storage_live(_7)
-    x = move tupled_args.0
+    x = move tupled_args._0
     storage_live(_4)
     storage_live(_5)
     _5 = move _1._0

--- a/charon/tests/ui/monomorphization/dyn-trait.out
+++ b/charon/tests/ui/monomorphization/dyn-trait.out
@@ -4,6 +4,8 @@
 #[lang_item(String)]
 pub opaque type String
 
+struct () {}
+
 // Full name: alloc::string::String::{impl Destruct for String}::drop_glue
 unsafe fn drop_glue<'_0>(_1: &'_0 mut String)
 = <opaque>
@@ -18,6 +20,10 @@ static impl_Display_for_String::{vtable}: core::fmt::Display::{vtable} = impl_Di
 // Full name: alloc::string::{impl Display for String}
 impl "impl_Display_for_String" Display for String {
     vtable: impl_Display_for_String::{vtable}
+}
+
+struct str {
+  _0: [u8],
 }
 
 // Full name: alloc::string::{impl ToString for str}::to_string::<str>

--- a/charon/tests/ui/monomorphization/fn_ptr_generics.out
+++ b/charon/tests/ui/monomorphization/fn_ptr_generics.out
@@ -8,6 +8,8 @@ pub enum Option::<u8> {
   Some { _0: u8 },
 }
 
+struct () {}
+
 // Full name: test_crate::init_option
 fn init_option()
 {

--- a/charon/tests/ui/monomorphization/fndefs-casts.out
+++ b/charon/tests/ui/monomorphization/fndefs-casts.out
@@ -66,6 +66,12 @@ pub trait Fn<Self, Args>
     vtable: core::ops::function::Fn::{vtable}
 }
 
+struct () {}
+
+struct (_,)::<&'_ u32> {
+  _0: &'_ u32,
+}
+
 // Full name: test_crate::foo::<u32>
 fn foo::<u32><'a>(x: &'a u32)
 {
@@ -79,30 +85,30 @@ fn foo::<u32><'a>(x: &'a u32)
     return
 }
 
-// Full name: test_crate::{impl FnOnce<(&'a u32,)> for for<'a> foo::<u32><'a>}
-impl<'a> FnOnce<(&'a u32,)> for for<'a> foo::<u32><'a> {
+// Full name: test_crate::{impl FnOnce<(&'_ u32,)> for for<'a> foo::<u32><'a>}
+impl<'a> FnOnce<(&'_ u32,)> for for<'a> foo::<u32><'a> {
     proof ImpliedClause0: (for<'a> foo::<u32><'a>: MetaSized) = {built_in impl MetaSized for for<'a> foo::<u32><'a>}
-    proof ImpliedClause1: ((&'a u32,): Sized) = {built_in impl Sized for (&'a u32,)}
-    proof ImpliedClause2: ((&'a u32,): Tuple) = {built_in impl Tuple for (&'a u32,)}
-    vtable: {impl FnOnce<(&'a u32,)> for for<'a> foo::<u32><'a>}::{vtable}::<u32><'a>
+    proof ImpliedClause1: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause2: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    vtable: {impl FnOnce<(&'_ u32,)> for for<'a> foo::<u32><'a>}::{vtable}::<u32><'a>
 }
 
-// Full name: test_crate::{impl FnMut<(&'a u32,)> for for<'a> foo::<u32><'a>}
-impl<'a> FnMut<(&'a u32,)> for for<'a> foo::<u32><'a> {
+// Full name: test_crate::{impl FnMut<(&'_ u32,)> for for<'a> foo::<u32><'a>}
+impl<'a> FnMut<(&'_ u32,)> for for<'a> foo::<u32><'a> {
     proof ImpliedClause0: (for<'a> foo::<u32><'a>: MetaSized) = {built_in impl MetaSized for for<'a> foo::<u32><'a>}
-    proof ImpliedClause1: (for<'a> foo::<u32><'a>: FnOnce<(&'a u32,)>) = {impl FnOnce<(&'a u32,)> for for<'a> foo::<u32><'a>}<'a>
-    proof ImpliedClause2: ((&'a u32,): Sized) = {built_in impl Sized for (&'a u32,)}
-    proof ImpliedClause3: ((&'a u32,): Tuple) = {built_in impl Tuple for (&'a u32,)}
-    vtable: {impl FnMut<(&'a u32,)> for for<'a> foo::<u32><'a>}::{vtable}::<u32><'a>
+    proof ImpliedClause1: (for<'a> foo::<u32><'a>: FnOnce<(&'_ u32,)>) = {impl FnOnce<(&'_ u32,)> for for<'a> foo::<u32><'a>}<'a>
+    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    vtable: {impl FnMut<(&'_ u32,)> for for<'a> foo::<u32><'a>}::{vtable}::<u32><'a>
 }
 
-// Full name: test_crate::{impl Fn<(&'a u32,)> for for<'a> foo::<u32><'a>}
-impl<'a> Fn<(&'a u32,)> for for<'a> foo::<u32><'a> {
+// Full name: test_crate::{impl Fn<(&'_ u32,)> for for<'a> foo::<u32><'a>}
+impl<'a> Fn<(&'_ u32,)> for for<'a> foo::<u32><'a> {
     proof ImpliedClause0: (for<'a> foo::<u32><'a>: MetaSized) = {built_in impl MetaSized for for<'a> foo::<u32><'a>}
-    proof ImpliedClause1: (for<'a> foo::<u32><'a>: FnMut<(&'a u32,)>) = {impl FnMut<(&'a u32,)> for for<'a> foo::<u32><'a>}<'a>
-    proof ImpliedClause2: ((&'a u32,): Sized) = {built_in impl Sized for (&'a u32,)}
-    proof ImpliedClause3: ((&'a u32,): Tuple) = {built_in impl Tuple for (&'a u32,)}
-    vtable: {impl Fn<(&'a u32,)> for for<'a> foo::<u32><'a>}::{vtable}::<u32><'a>
+    proof ImpliedClause1: (for<'a> foo::<u32><'a>: FnMut<(&'_ u32,)>) = {impl FnMut<(&'_ u32,)> for for<'a> foo::<u32><'a>}<'a>
+    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    vtable: {impl Fn<(&'_ u32,)> for for<'a> foo::<u32><'a>}::{vtable}::<u32><'a>
 }
 
 // Full name: test_crate::foo::<u8>
@@ -137,12 +143,12 @@ fn takes_closure::<for<'a> foo::<u32><'a>>(c: for<'a> foo::<u32><'a>)
     let _0: (); // return
     let c: for<'a> foo::<u32><'a>; // arg #1
     let _2: &'1 for<'a> foo::<u32><'a>; // anonymous local
-    let _3: (&'4 u32,); // anonymous local
-    let _4: &'5 u32; // anonymous local
-    let _5: &'6 u32; // anonymous local
-    let _6: &'7 u32; // anonymous local
-    let _7: &'8 u32; // anonymous local
-    let _8: &'19 u32; // anonymous local
+    let _3: (&'_ u32,); // anonymous local
+    let _4: &'3 u32; // anonymous local
+    let _5: &'4 u32; // anonymous local
+    let _6: &'5 u32; // anonymous local
+    let _7: &'6 u32; // anonymous local
+    let _8: &'14 u32; // anonymous local
     let _9: u32; // anonymous local
 
     storage_live(_7)
@@ -163,7 +169,7 @@ fn takes_closure::<for<'a> foo::<u32><'a>>(c: for<'a> foo::<u32><'a>)
     _5 = &(*_6)
     _4 = &(*_5)
     _3 = (move _4,)
-    _0 = {impl Fn<(&'a u32,)> for for<'a> foo::<u32><'a>}<'13>::call<'14>(move _2, move _3)
+    _0 = {impl Fn<(&'_ u32,)> for for<'a> foo::<u32><'a>}<'8>::call<'9>(move _2, move _3)
     ↳⚡ storage_dead(_6)
         storage_dead(c)
         unwind_continue

--- a/charon/tests/ui/monomorphization/generic-method.out
+++ b/charon/tests/ui/monomorphization/generic-method.out
@@ -8,6 +8,8 @@ opaque type {vtable}
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct () {}
+
 // Full name: test_crate::Foo
 trait Foo<Self>
 {

--- a/charon/tests/ui/monomorphization/global_with_generics.out
+++ b/charon/tests/ui/monomorphization/global_with_generics.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::Foo::<i32>
 struct Foo::<i32> {
   value: i32,

--- a/charon/tests/ui/monomorphization/issue-1159-assoc-const.out
+++ b/charon/tests/ui/monomorphization/issue-1159-assoc-const.out
@@ -41,6 +41,19 @@ pub enum Option::<&'_ [u64]> {
   Some { _0: &'_ [u64] },
 }
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct (_, _)::<u64, bool> {
+  _0: u64,
+  _1: bool,
+}
+
 // Full name: test_crate::MyConfig
 pub trait MyConfig<Self>
 {

--- a/charon/tests/ui/monomorphization/issue-1262-defaulted-method-indirection.out
+++ b/charon/tests/ui/monomorphization/issue-1262-defaulted-method-indirection.out
@@ -8,6 +8,8 @@ opaque type {vtable}
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct () {}
+
 // Full name: test_crate::Foo
 pub trait Foo<Self>
 {

--- a/charon/tests/ui/monomorphization/issue-722-poly-items-in-names.out
+++ b/charon/tests/ui/monomorphization/issue-722-poly-items-in-names.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::Point::<i32>
 struct Point::<i32> {
   x: i32,

--- a/charon/tests/ui/monomorphization/issue-917-inline-const-with-poly-type.out
+++ b/charon/tests/ui/monomorphization/issue-917-inline-const-with-poly-type.out
@@ -16,6 +16,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -72,6 +74,10 @@ pub trait Fn<Self, Args>
     proof ImpliedClause2: (Args: Sized)
     proof ImpliedClause3: (Args: Tuple)
     vtable: core::ops::function::Fn::{vtable}
+}
+
+struct (_,)::<()> {
+  _0: (),
 }
 
 // Full name: test_crate::foo::{const}::closure::<()>
@@ -231,7 +237,7 @@ fn call::<()><'_0>(_1: &'_0 closure::<()>, tupled_args: ((),))
     storage_live(_0)
     storage_live(x)
     _0 = ()
-    x = move tupled_args.0
+    x = move tupled_args._0
     _0 = ()
     storage_dead(x)
     storage_dead(tupled_args)

--- a/charon/tests/ui/monomorphization/issue-922-assoc-const-with-default.out
+++ b/charon/tests/ui/monomorphization/issue-922-assoc-const-with-default.out
@@ -22,6 +22,8 @@ pub trait Sized<Self>
 pub fn size_of::<()>() -> usize
 = <opaque>
 
+struct () {}
+
 // Full name: test_crate::SizedTypeProperties
 pub trait SizedTypeProperties<Self>
 {

--- a/charon/tests/ui/monomorphization/lifetime-bound-call.out
+++ b/charon/tests/ui/monomorphization/lifetime-bound-call.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::callee::<'_>
 fn callee::<'_>()
 {

--- a/charon/tests/ui/monomorphization/rec-adt.out
+++ b/charon/tests/ui/monomorphization/rec-adt.out
@@ -12,6 +12,8 @@ pub enum Option::<NonNull::<Node::<u8>>> {
   Some { _0: NonNull::<Node::<u8>> },
 }
 
+struct () {}
+
 // Full name: test_crate::LinkedList::<u8>
 pub struct LinkedList::<u8> {
   head: Option::<NonNull::<Node::<u8>>>,

--- a/charon/tests/ui/monomorphization/simpl-trait-assoc-types-2.out
+++ b/charon/tests/ui/monomorphization/simpl-trait-assoc-types-2.out
@@ -17,6 +17,8 @@ fn core::marker::MetaSized::{vtable}::<usize>() -> core::marker::MetaSized::{vta
 
 static core::marker::MetaSized::{vtable}::<usize>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<usize>()
 
+struct () {}
+
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple-trait-assoc-types-3.out
+++ b/charon/tests/ui/monomorphization/simple-trait-assoc-types-3.out
@@ -17,6 +17,8 @@ fn core::marker::MetaSized::{vtable}::<usize>() -> core::marker::MetaSized::{vta
 
 static core::marker::MetaSized::{vtable}::<usize>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<usize>()
 
+struct () {}
+
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple-trait-assoc-types.out
+++ b/charon/tests/ui/monomorphization/simple-trait-assoc-types.out
@@ -12,6 +12,8 @@ fn core::marker::MetaSized::{vtable}::<i32>() -> core::marker::MetaSized::{vtabl
 
 static core::marker::MetaSized::{vtable}::<i32>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<i32>()
 
+struct () {}
+
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple-trait-generics-2.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics-2.out
@@ -26,6 +26,8 @@ fn core::marker::MetaSized::{vtable}::<u32>() -> core::marker::MetaSized::{vtabl
 
 static core::marker::MetaSized::{vtable}::<u32>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<u32>()
 
+struct () {}
+
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple-trait-generics-assoc-2.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics-assoc-2.out
@@ -26,6 +26,8 @@ fn core::marker::MetaSized::{vtable}::<bool>() -> core::marker::MetaSized::{vtab
 
 static core::marker::MetaSized::{vtable}::<bool>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<bool>()
 
+struct () {}
+
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple-trait-generics-assoc.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics-assoc.out
@@ -21,6 +21,8 @@ fn core::marker::MetaSized::{vtable}::<i32>() -> core::marker::MetaSized::{vtabl
 
 static core::marker::MetaSized::{vtable}::<i32>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<i32>()
 
+struct () {}
+
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple-trait-generics.out
+++ b/charon/tests/ui/monomorphization/simple-trait-generics.out
@@ -21,6 +21,8 @@ fn core::marker::MetaSized::{vtable}::<i32>() -> core::marker::MetaSized::{vtabl
 
 static core::marker::MetaSized::{vtable}::<i32>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<i32>()
 
+struct () {}
+
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple-trait-two-methods.out
+++ b/charon/tests/ui/monomorphization/simple-trait-two-methods.out
@@ -12,6 +12,8 @@ fn core::marker::MetaSized::{vtable}::<i32>() -> core::marker::MetaSized::{vtabl
 
 static core::marker::MetaSized::{vtable}::<i32>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<i32>()
 
+struct () {}
+
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple_trait.out
+++ b/charon/tests/ui/monomorphization/simple_trait.out
@@ -12,6 +12,8 @@ fn core::marker::MetaSized::{vtable}::<i32>() -> core::marker::MetaSized::{vtabl
 
 static core::marker::MetaSized::{vtable}::<i32>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<i32>()
 
+struct () {}
+
 struct test_crate::Trait::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple_trait_with_trait_alias.out
+++ b/charon/tests/ui/monomorphization/simple_trait_with_trait_alias.out
@@ -7,6 +7,8 @@ opaque type core::marker::MetaSized::{vtable}
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct () {}
+
 struct test_crate::A::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/simple_trait_with_trait_alias_generics.out
+++ b/charon/tests/ui/monomorphization/simple_trait_with_trait_alias_generics.out
@@ -16,6 +16,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 struct test_crate::A::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphization/trait_impls.out
+++ b/charon/tests/ui/monomorphization/trait_impls.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::{impl Trait for bool}::method
 pub fn method<'_0>(self: &'_0 bool)
 {

--- a/charon/tests/ui/monomorphization/trait_impls_ullbc.out
+++ b/charon/tests/ui/monomorphization/trait_impls_ullbc.out
@@ -4,6 +4,8 @@
 pub fn eq<'_0, '_1>(_1: &'_0 bool, _2: &'_1 bool) -> bool
 = <opaque>
 
+struct () {}
+
 // Full name: test_crate::do_test::<bool>
 fn do_test::<bool>(init: bool, expected: bool)
 {

--- a/charon/tests/ui/monomorphization/unsatisfied-method-bounds.out
+++ b/charon/tests/ui/monomorphization/unsatisfied-method-bounds.out
@@ -7,6 +7,8 @@ opaque type core::marker::MetaSized::{vtable}
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct () {}
+
 struct test_crate::MyIterator::{vtable} {
   size: usize,
   align: usize,

--- a/charon/tests/ui/monomorphize-mut-no-types.out
+++ b/charon/tests/ui/monomorphize-mut-no-types.out
@@ -50,6 +50,8 @@ pub trait core::marker::Sized::<Option<Option<&_ mut _>>><'_0, T0>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/monomorphize-mut.out
+++ b/charon/tests/ui/monomorphize-mut.out
@@ -134,6 +134,8 @@ pub trait core::marker::MetaSized::<test_crate::List::<&_ mut _><_, _>[TraitClau
 where
     TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -294,6 +296,10 @@ where
   Some { _0: IterWrapper<'_0, T0>[TraitClause1] },
 }
 
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: core::option::{Option<T>[TraitClause0]}::map
 pub fn map<T, U, F>(_1: Option<T>[TraitClause0], _2: F) -> Option<U>[TraitClause1]
 where
@@ -308,6 +314,22 @@ where
 // Full name: alloc::alloc::Global
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
+
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type alloc::boxed::Box::<test_crate::List::<&_ mut _><_, _>[TraitClause2]><'_0, T0>
+where
+    TraitClause0: (T0: core::marker::MetaSized::<test_crate::List::<&_ mut _><_, _>[TraitClause0]><'_0>[TraitClause2]),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+    TraitClause2: (T0: core::marker::Sized::<&_ mut _><'_0>),
 
 // Full name: test_crate::option_mut
 fn option_mut<X, A>(x: A)
@@ -403,7 +425,7 @@ where
     let args: (T,); // arg #2
 
     storage_live(_0)
-    _0 = identity<T>[TraitClause0](move args.0)
+    _0 = identity<T>[TraitClause0](move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -841,7 +863,7 @@ where
     TraitClause0: (T: Sized),
 {
   val: T,
-  next: alloc::boxed::Box<List<T>[TraitClause0]>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}],
+  next: Box<List<T>[TraitClause0]>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}],
 }
 
 enum test_crate::List::<&_ mut _><'_0, T0>
@@ -857,7 +879,7 @@ where
     TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
 {
   val: &'_0 mut T0,
-  next: alloc::boxed::Box<test_crate::List::<&_ mut _><'_0, T0>[TraitClause0]>[{built_in impl core::marker::MetaSized::<test_crate::List::<&_ mut _><_, _>[TraitClause0]><'_0>[TraitClause0] for T0}, {built_in impl Sized for Global}],
+  next: alloc::boxed::Box::<test_crate::List::<&_ mut _><_, _>[TraitClause2]><'_0, T0>[{built_in impl core::marker::MetaSized::<test_crate::List::<&_ mut _><_, _>[TraitClause0]><'_0>[TraitClause0] for T0}, {built_in impl Sized for Global}, TraitClause0],
 }
 
 // Full name: test_crate::use_list_mut

--- a/charon/tests/ui/multi-target/cstr.out
+++ b/charon/tests/ui/multi-target/cstr.out
@@ -10,6 +10,8 @@ pub struct core::ffi::c_str::CStr::powerpc64-unknown-linux-gnu {
   inner: [u8],
 }
 
+struct () {}
+
 fn test_crate::main::x86_64-unknown-linux-gnu()
 {
     let _0: (); // return

--- a/charon/tests/ui/multi-target/default-trait-assoc-const.out
+++ b/charon/tests/ui/multi-target/default-trait-assoc-const.out
@@ -2,6 +2,8 @@
 #[lang_item(MetaSized)]
 pub trait core::marker::MetaSized<Self>
 
+struct () {}
+
 trait test_crate::Trait<Self>
 {
     proof ImpliedClause0: (Self: core::marker::MetaSized)

--- a/charon/tests/ui/multi-target/issue-1185-1-inline-const.out
+++ b/charon/tests/ui/multi-target/issue-1185-1-inline-const.out
@@ -3,6 +3,8 @@ pub fn core::num::{u32}::MAX() -> u32
 
 pub const core::num::{u32}::MAX: u32 = core::num::{u32}::MAX()
 
+struct () {}
+
 pub fn test_crate::const_time_array_copy_mwe<'_0, const N : usize>(_a: &'_0 mut [u8; N])
 {
     let _0: (); // return

--- a/charon/tests/ui/multi-target/issue-1185-2-generic-make.out
+++ b/charon/tests/ui/multi-target/issue-1185-2-generic-make.out
@@ -1,3 +1,5 @@
+struct () {}
+
 #[lang_item(Destruct)]
 pub trait core::marker::Destruct<Self>
 {

--- a/charon/tests/ui/multi-target/issue-1185-3-box-drop-glue.out
+++ b/charon/tests/ui/multi-target/issue-1185-3-box-drop-glue.out
@@ -1,6 +1,10 @@
 #[lang_item(GlobalAlloc)]
 pub struct alloc::alloc::Global {}
 
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type alloc::boxed::Box<T>
+
 unsafe fn alloc::boxed::Box::{impl core::marker::Destruct for alloc::boxed::Box<T>}::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>)
 where
     TypeOutlives0: T: '_0,

--- a/charon/tests/ui/multi-target/issue-1185-4-wrapping-add.out
+++ b/charon/tests/ui/multi-target/issue-1185-4-wrapping-add.out
@@ -1,6 +1,8 @@
 pub fn core::num::{u32}::wrapping_add(_1: u32, _2: u32) -> u32
 = <opaque>
 
+struct () {}
+
 pub fn test_crate::mod_reduce(a: u32) -> u32
 {
     let _0: u32; // return

--- a/charon/tests/ui/multi-target/issue-1213-merge-methods-when-missing-simple.out
+++ b/charon/tests/ui/multi-target/issue-1213-merge-methods-when-missing-simple.out
@@ -10,6 +10,8 @@ pub trait core::marker::Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 #[charon::opaque]
 trait test_crate::Trait<Self>
 {

--- a/charon/tests/ui/multi-target/issue-1213-merge-methods-when-missing.out
+++ b/charon/tests/ui/multi-target/issue-1213-merge-methods-when-missing.out
@@ -15,6 +15,14 @@ where
     TraitClause0: (A: core::marker::Sized),
     TraitClause1: (B: core::marker::Sized),
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: core::marker::Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 #[lang_item(Option)]
 #[diagnostic_item("Option")]
 pub enum core::option::Option<T>
@@ -207,6 +215,12 @@ where
     TypeOutlives0: T: '_0,
 = <opaque>
 
+struct () {}
+
+struct (_,)<A> {
+  _0: A,
+}
+
 fn test_crate::f<'_0>(blocks: &'_0 mut [u8])
 {
     let _0: (); // return
@@ -277,9 +291,9 @@ fn test_crate::g<'_0, '_1>(s0: &'_0 [u8], s1: &'_1 [u8])
     let _7: core::slice::iter::Iter<'34, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
     let _8: &'35 [u8]; // anonymous local
     let iter: core::iter::adapters::zip::Zip<core::slice::iter::Iter<'36, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'37, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'36, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'37, u8>[{built_in impl core::marker::Sized for u8}]}]; // local
-    let _10: core::option::Option<(&'61 u8, &'62 u8)>[{built_in impl core::marker::Sized for (&'61 u8, &'62 u8)}]; // anonymous local
-    let _11: &'78 mut core::iter::adapters::zip::Zip<core::slice::iter::Iter<'79, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'80, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'79, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'80, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
-    let _12: &'87 mut core::iter::adapters::zip::Zip<core::slice::iter::Iter<'88, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'89, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'88, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'89, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
+    let _10: core::option::Option<(&'88 u8, &'89 u8)>[{built_in impl core::marker::Sized for (&'88 u8, &'89 u8)}]; // anonymous local
+    let _11: &'117 mut core::iter::adapters::zip::Zip<core::slice::iter::Iter<'118, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'119, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'118, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'119, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
+    let _12: &'126 mut core::iter::adapters::zip::Zip<core::slice::iter::Iter<'127, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'128, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'127, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'128, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -288,7 +302,7 @@ fn test_crate::g<'_0, '_1>(s0: &'_0 [u8], s1: &'_1 [u8])
     storage_live(_5)
     storage_live(_6)
     _6 = &(*s0) with_metadata(copy s0.metadata)
-    _5 = core::slice::{[T]}::iter<'97, u8>[{built_in impl core::marker::Sized for u8}](move _6)
+    _5 = core::slice::{[T]}::iter<'136, u8>[{built_in impl core::marker::Sized for u8}](move _6)
     ↳⚡ storage_dead(s1)
         storage_dead(s0)
         unwind_continue
@@ -296,18 +310,18 @@ fn test_crate::g<'_0, '_1>(s0: &'_0 [u8], s1: &'_1 [u8])
     storage_live(_7)
     storage_live(_8)
     _8 = &(*s1) with_metadata(copy s1.metadata)
-    _7 = core::slice::{[T]}::iter<'99, u8>[{built_in impl core::marker::Sized for u8}](move _8)
+    _7 = core::slice::{[T]}::iter<'138, u8>[{built_in impl core::marker::Sized for u8}](move _8)
     ↳⚡ storage_dead(s1)
         storage_dead(s0)
         unwind_continue
     storage_dead(_8)
-    _4 = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}::zip<'101, u8, core::slice::iter::Iter<'102, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for u8}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'102, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'101, u8>[{built_in impl core::marker::Sized for u8}]}, core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}<core::slice::iter::Iter<'102, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'102, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'102, u8>[{built_in impl core::marker::Sized for u8}]]](move _5, move _7)
+    _4 = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}::zip<'140, u8, core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for u8}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'140, u8>[{built_in impl core::marker::Sized for u8}]}, core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}<core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'141, u8>[{built_in impl core::marker::Sized for u8}]]](move _5, move _7)
     ↳⚡ storage_dead(s1)
         storage_dead(s0)
         unwind_continue
     storage_dead(_7)
     storage_dead(_5)
-    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::iter::adapters::zip::Zip<core::slice::iter::Iter<'144, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'147, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'144, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'147, u8>[{built_in impl core::marker::Sized for u8}]}]>[{built_in impl core::marker::Sized for core::iter::adapters::zip::Zip<core::slice::iter::Iter<'144, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'147, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'144, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'147, u8>[{built_in impl core::marker::Sized for u8}]}]}, core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}<core::slice::iter::Iter<'144, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'147, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'144, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'147, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'144, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'147, u8>[{built_in impl core::marker::Sized for u8}]]](move _4)
+    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::iter::adapters::zip::Zip<core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]}]>[{built_in impl core::marker::Sized for core::iter::adapters::zip::Zip<core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]}]}, core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}<core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'186, u8>[{built_in impl core::marker::Sized for u8}]]](move _4)
     ↳⚡ storage_dead(s1)
         storage_dead(s0)
         unwind_continue
@@ -320,7 +334,7 @@ fn test_crate::g<'_0, '_1>(s0: &'_0 [u8], s1: &'_1 [u8])
         storage_live(_12)
         _12 = &mut iter
         _11 = &two-phase-mut (*_12)
-        _10 = core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}::next<'265, core::slice::iter::Iter<'246, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'247, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'246, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'247, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'246, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'247, u8>[{built_in impl core::marker::Sized for u8}]](move _11)
+        _10 = core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}::next<'304, core::slice::iter::Iter<'285, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'286, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'285, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'286, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'285, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'286, u8>[{built_in impl core::marker::Sized for u8}]](move _11)
         ↳⚡ storage_dead(s1)
             storage_dead(s0)
             unwind_continue

--- a/charon/tests/ui/multi-target/issue-1307-required-method.out
+++ b/charon/tests/ui/multi-target/issue-1307-required-method.out
@@ -19,6 +19,8 @@ pub trait core::clone::Clone<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 pub struct test_crate::Foo {}
 
 pub fn test_crate::{impl core::clone::Clone for test_crate::Foo}::clone<'_0>(self: &'_0 test_crate::Foo) -> test_crate::Foo

--- a/charon/tests/ui/multi-target/multi-target-from-symcrypt.out
+++ b/charon/tests/ui/multi-target/multi-target-from-symcrypt.out
@@ -3,6 +3,8 @@ pub opaque type core::core_arch::arm_shared::neon::uint16x8_t
 pub unsafe fn core::core_arch::aarch64::neon::generated::vld1q_u16(_1: *const u16) -> core::core_arch::arm_shared::neon::uint16x8_t
 = <opaque>
 
+struct () {}
+
 pub unsafe fn core::core_arch::aarch64::neon::generated::vst1q_u16(_1: *mut u16, _2: core::core_arch::arm_shared::neon::uint16x8_t)
 = <opaque>
 
@@ -147,6 +149,14 @@ impl core::cmp::PartialOrd<usize> for usize {
     vtable: core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}::{vtable}
 }
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: core::marker::Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 #[diagnostic_item("range_step")]
 pub trait core::iter::range::Step<Self>
 {
@@ -249,6 +259,10 @@ where
     TraitClause0: (T: core::marker::Sized),
     TypeOutlives0: T: '_0,
 = <opaque>
+
+struct (_,)<A> {
+  _0: A,
+}
 
 trait test_crate::NttIntrinsicsInterface<Self>
 {

--- a/charon/tests/ui/multi-target/multi-targets-3-dedup.out
+++ b/charon/tests/ui/multi-target/multi-targets-3-dedup.out
@@ -1,6 +1,28 @@
 pub fn core::clone::impls::{impl core::clone::Clone for u32}::clone<'_0>(_1: &'_0 u32) -> u32
 = <opaque>
 
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait core::marker::MetaSized<Self>
+
+#[fundamental]
+#[lang_item(Sized)]
+pub trait core::marker::Sized<Self>
+{
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: core::marker::Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 fn test_crate::clone_it<'_0>(x: &'_0 u32) -> u32
 {
     let _0: u32; // return

--- a/charon/tests/ui/multi-target/multi-targets-file-ids.out
+++ b/charon/tests/ui/multi-target/multi-targets-file-ids.out
@@ -3,6 +3,8 @@ pub opaque type core::core_arch::arm_shared::neon::uint16x8_t
 pub unsafe fn core::core_arch::aarch64::neon::generated::vld1q_u16(_1: *const u16) -> core::core_arch::arm_shared::neon::uint16x8_t
 = <opaque>
 
+struct () {}
+
 pub unsafe fn core::core_arch::aarch64::neon::generated::vst1q_u16(_1: *mut u16, _2: core::core_arch::arm_shared::neon::uint16x8_t)
 = <opaque>
 
@@ -147,6 +149,14 @@ impl core::cmp::PartialOrd<usize> for usize {
     vtable: core::cmp::impls::{impl core::cmp::PartialOrd<usize> for usize}::{vtable}
 }
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: core::marker::Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 #[diagnostic_item("range_step")]
 pub trait core::iter::range::Step<Self>
 {
@@ -249,6 +259,10 @@ where
     TraitClause0: (T: core::marker::Sized),
     TypeOutlives0: T: '_0,
 = <opaque>
+
+struct (_,)<A> {
+  _0: A,
+}
 
 trait test_crate::SimdOps<Self>
 {

--- a/charon/tests/ui/multi-target/multi-targets.out
+++ b/charon/tests/ui/multi-target/multi-targets.out
@@ -1,3 +1,23 @@
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait core::marker::MetaSized<Self>
+
+#[fundamental]
+#[lang_item(Sized)]
+pub trait core::marker::Sized<Self>
+{
+    proof ImpliedClause0: (Self: core::marker::MetaSized)
+    non-dyn-compatible
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: core::marker::Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 pub struct test_crate::StructTargetIndep {
   x: u64,
   y: u64,

--- a/charon/tests/ui/no-gen-tuple-structs.out
+++ b/charon/tests/ui/no-gen-tuple-structs.out
@@ -1,0 +1,396 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+opaque type ()
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Tuple
+#[fundamental]
+#[lang_item(Tuple)]
+pub trait Tuple<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+// Full name: core::ops::function::FnOnce
+#[fundamental]
+#[lang_item(FnOnce)]
+pub trait FnOnce<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
+    type Output
+    fn call_once;
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
+}
+
+// Full name: core::ops::function::FnMut
+#[fundamental]
+#[lang_item(FnMut)]
+pub trait FnMut<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    fn call_mut<'_0_1>;
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
+}
+
+// Full name: core::ops::function::Fn
+#[fundamental]
+#[lang_item(Fn)]
+pub trait Fn<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    fn call<'_0_1>;
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
+}
+
+// Full name: test_crate::mk_unit
+fn mk_unit()
+{
+    let _0: (); // return
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::mk_pair
+fn mk_pair(x: u32, y: bool) -> (u32, bool)
+{
+    let _0: (u32, bool); // return
+    let x: u32; // arg #1
+    let y: bool; // arg #2
+    let _3: u32; // anonymous local
+    let _4: bool; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = copy x
+    storage_live(_4)
+    _4 = copy y
+    _0 = (move _3, move _4)
+    storage_dead(_4)
+    storage_dead(_3)
+    storage_dead(y)
+    storage_dead(x)
+    return
+}
+
+// Full name: test_crate::fst
+fn fst(p: (u32, bool)) -> u32
+{
+    let _0: u32; // return
+    let p: (u32, bool); // arg #1
+
+    storage_live(_0)
+    _0 = copy p.0
+    storage_dead(p)
+    return
+}
+
+// Full name: test_crate::nested
+fn nested<T>(x: T, y: (u8, u8, u8)) -> (T, (u8, u8, u8))
+where
+    TraitClause0: (T: Sized),
+{
+    let _0: (T, (u8, u8, u8)); // return
+    let x: T; // arg #1
+    let y: (u8, u8, u8); // arg #2
+    let _3: T; // anonymous local
+    let _4: (u8, u8, u8); // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = move x
+    storage_live(_4)
+    _4 = copy y
+    _0 = (move _3, move _4)
+    storage_dead(_4)
+    conditional_drop[{built_in impl Destruct for T}::drop_glue<'0>] _3
+    ↳⚡ conditional_drop[{built_in impl Destruct for T}::drop_glue<'2>] x
+        ↳⚡ storage_dead(y)
+            storage_dead(x)
+            unwind_terminate
+        storage_dead(y)
+        storage_dead(x)
+        unwind_continue
+    storage_dead(_3)
+    conditional_drop[{built_in impl Destruct for T}::drop_glue<'1>] x
+    ↳⚡ storage_dead(y)
+        storage_dead(x)
+        unwind_continue
+    storage_dead(y)
+    storage_dead(x)
+    return
+}
+
+// Full name: test_crate::Struct
+struct Struct {
+  field: (u32, (bool, char)),
+}
+
+// Full name: test_crate::get_field
+fn get_field(s: Struct) -> (bool, char)
+{
+    let _0: (bool, char); // return
+    let s: Struct; // arg #1
+
+    storage_live(_0)
+    _0 = copy s.field.1
+    storage_dead(s)
+    return
+}
+
+// Full name: test_crate::Trait
+trait Trait<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self::Assoc: Sized)
+    type Assoc
+    vtable: test_crate::Trait::{vtable}<Self::Assoc>
+}
+
+// Full name: test_crate::{impl Trait for u32}
+impl "impl_Trait_for_u32" Trait for u32 {
+    proof ImpliedClause0: (u32: MetaSized) = {built_in impl MetaSized for u32}
+    proof ImpliedClause1: ((u32, u32): Sized) = {built_in impl Sized for (u32, u32)}
+    type Assoc = (u32, u32)
+    vtable: impl_Trait_for_u32::{vtable}
+}
+
+// Full name: test_crate::call_closure
+fn call_closure<T0>(f: T0) -> u32
+where
+    TraitClause0: (T0: Sized),
+    TraitClause1: (T0: Fn<(u32, bool)>),
+    TypeConstraint0: TraitClause1::ImpliedClause1::ImpliedClause1::Output = u32,
+{
+    let _0: u32; // return
+    let f: T0; // arg #1
+    let _2: &'1 T0; // anonymous local
+    let _3: (u32, bool); // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = &f
+    storage_live(_3)
+    _3 = (const 0u32, const true)
+    _0 = TraitClause1::call<'2>(move _2, move _3)
+    ↳⚡ conditional_drop[{built_in impl Destruct for T0}::drop_glue<'3>] f
+        ↳⚡ storage_dead(f)
+            unwind_terminate
+        storage_dead(f)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    conditional_drop[{built_in impl Destruct for T0}::drop_glue<'4>] f
+    ↳⚡ storage_dead(f)
+        unwind_continue
+    storage_dead(f)
+    return
+}
+
+// Full name: test_crate::use_closure::closure
+struct closure<'_0> {
+  _0: &'_0 u32,
+}
+
+// Full name: test_crate::use_closure::{impl Fn<(u32, bool)> for closure<'_0>}::call
+fn call<'_0, '_1>(_1: &'_1 closure<'_0>, tupled_args: (u32, bool)) -> u32
+where
+    RegionOutlives0: '_0: '_1,
+{
+    let _0: u32; // return
+    let _1: &'1 closure<'_0>; // arg #1
+    let tupled_args: (u32, bool); // arg #2
+    let x: u32; // local
+    let y: bool; // local
+    let _5: bool; // anonymous local
+
+    storage_live(_0)
+    storage_live(x)
+    storage_live(y)
+    x = move tupled_args.0
+    y = move tupled_args.1
+    storage_live(_5)
+    _5 = copy y
+    if move _5 {
+    } else {
+        _0 = copy (*(*_1)._0)
+        storage_dead(_5)
+        storage_dead(y)
+        storage_dead(x)
+        storage_dead(tupled_args)
+        storage_dead(_1)
+        return
+    }
+    _0 = copy x
+    storage_dead(_5)
+    storage_dead(y)
+    storage_dead(x)
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::use_closure::{impl FnMut<(u32, bool)> for closure<'_0>}::call_mut
+fn call_mut<'_0, '_1>(state: &'_1 mut closure<'_0>, args: (u32, bool)) -> u32
+where
+    RegionOutlives0: '_0: '_1,
+{
+    let _0: u32; // return
+    let state: &'_1 mut closure<'_0>; // arg #1
+    let args: (u32, bool); // arg #2
+    let _3: &'0 closure<'_0>; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &(*state)
+    _0 = call<'_0, '2>(move _3, move args)
+    ↳⚡ storage_dead(_3)
+        storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::use_closure::closure::{impl Destruct for closure<'_0>}::drop_glue
+unsafe fn drop_glue<'_0, '_1>(_1: &'_1 mut closure<'_0>)
+where
+    RegionOutlives0: '_0: '_1,
+{
+    let _0: (); // return
+    let _1: &'1 mut closure<'_0>; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::use_closure::{impl FnOnce<(u32, bool)> for closure<'_0>}::call_once
+fn call_once<'_0>(_1: closure<'_0>, _2: (u32, bool)) -> u32
+{
+    let _0: u32; // return
+    let _1: closure<'_0>; // arg #1
+    let _2: (u32, bool); // arg #2
+    let _3: &'1 mut closure<'_0>; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = call_mut<'_0, '4>(move _3, move _2)
+    ↳⚡ drop[drop_glue<'_0, '7>] _1
+        ↳⚡ storage_dead(_3)
+            storage_dead(_2)
+            storage_dead(_1)
+            unwind_terminate
+        storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    drop[drop_glue<'_0, '10>] _1
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::use_closure::{impl FnOnce<(u32, bool)> for closure<'_0>}
+impl<'_0> "impl_FnOnce_unit_for_closure" FnOnce<(u32, bool)> for closure<'_0> {
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: ((u32, bool): Sized) = {built_in impl Sized for (u32, bool)}
+    proof ImpliedClause2: ((u32, bool): Tuple) = {built_in impl Tuple for (u32, bool)}
+    proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
+    type Output = u32
+    fn call_once = call_once<'_0>
+    vtable: impl_FnOnce_unit_for_closure::{vtable}<'_0>
+}
+
+// Full name: test_crate::use_closure::{impl FnMut<(u32, bool)> for closure<'_0>}
+impl<'_0> "impl_FnMut_unit_for_closure" FnMut<(u32, bool)> for closure<'_0> {
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: (closure<'_0>: FnOnce<(u32, bool)>) = impl_FnOnce_unit_for_closure<'_0>
+    proof ImpliedClause2: ((u32, bool): Sized) = {built_in impl Sized for (u32, bool)}
+    proof ImpliedClause3: ((u32, bool): Tuple) = {built_in impl Tuple for (u32, bool)}
+    fn call_mut<'_0_1> = call_mut<'_0, '_0_1>
+    vtable: impl_FnMut_unit_for_closure::{vtable}<'_0>
+}
+
+// Full name: test_crate::use_closure::{impl Fn<(u32, bool)> for closure<'_0>}
+impl<'_0> "impl_Fn_unit_for_closure" Fn<(u32, bool)> for closure<'_0> {
+    proof ImpliedClause0: (closure<'_0>: MetaSized) = {built_in impl MetaSized for closure<'_0>}
+    proof ImpliedClause1: (closure<'_0>: FnMut<(u32, bool)>) = impl_FnMut_unit_for_closure<'_0>
+    proof ImpliedClause2: ((u32, bool): Sized) = {built_in impl Sized for (u32, bool)}
+    proof ImpliedClause3: ((u32, bool): Tuple) = {built_in impl Tuple for (u32, bool)}
+    fn call<'_0_1> = call<'_0, '_0_1>
+    vtable: impl_Fn_unit_for_closure::{vtable}<'_0>
+}
+
+// Full name: test_crate::use_closure
+fn use_closure(z: u32) -> u32
+{
+    let _0: u32; // return
+    let z: u32; // arg #1
+    let _2: closure<'1>; // anonymous local
+    let _3: &'3 u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    storage_live(_3)
+    _3 = &z
+    _2 = closure { _0: move _3 }
+    storage_dead(_3)
+    _0 = call_closure<closure<'6>>[{built_in impl Sized for closure<'6>}, impl_Fn_unit_for_closure<'6>](move _2)
+    ↳⚡ storage_dead(z)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(z)
+    return
+}
+
+// Full name: test_crate::use_closure::closure::{impl Destruct for closure<'_0>}
+impl<'_0> "impl_Destruct_for_closure" Destruct for closure<'_0> {
+    fn drop_glue<'_0_1> = drop_glue<'_0, '_0_1>
+    non-dyn-compatible
+}
+
+
+

--- a/charon/tests/ui/no-gen-tuple-structs.rs
+++ b/charon/tests/ui/no-gen-tuple-structs.rs
@@ -1,0 +1,42 @@
+//@ charon-args=--no-gen-tuple-structs
+
+fn mk_unit() -> () {
+    ()
+}
+
+fn mk_pair(x: u32, y: bool) -> (u32, bool) {
+    (x, y)
+}
+
+fn fst(p: (u32, bool)) -> u32 {
+    p.0
+}
+
+fn nested<T>(x: T, y: (u8, u8, u8)) -> (T, (u8, u8, u8)) {
+    (x, y)
+}
+
+struct Struct {
+    field: (u32, (bool, char)),
+}
+
+fn get_field(s: Struct) -> (bool, char) {
+    s.field.1
+}
+
+trait Trait {
+    type Assoc;
+}
+
+impl Trait for u32 {
+    type Assoc = (u32, u32);
+}
+
+// Closures take their arguments as a tuple.
+fn call_closure(f: impl Fn(u32, bool) -> u32) -> u32 {
+    f(0, true)
+}
+
+fn use_closure(z: u32) -> u32 {
+    call_closure(|x, y| if y { x } else { z })
+}

--- a/charon/tests/ui/no_nested_borrows.out
+++ b/charon/tests/ui/no_nested_borrows.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -26,8 +28,16 @@ pub trait Destruct<Self>
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -35,16 +45,16 @@ where
     TypeOutlives1: A: '_0,
 = <opaque>
 
-// Full name: alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
+// Full name: alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
 #[track_caller]
 #[diagnostic_item("box_new")]
-pub fn new<T>(_1: T) -> alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+pub fn new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
 where
     TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: alloc::boxed::{impl Deref for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::deref
-pub fn deref<'_0, T, A>(_1: &'_0 alloc::boxed::Box<T>[TraitClause0, TraitClause1]) -> &'_0 T
+// Full name: alloc::boxed::{impl Deref for Box<T>[TraitClause0, TraitClause1]}::deref
+pub fn deref<'_0, T, A>(_1: &'_0 Box<T>[TraitClause0, TraitClause1]) -> &'_0 T
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -52,14 +62,22 @@ where
     TypeOutlives1: A: '_0,
 = <opaque>
 
-// Full name: alloc::boxed::{impl DerefMut for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::deref_mut
-pub fn deref_mut<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1]) -> &'_0 mut T
+// Full name: alloc::boxed::{impl DerefMut for Box<T>[TraitClause0, TraitClause1]}::deref_mut
+pub fn deref_mut<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1]) -> &'_0 mut T
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
     TypeOutlives0: T: '_0,
     TypeOutlives1: A: '_0,
 = <opaque>
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
 
 // Full name: test_crate::Pair
 pub struct Pair<T1, T2>
@@ -76,7 +94,7 @@ pub enum List<T>
 where
     TraitClause0: (T: Sized),
 {
-  Cons { _0: T, _1: alloc::boxed::Box<List<T>[TraitClause0]>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}] },
+  Cons { _0: T, _1: Box<List<T>[TraitClause0]>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}] },
   Nil,
 }
 
@@ -468,7 +486,7 @@ pub fn test_list1()
 {
     let _0: (); // return
     let l: List<i32>[{built_in impl Sized for i32}]; // local
-    let _2: alloc::boxed::Box<List<i32>[{built_in impl Sized for i32}]>[{built_in impl MetaSized for List<i32>[{built_in impl Sized for i32}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _2: Box<List<i32>[{built_in impl Sized for i32}]>[{built_in impl MetaSized for List<i32>[{built_in impl Sized for i32}]}, {built_in impl Sized for Global}]; // anonymous local
     let _3: List<i32>[{built_in impl Sized for i32}]; // anonymous local
 
     storage_live(_0)
@@ -499,11 +517,11 @@ pub fn test_list1()
 pub fn test_box1()
 {
     let _0: (); // return
-    let b: alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}]; // local
+    let b: Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}]; // local
     let x_2: &'1 mut i32; // local
-    let _3: &'3 mut alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}]; // anonymous local
+    let _3: &'3 mut Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}]; // anonymous local
     let x_4: &'5 i32; // local
-    let _5: &'7 alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}]; // anonymous local
+    let _5: &'7 Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}]; // anonymous local
     let _6: bool; // anonymous local
     let _7: i32; // anonymous local
 
@@ -513,7 +531,7 @@ pub fn test_box1()
     b = new<i32>[{built_in impl Sized for i32}](const 0i32)
     ↳⚡ unwind_continue
     fake_read(b)
-    set_type(typeof(b) == alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}])
+    set_type(typeof(b) == Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}])
     storage_live(x_2)
     storage_live(_3)
     _3 = &two-phase-mut b
@@ -613,7 +631,7 @@ where
     let _0: (T, List<T>[TraitClause0]); // return
     let l: List<T>[TraitClause0]; // arg #1
     let hd: T; // local
-    let tl: alloc::boxed::Box<List<T>[TraitClause0]>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
+    let tl: Box<List<T>[TraitClause0]>[{built_in impl MetaSized for List<T>[TraitClause0]}, {built_in impl Sized for Global}]; // local
     let _4: T; // anonymous local
     let _5: List<T>[TraitClause0]; // anonymous local
 
@@ -704,7 +722,7 @@ where
     TraitClause0: (T: Sized),
 {
   Leaf { _0: T },
-  Node { _0: T, _1: NodeElem<T>[TraitClause0], _2: alloc::boxed::Box<Tree<T>[TraitClause0]>[{built_in impl MetaSized for Tree<T>[TraitClause0]}, {built_in impl Sized for Global}] },
+  Node { _0: T, _1: NodeElem<T>[TraitClause0], _2: Box<Tree<T>[TraitClause0]>[{built_in impl MetaSized for Tree<T>[TraitClause0]}, {built_in impl Sized for Global}] },
 }
 
 // Full name: test_crate::NodeElem
@@ -712,7 +730,7 @@ pub enum NodeElem<T>
 where
     TraitClause0: (T: Sized),
 {
-  Cons { _0: alloc::boxed::Box<Tree<T>[TraitClause0]>[{built_in impl MetaSized for Tree<T>[TraitClause0]}, {built_in impl Sized for Global}], _1: alloc::boxed::Box<NodeElem<T>[TraitClause0]>[{built_in impl MetaSized for NodeElem<T>[TraitClause0]}, {built_in impl Sized for Global}] },
+  Cons { _0: Box<Tree<T>[TraitClause0]>[{built_in impl MetaSized for Tree<T>[TraitClause0]}, {built_in impl Sized for Global}], _1: Box<NodeElem<T>[TraitClause0]>[{built_in impl MetaSized for NodeElem<T>[TraitClause0]}, {built_in impl Sized for Global}] },
   Nil,
 }
 

--- a/charon/tests/ui/nondiverging-intrinsics.out
+++ b/charon/tests/ui/nondiverging-intrinsics.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: core::intrinsics::assume
 #[rustc_intrinsic]
 pub unsafe fn assume(b_1: bool)

--- a/charon/tests/ui/panics.out
+++ b/charon/tests/ui/panics.out
@@ -1,5 +1,11 @@
 # Final LLBC before serialization:
 
+struct () {}
+
+struct str {
+  _0: [u8],
+}
+
 // Full name: test_crate::panic1
 fn panic1()
 {

--- a/charon/tests/ui/params.out
+++ b/charon/tests/ui/params.out
@@ -18,6 +18,14 @@ pub trait Sized<Self>
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
 // Full name: test_crate::test_static
 fn test_static(x: &'static u32) -> &'static u32
 {
@@ -57,7 +65,7 @@ where
     TypeOutlives3: T1: 'b,
 {
   V1 { _0: &'a mut T1, _1: &'b mut T2 },
-  V2 { _0: alloc::boxed::Box<E1<'a, 'b, T2, T1>[TraitClause1, TraitClause0]>[{built_in impl MetaSized for E1<'a, 'b, T2, T1>[TraitClause1, TraitClause0]}, {built_in impl Sized for Global}] },
+  V2 { _0: Box<E1<'a, 'b, T2, T1>[TraitClause1, TraitClause0]>[{built_in impl MetaSized for E1<'a, 'b, T2, T1>[TraitClause1, TraitClause0]}, {built_in impl Sized for Global}] },
 }
 
 // Full name: test_crate::E2
@@ -71,7 +79,7 @@ where
     TypeOutlives3: T2: 'a,
 {
   V1 { _0: &'a mut T1, _1: &'b mut T2 },
-  V3 { _0: alloc::boxed::Box<E2<'b, 'a, T1, T2>[TraitClause0, TraitClause1]>[{built_in impl MetaSized for E2<'b, 'a, T1, T2>[TraitClause0, TraitClause1]}, {built_in impl Sized for Global}] },
+  V3 { _0: Box<E2<'b, 'a, T1, T2>[TraitClause0, TraitClause1]>[{built_in impl MetaSized for E2<'b, 'a, T1, T2>[TraitClause0, TraitClause1]}, {built_in impl Sized for Global}] },
 }
 
 // Full name: test_crate::E3
@@ -89,8 +97,8 @@ where
     RegionOutlives1: 'b: 'c,
 {
   V1 { _0: &'a mut T1, _1: &'b mut T2 },
-  V2 { _0: alloc::boxed::Box<E3<'a, 'b, 'c, T2, T1>[TraitClause1, TraitClause0]>[{built_in impl MetaSized for E3<'a, 'b, 'c, T2, T1>[TraitClause1, TraitClause0]}, {built_in impl Sized for Global}] },
-  V3 { _0: alloc::boxed::Box<E3<'b, 'a, 'c, T1, T2>[TraitClause0, TraitClause1]>[{built_in impl MetaSized for E3<'b, 'a, 'c, T1, T2>[TraitClause0, TraitClause1]}, {built_in impl Sized for Global}] },
+  V2 { _0: Box<E3<'a, 'b, 'c, T2, T1>[TraitClause1, TraitClause0]>[{built_in impl MetaSized for E3<'a, 'b, 'c, T2, T1>[TraitClause1, TraitClause0]}, {built_in impl Sized for Global}] },
+  V3 { _0: Box<E3<'b, 'a, 'c, T1, T2>[TraitClause0, TraitClause1]>[{built_in impl MetaSized for E3<'b, 'a, 'c, T1, T2>[TraitClause0, TraitClause1]}, {built_in impl Sized for Global}] },
   V4 { _0: &'c &'a T1 },
 }
 
@@ -111,8 +119,8 @@ where
     RegionOutlives1: 'b: 'c,
 {
   V1 { _0: &'a mut T1, _1: &'b mut T2 },
-  V2 { _0: alloc::boxed::Box<E4<'a, 'b, 'c, T2, T1, T3>[TraitClause1, TraitClause0, TraitClause2]>[{built_in impl MetaSized for E4<'a, 'b, 'c, T2, T1, T3>[TraitClause1, TraitClause0, TraitClause2]}, {built_in impl Sized for Global}] },
-  V3 { _0: alloc::boxed::Box<E4<'b, 'a, 'c, T1, T2, T3>[TraitClause0, TraitClause1, TraitClause2]>[{built_in impl MetaSized for E4<'b, 'a, 'c, T1, T2, T3>[TraitClause0, TraitClause1, TraitClause2]}, {built_in impl Sized for Global}] },
+  V2 { _0: Box<E4<'a, 'b, 'c, T2, T1, T3>[TraitClause1, TraitClause0, TraitClause2]>[{built_in impl MetaSized for E4<'a, 'b, 'c, T2, T1, T3>[TraitClause1, TraitClause0, TraitClause2]}, {built_in impl Sized for Global}] },
+  V3 { _0: Box<E4<'b, 'a, 'c, T1, T2, T3>[TraitClause0, TraitClause1, TraitClause2]>[{built_in impl MetaSized for E4<'b, 'a, 'c, T1, T2, T3>[TraitClause0, TraitClause1, TraitClause2]}, {built_in impl Sized for Global}] },
   V4 { _0: &'c &'a T3 },
 }
 
@@ -133,8 +141,8 @@ where
     RegionOutlives1: 'c: 'b,
 {
   V1 { _0: &'a mut T1, _1: &'b mut T2 },
-  V2 { _0: alloc::boxed::Box<E5<'a, 'b, 'c, T2, T1, T3>[TraitClause1, TraitClause0, TraitClause2]>[{built_in impl MetaSized for E5<'a, 'b, 'c, T2, T1, T3>[TraitClause1, TraitClause0, TraitClause2]}, {built_in impl Sized for Global}] },
-  V3 { _0: alloc::boxed::Box<E5<'b, 'a, 'c, T1, T2, T3>[TraitClause0, TraitClause1, TraitClause2]>[{built_in impl MetaSized for E5<'b, 'a, 'c, T1, T2, T3>[TraitClause0, TraitClause1, TraitClause2]}, {built_in impl Sized for Global}] },
+  V2 { _0: Box<E5<'a, 'b, 'c, T2, T1, T3>[TraitClause1, TraitClause0, TraitClause2]>[{built_in impl MetaSized for E5<'a, 'b, 'c, T2, T1, T3>[TraitClause1, TraitClause0, TraitClause2]}, {built_in impl Sized for Global}] },
+  V3 { _0: Box<E5<'b, 'a, 'c, T1, T2, T3>[TraitClause0, TraitClause1, TraitClause2]>[{built_in impl MetaSized for E5<'b, 'a, 'c, T1, T2, T3>[TraitClause0, TraitClause1, TraitClause2]}, {built_in impl Sized for Global}] },
   V4 { _0: &'a &'c T3 },
 }
 

--- a/charon/tests/ui/partial-monomorphization/issue-1204-partial-mono-tuples.out
+++ b/charon/tests/ui/partial-monomorphization/issue-1204-partial-mono-tuples.out
@@ -34,6 +34,11 @@ pub trait Destruct<Self>
     non-dyn-compatible
 }
 
+struct (_, _)<A, B> {
+  _0: A,
+  _1: B,
+}
+
 #[lang_item(Destruct)]
 pub trait core::marker::Destruct::<(&_ mut _, &_ mut _)><'_0, '_1, T0, T1>
 {
@@ -82,14 +87,14 @@ where
     TypeOutlives0: T: 'a,
     TypeOutlives1: U: 'a,
 {
-    let _0: (&'4 mut T, &'5 mut U); // return
-    let x: (&'6 mut T, &'7 mut U); // arg #1
-    let _2: (&'8 mut T, &'9 mut U); // anonymous local
+    let _0: (&'8 mut T, &'9 mut U); // return
+    let x: (&'13 mut T, &'14 mut U); // arg #1
+    let _2: (&'18 mut T, &'19 mut U); // anonymous local
 
     storage_live(_0)
     storage_live(_2)
     _2 = move x
-    _0 = test_crate::id::<(&_ mut _, &_ mut _)><'14, '15, T, U>[{built_in impl core::marker::Sized::<(&_ mut _, &_ mut _)><'14, '15, U> for T}](move _2)
+    _0 = test_crate::id::<(&_ mut _, &_ mut _)><'32, '33, T, U>[{built_in impl core::marker::Sized::<(&_ mut _, &_ mut _)><'32, '33, U> for T}](move _2)
     ↳⚡ storage_dead(x)
         unwind_continue
     storage_dead(_2)

--- a/charon/tests/ui/partial-monomorphization/mono-mut-tuple.out
+++ b/charon/tests/ui/partial-monomorphization/mono-mut-tuple.out
@@ -1,0 +1,219 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait core::marker::MetaSized::<&_ mut _><'_0, T0>
+
+#[fundamental]
+#[lang_item(Sized)]
+pub trait core::marker::Sized::<&_ mut _><'_0, T0>
+{
+    proof ImpliedClause0: (T0: core::marker::MetaSized::<&_ mut _><'_0>)
+    non-dyn-compatible
+}
+
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait core::marker::MetaSized::<(&_ mut _, _)><'_0, T0, T1>
+where
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
+
+#[fundamental]
+#[lang_item(Sized)]
+pub trait core::marker::Sized::<(&_ mut _, _)><'_0, T0, T1>
+where
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
+{
+    proof ImpliedClause0: (T0: core::marker::MetaSized::<(&_ mut _, _)><'_0, T1>[TraitClause0])
+    non-dyn-compatible
+}
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+struct (_, _)::<&_ mut _, _><'_0, T0, T1>
+where
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
+{
+  _0: &'_0 mut T0,
+  _1: T1,
+}
+
+#[lang_item(Destruct)]
+pub trait core::marker::Destruct::<(&_ mut _, _)><'_0, T0, T1>
+where
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+#[lang_item(Destruct)]
+pub trait core::marker::Destruct::<&_ mut _><'_0, T0>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+// Full name: (_, _)::{impl Destruct for (A, B)}::drop_glue
+unsafe fn drop_glue<'_0, A, B>(_1: &'_0 mut (A, B))
+where
+    TraitClause0: (A: Sized),
+    TypeOutlives0: A: '_0,
+    TypeOutlives1: B: '_0,
+{
+    let _0: (); // return
+    let _1: &'1 mut (A, B); // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    drop[{built_in impl Destruct for A}::drop_glue<'2>] (*_1)._0
+    ↳⚡ drop[{built_in impl Destruct for B}::drop_glue<'4>] (*_1)._1
+        ↳⚡ storage_dead(_1)
+            unwind_terminate
+        storage_dead(_1)
+        unwind_continue
+    drop[{built_in impl Destruct for B}::drop_glue<'3>] (*_1)._1
+    ↳⚡ storage_dead(_1)
+        unwind_continue
+    storage_dead(_1)
+    return
+}
+
+// Full name: (_, _)::{impl Destruct for (A, B)}
+impl<A, B> "impl_Destruct_for_tuple" Destruct for (A, B)
+where
+    TraitClause0: (A: Sized),
+{
+    fn drop_glue<'_0_1> = drop_glue<'_0_1, A, B>[TraitClause0]
+    non-dyn-compatible
+}
+
+// Full name: (_, _)::{impl Destruct for (A, B)}::drop_glue::<_, &_ mut _, _>
+unsafe fn (_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'_0, '_1, T0, T1>(_1: &'_0 mut (&'_1 mut T0, T1))
+where
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_1>),
+    TypeOutlives0: &'_1 mut T0: '_0,
+    TypeOutlives1: T1: '_0,
+{
+    let _0: (); // return
+    let _1: &'1 mut (&'_1 mut T0, T1); // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    drop[{built_in impl core::marker::Destruct::<&_ mut _><'_1> for T0}::drop_glue<'2>] (*_1)._0
+    ↳⚡ drop[{built_in impl Destruct for T1}::drop_glue<'4>] (*_1)._1
+        ↳⚡ storage_dead(_1)
+            unwind_terminate
+        storage_dead(_1)
+        unwind_continue
+    drop[{built_in impl Destruct for T1}::drop_glue<'3>] (*_1)._1
+    ↳⚡ storage_dead(_1)
+        unwind_continue
+    storage_dead(_1)
+    return
+}
+
+// Full name: (_, _)::{impl Destruct for (A, B)}::<&_ mut _, _>
+impl<'_0, T0, T1> core::marker::Destruct::<(&_ mut _, _)><'_0, T1>[TraitClause0] for T0
+where
+    TraitClause0: (T0: core::marker::Sized::<&_ mut _><'_0>),
+{
+    fn drop_glue<'_0_1> = (_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'_0_1, '_0, T0, T1>[TraitClause0]
+    non-dyn-compatible
+}
+
+// Full name: test_crate::id
+fn id<T>(x: T) -> T
+where
+    TraitClause0: (T: Sized),
+{
+    let _0: T; // return
+    let x: T; // arg #1
+
+    storage_live(_0)
+    _0 = move x
+    conditional_drop[{built_in impl Destruct for T}::drop_glue<'0>] x
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    storage_dead(x)
+    return
+}
+
+fn test_crate::id::<(&_ mut _, _)><'_0, T0, T1>(x: (&'_0 mut T0, T1)) -> (&'_0 mut T0, T1)
+where
+    TraitClause0: (T0: core::marker::Sized::<(&_ mut _, _)><'_0, T1>[TraitClause1]),
+    TraitClause1: (T0: core::marker::Sized::<&_ mut _><'_0>),
+{
+    let _0: (&'_0 mut T0, T1); // return
+    let x: (&'_0 mut T0, T1); // arg #1
+
+    storage_live(_0)
+    _0 = move x
+    conditional_drop[{built_in impl core::marker::Destruct::<(&_ mut _, _)><'_0, T1>[TraitClause1] for T0}::drop_glue<'0>] x
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    storage_dead(x)
+    return
+}
+
+// Full name: test_crate::call
+fn call<'a, T>(x: (&'a mut u32, T)) -> (&'a mut u32, T)
+where
+    TraitClause0: (T: Sized),
+{
+    let _0: (&'6 mut u32, T); // return
+    let x: (&'10 mut u32, T); // arg #1
+    let _2: (&'14 mut u32, T); // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = move x
+    _0 = test_crate::id::<(&_ mut _, _)><'25, u32, T>[{built_in impl core::marker::Sized::<(&_ mut _, _)><'25, T>[{built_in impl core::marker::Sized::<&_ mut _><'25> for u32}] for u32}, {built_in impl core::marker::Sized::<&_ mut _><'25> for u32}](move _2)
+    ↳⚡ conditional_drop[(_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'72, '66, u32, T>[{built_in impl core::marker::Sized::<&_ mut _><'66> for u32}]] _2
+        ↳⚡ storage_dead(x)
+            unwind_terminate
+        conditional_drop[(_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'108, '102, u32, T>[{built_in impl core::marker::Sized::<&_ mut _><'102> for u32}]] x
+        ↳⚡ storage_dead(x)
+            unwind_terminate
+        storage_dead(x)
+        unwind_continue
+    storage_dead(_2)
+    conditional_drop[(_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'90, '84, u32, T>[{built_in impl core::marker::Sized::<&_ mut _><'84> for u32}]] x
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    storage_dead(x)
+    return
+}
+
+
+

--- a/charon/tests/ui/partial-monomorphization/mono-mut-tuple.rs
+++ b/charon/tests/ui/partial-monomorphization/mono-mut-tuple.rs
@@ -1,0 +1,10 @@
+//@ charon-arg=--monomorphize-mut
+//! Check pretty-printing of tuples with `--monomorphize-mut`
+
+fn id<T>(x: T) -> T {
+    x
+}
+
+fn call<'a, T>(x: (&'a mut u32, T)) -> (&'a mut u32, T) {
+    id(x)
+}

--- a/charon/tests/ui/plain-panic-str.out
+++ b/charon/tests/ui/plain-panic-str.out
@@ -1,5 +1,11 @@
 # Final LLBC before serialization:
 
+struct () {}
+
+struct str {
+  _0: [u8],
+}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/pointers-in-consts-no-warns.out
+++ b/charon/tests/ui/pointers-in-consts-no-warns.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::DISGUISED_INT
 fn DISGUISED_INT() -> *const ()
 {

--- a/charon/tests/ui/pointers-in-consts.out
+++ b/charon/tests/ui/pointers-in-consts.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::DISGUISED_INT
 fn DISGUISED_INT() -> *const ()
 {

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -67,6 +67,8 @@ impl "impl_Eq_for_u32" Eq for u32 {
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Sized
 #[fundamental]
 #[lang_item(Sized)]
@@ -237,6 +239,10 @@ impl "impl_BuildHasher_for_RandomState" BuildHasher for RandomState {
 // Full name: alloc::alloc::Global
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
+
+struct str {
+  _0: [u8],
+}
 
 // Full name: test_crate::get_or_insert
 pub fn get_or_insert<'_0>(map: &'_0 mut HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]) -> &'_0 u32

--- a/charon/tests/ui/predicates-on-late-bound-vars.out
+++ b/charon/tests/ui/predicates-on-late-bound-vars.out
@@ -76,6 +76,8 @@ where
   Some { _0: T },
 }
 
+struct () {}
+
 // Full name: core::result::Result::{impl Destruct for Result<T, E>[TraitClause0, TraitClause1]}::drop_glue
 unsafe fn drop_glue<'_0, T, E>(_1: &'_0 mut Result<T, E>[TraitClause0, TraitClause1])
 where

--- a/charon/tests/ui/projection-index-from-end.out
+++ b/charon/tests/ui/projection-index-from-end.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::slice_pattern_end
 fn slice_pattern_end<'_0>(x: &'_0 [()])
 {

--- a/charon/tests/ui/ptr-offset.out
+++ b/charon/tests/ui/ptr-offset.out
@@ -1,9 +1,5 @@
 # Final LLBC before serialization:
 
-// Full name: core::ptr::const_ptr::{*const T}::addr
-pub fn addr<T>(_1: *const T) -> usize
-= <opaque>
-
 // Full name: core::marker::MetaSized
 #[fundamental]
 #[lang_item(MetaSized)]
@@ -17,6 +13,20 @@ pub trait Sized<Self>
     proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
 }
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct () {}
+
+// Full name: core::ptr::const_ptr::{*const T}::addr
+pub fn addr<T>(_1: *const T) -> usize
+= <opaque>
 
 // Full name: core::option::Option
 #[lang_item(Option)]
@@ -107,7 +117,7 @@ fn runtime(this: *const (), count: isize, size: usize) -> bool
     storage_dead(_13)
     storage_dead(_11)
     storage_live(overflow)
-    overflow = copy _10.1
+    overflow = copy _10._1
     storage_dead(_10)
     storage_live(_14)
     _14 = copy overflow
@@ -137,6 +147,20 @@ pub fn panic_nounwind_fmt<'_0>(_1: Arguments<'_0>, _2: bool) -> !
 fn check_language_ub() -> bool
 = <opaque>
 
+struct str {
+  _0: [u8],
+}
+
+struct (_, _, _)<A, B, C>
+where
+    TraitClause0: (A: Sized),
+    TraitClause1: (B: Sized),
+{
+  _0: A,
+  _1: B,
+  _2: C,
+}
+
 // Full name: core::ptr::const_ptr::{*const T}::offset::runtime_offset_nowrap
 fn runtime_offset_nowrap(this: *const (), count: isize, size: usize) -> bool
 {
@@ -161,7 +185,7 @@ fn runtime_offset_nowrap(this: *const (), count: isize, size: usize) -> bool
     storage_dead(_7)
     storage_dead(_6)
     storage_dead(_5)
-    _0 = runtime(move _4.0, move _4.1, move _4.2)
+    _0 = runtime(move _4._0, move _4._1, move _4._2)
     ↳⚡ storage_dead(size)
         storage_dead(count)
         storage_dead(this)

--- a/charon/tests/ui/ptr_no_provenance.out
+++ b/charon/tests/ui/ptr_no_provenance.out
@@ -80,6 +80,8 @@ pub trait Ord<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::cmp::impls::{impl PartialEq<()> for ()}::eq
 pub fn eq<'_0, '_1>(_1: &'_0 (), _2: &'_1 ()) -> bool
 = <opaque>
@@ -248,6 +250,10 @@ where
     storage_dead(_2)
     storage_dead(_1)
     return
+}
+
+struct str {
+  _0: [u8],
 }
 
 // Full name: test_crate::main

--- a/charon/tests/ui/quantified-clause.out
+++ b/charon/tests/ui/quantified-clause.out
@@ -73,6 +73,8 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -126,6 +128,18 @@ where
 {
   Ok { _0: T },
   Err { _0: E },
+}
+
+struct (_,)<A> {
+  _0: A,
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
 }
 
 // Full name: test_crate::foo

--- a/charon/tests/ui/raw-boxes.out
+++ b/charon/tests/ui/raw-boxes.out
@@ -3,6 +3,8 @@
 // Full name: core::alloc::AllocError
 pub struct AllocError {}
 
+struct () {}
+
 // Full name: core::result::Result
 #[diagnostic_item("Result")]
 pub enum Result<T, E>
@@ -166,6 +168,10 @@ where
     ↳⚡ unwind_continue
     storage_dead(_2)
     return
+}
+
+struct str {
+  _0: [u8],
 }
 
 #[track_caller]
@@ -1761,6 +1767,10 @@ where
     return
 }
 
+struct (_,)<A> {
+  _0: A,
+}
+
 #[diagnostic_item("ptr_const_is_null")]
 pub fn core::ptr::const_ptr::{*const T}::is_null<T>(self: *const T) -> bool
 {
@@ -1782,7 +1792,7 @@ pub fn core::ptr::const_ptr::{*const T}::is_null<T>(self: *const T) -> bool
     _5 = copy ptr
     _4 = (move _5,)
     storage_dead(_5)
-    _0 = runtime(move _4.0)
+    _0 = runtime(move _4._0)
     ↳⚡ unwind_continue
     storage_dead(_4)
     storage_dead(ptr)
@@ -2371,6 +2381,14 @@ where
     return
 }
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: alloc::boxed::{Box<T, A>[TraitClause0, TraitClause1, TraitClause2]}::into_raw_with_allocator
 pub fn into_raw_with_allocator<T, A>(b_1: Box<T, A>[TraitClause0, TraitClause1, TraitClause2]) -> (*mut T, A)
 where
@@ -2474,9 +2492,9 @@ where
     ↳⚡ unwind_continue
     storage_dead(_6)
     storage_live(ptr)
-    ptr = copy _5.0
+    ptr = copy _5._0
     storage_live(alloc)
-    alloc = move _5.1
+    alloc = move _5._1
     storage_dead(_5)
     storage_live(_7)
     storage_live(_8)

--- a/charon/tests/ui/reconstruct_early_return.out
+++ b/charon/tests/ui/reconstruct_early_return.out
@@ -1,5 +1,29 @@
 # Final LLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::f
 fn f() -> usize
 {

--- a/charon/tests/ui/region-inference-vars.out
+++ b/charon/tests/ui/region-inference-vars.out
@@ -25,6 +25,8 @@ where
   Err { _0: E },
 }
 
+struct () {}
+
 // Full name: test_crate::MyTryFrom
 pub trait MyTryFrom<Self, T>
 {

--- a/charon/tests/ui/regressions/invalid-reconstruct-assert.out
+++ b/charon/tests/ui/regressions/invalid-reconstruct-assert.out
@@ -12,6 +12,8 @@ pub enum Ordering {
 pub fn cmp<'_0, '_1>(_1: &'_0 u32, _2: &'_1 u32) -> Ordering
 = <opaque>
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -91,6 +93,10 @@ where
 {
   Ok { _0: T },
   Err { _0: E },
+}
+
+struct (_,)<A> {
+  _0: A,
 }
 
 #[track_caller]
@@ -314,7 +320,7 @@ where
         _15 = &(*_29);
         storage_dead(_29);
         _14 = (copy _15,);
-        cmp_12 = TraitClause2::call_mut<'19>(move _13, move _14) -> bb16 (unwind: bb15);
+        cmp_12 = TraitClause2::call_mut<'20>(move _13, move _14) -> bb16 (unwind: bb15);
     }
 
     bb14: {
@@ -322,7 +328,7 @@ where
     }
 
     bb15: {
-        drop[TraitClause3::drop_glue<'24>] f -> bb22 (unwind: bb23);
+        drop[TraitClause3::drop_glue<'26>] f -> bb22 (unwind: bb23);
     }
 
     bb16: {
@@ -353,7 +359,7 @@ where
         storage_dead(_35);
         storage_dead(index);
         _20 = (copy _21,);
-        cmp_18 = TraitClause2::call_mut<'23>(move _19, move _20) -> bb21 (unwind: bb15);
+        cmp_18 = TraitClause2::call_mut<'25>(move _19, move _20) -> bb21 (unwind: bb15);
     }
 
     bb20: {
@@ -487,7 +493,7 @@ where
     bb34: {
         storage_dead(cmp_18);
         storage_dead(size);
-        drop[TraitClause3::drop_glue<'25>] f -> bb40 (unwind: bb38);
+        drop[TraitClause3::drop_glue<'27>] f -> bb40 (unwind: bb38);
     }
 
     bb35: {
@@ -626,7 +632,7 @@ fn call_mut<'_0, '_1>(_1: &'_1 mut closure, tupled_args: (&'_0 u32,)) -> Orderin
         storage_live(_0);
         storage_live(x);
         storage_live(_7);
-        x = move tupled_args.0;
+        x = move tupled_args._0;
         storage_live(_4);
         _4 = &(*x);
         storage_live(_5);

--- a/charon/tests/ui/regressions/issue-1010-missing-lifetime.out
+++ b/charon/tests/ui/regressions/issue-1010-missing-lifetime.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -71,6 +73,10 @@ pub trait Fn<Self, Args>
     vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: test_crate::make_early
 fn make_early<'a, T>(_1: fn(&'a T))
 where
@@ -112,7 +118,7 @@ fn {impl Fn<(&'_ u16,)> for test_crate::main::closure#1}::call<'_0, '_1>(_1: &'_
     storage_live(_0)
     storage_live(_3)
     _0 = ()
-    _3 = move tupled_args.0
+    _3 = move tupled_args._0
     _0 = ()
     storage_dead(_3)
     storage_dead(tupled_args)
@@ -254,7 +260,7 @@ fn {impl Fn<(&'_ u8,)> for test_crate::main::closure}::call<'_0, '_1>(_1: &'_1 t
     storage_live(_0)
     storage_live(_3)
     _0 = ()
-    _3 = move tupled_args.0
+    _3 = move tupled_args._0
     _0 = ()
     storage_dead(_3)
     storage_dead(tupled_args)

--- a/charon/tests/ui/regressions/issue-1067-filename-ice.out
+++ b/charon/tests/ui/regressions/issue-1067-filename-ice.out
@@ -33,6 +33,8 @@ where
   Err { _0: E },
 }
 
+struct () {}
+
 // Full name: core::result::Result::{impl Destruct for Result<T, E>[TraitClause0, TraitClause1]}::drop_glue
 unsafe fn impl_Destruct_for_Result::drop_glue<'_0, T, E>(_1: &'_0 mut Result<T, E>[TraitClause0, TraitClause1])
 where

--- a/charon/tests/ui/regressions/issue-1073-out-of-bounds-body-region.out
+++ b/charon/tests/ui/regressions/issue-1073-out-of-bounds-body-region.out
@@ -3,6 +3,8 @@
 // Full name: core::io::io_slice::IoSlice
 pub opaque type IoSlice<'a>
 
+struct () {}
+
 // Full name: core::io::io_slice::{IoSlice<'a>}::advance_slices
 pub fn advance_slices<'a, '_1, '_2>(_1: &'_1 mut &'_2 mut [IoSlice<'a>], _2: usize)
 where

--- a/charon/tests/ui/regressions/issue-1294-remove-clause-underflow.out
+++ b/charon/tests/ui/regressions/issue-1294-remove-clause-underflow.out
@@ -24,6 +24,8 @@ pub trait Clone<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Trait
 trait Trait<Self>
 {

--- a/charon/tests/ui/regressions/issue-1296-exclude-needed-builtin-ty.out
+++ b/charon/tests/ui/regressions/issue-1296-exclude-needed-builtin-ty.out
@@ -1,16 +1,18 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::main
 fn main()
 {
     let _0: (); // return
     let _1: Vec<i32>[{built_in impl Sized for i32}, {built_in impl Sized for Global}]; // anonymous local
-    let _2: alloc::boxed::Box<MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
-    let _3: alloc::boxed::Box<MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _2: Box<MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _3: Box<MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let ret: Vec<i32>[{built_in impl Sized for i32}, {built_in impl Sized for Global}]; // local
-    let b: alloc::boxed::Box<MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]}, {built_in impl Sized for Global}]; // local
-    let x: alloc::boxed::Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}]; // local
-    let y: alloc::boxed::Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]; // local
+    let b: Box<MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]}, {built_in impl Sized for Global}]; // local
+    let x: Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}]; // local
+    let y: Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]; // local
 
     storage_live(_0)
     _0 = ()
@@ -40,7 +42,7 @@ fn main()
         ↳⚡ storage_dead(ret)
             unwind_terminate
         unwind_continue
-    y = unsize_cast<alloc::boxed::Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 1usize>(move x)
+    y = unsize_cast<Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}], Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 1usize>(move x)
     ret = into_vec<i32, Global>[{built_in impl Sized for i32}, {built_in impl Sized for Global}](move y)
     ↳⚡ storage_dead(y)
         storage_dead(x)

--- a/charon/tests/ui/regressions/issue-1297-box-new-allocator-ty.out
+++ b/charon/tests/ui/regressions/issue-1297-box-new-allocator-ty.out
@@ -24,8 +24,18 @@ where
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+struct () {}
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -33,10 +43,10 @@ where
     TypeOutlives1: A: '_0,
 = <opaque>
 
-// Full name: alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
+// Full name: alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
 #[track_caller]
 #[diagnostic_item("box_new")]
-pub fn new<T>(_1: T) -> alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+pub fn new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
 where
     TraitClause0: (T: Sized),
 = <opaque>
@@ -49,7 +59,7 @@ where
     TraitClause1: (type_error("removed allocator parameter"): Sized),
 
 // Full name: alloc::slice::{[T]}::into_vec
-pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
+pub fn into_vec<T, A>(_1: Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (A: Sized),
@@ -69,12 +79,12 @@ fn main()
 {
     let _0: (); // return
     let _1: Vec<i32>[{built_in impl Sized for i32}, {built_in impl Sized for Global}]; // anonymous local
-    let _2: alloc::boxed::Box<MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _2: Box<MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[i32; 1usize]>[{built_in impl Sized for [i32; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let ret: Vec<i32>[{built_in impl Sized for i32}, {built_in impl Sized for Global}]; // local
-    let x: alloc::boxed::Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}]; // local
-    let y: alloc::boxed::Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]; // local
+    let x: Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}]; // local
+    let y: Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]; // local
     let _6: [i32; 1usize]; // anonymous local
-    let _7: alloc::boxed::Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _7: Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -94,7 +104,7 @@ fn main()
     storage_dead(_6)
     x = move _7
     storage_dead(_7)
-    y = unsize_cast<alloc::boxed::Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 1usize>(move x)
+    y = unsize_cast<Box<[i32; 1usize]>[{built_in impl MetaSized for [i32; 1usize]}, {built_in impl Sized for Global}], Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 1usize>(move x)
     ret = into_vec<i32, Global>[{built_in impl Sized for i32}, {built_in impl Sized for Global}](move y)
     ↳⚡ storage_dead(y)
         storage_dead(x)

--- a/charon/tests/ui/regressions/issue-393-vec-with-control-flow.out
+++ b/charon/tests/ui/regressions/issue-393-vec-with-control-flow.out
@@ -35,8 +35,16 @@ where
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -44,15 +52,15 @@ where
     TypeOutlives1: A: '_0,
 = <opaque>
 
-// Full name: alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new_uninit
+// Full name: alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new_uninit
 #[track_caller]
-pub fn new_uninit<T>() -> alloc::boxed::Box<MaybeUninit<T>[TraitClause0]>[{built_in impl MetaSized for MaybeUninit<T>[TraitClause0]}, {built_in impl Sized for Global}]
+pub fn new_uninit<T>() -> Box<MaybeUninit<T>[TraitClause0]>[{built_in impl MetaSized for MaybeUninit<T>[TraitClause0]}, {built_in impl Sized for Global}]
 where
     TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: alloc::boxed::{alloc::boxed::Box<MaybeUninit<T>[TraitClause0]>[{built_in impl MetaSized for MaybeUninit<T>[TraitClause0]}, TraitClause1]}::write
-pub fn write<T, A>(_1: alloc::boxed::Box<MaybeUninit<T>[TraitClause0]>[{built_in impl MetaSized for MaybeUninit<T>[TraitClause0]}, TraitClause1], _2: T) -> alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, TraitClause1]
+// Full name: alloc::boxed::{Box<MaybeUninit<T>[TraitClause0]>[{built_in impl MetaSized for MaybeUninit<T>[TraitClause0]}, TraitClause1]}::write
+pub fn write<T, A>(_1: Box<MaybeUninit<T>[TraitClause0]>[{built_in impl MetaSized for MaybeUninit<T>[TraitClause0]}, TraitClause1], _2: T) -> Box<T>[TraitClause0::ImpliedClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (A: Sized),
@@ -66,7 +74,7 @@ where
     TraitClause1: (type_error("removed allocator parameter"): Sized),
 
 // Full name: alloc::slice::{[T]}::into_vec
-pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
+pub fn into_vec<T, A>(_1: Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (A: Sized),
@@ -87,16 +95,16 @@ pub fn next(b: bool) -> Option<Vec<u8>[{built_in impl Sized for u8}, {built_in i
     let _0: Option<Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]>[{built_in impl Sized for Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]}]; // return
     let b: bool; // arg #1
     let vec: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // local
-    let _3: alloc::boxed::Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
-    let _4: alloc::boxed::Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _3: Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _4: Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let _5: u8; // anonymous local
     let _6: bool; // anonymous local
     let _7: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // anonymous local
     let ret: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // local
-    let x: alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // local
-    let y: alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
+    let x: Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // local
+    let y: Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
     let _11: [u8; 1usize]; // anonymous local
-    let _12: alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _12: Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
 
     storage_live(_0)
     storage_live(vec)
@@ -143,7 +151,7 @@ pub fn next(b: bool) -> Option<Vec<u8>[{built_in impl Sized for u8}, {built_in i
     storage_dead(_11)
     x = move _12
     storage_dead(_12)
-    y = unsize_cast<alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 1usize>(move x)
+    y = unsize_cast<Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}], Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 1usize>(move x)
     ret = into_vec<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}](move y)
     ↳⚡ storage_dead(y)
         storage_dead(x)

--- a/charon/tests/ui/regressions/issue-792-trait-ref-panic-when-tracing.out
+++ b/charon/tests/ui/regressions/issue-792-trait-ref-panic-when-tracing.out
@@ -14,6 +14,16 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::Internal
 trait Internal<Self>
 {

--- a/charon/tests/ui/regressions/reconstruct-fallible.out
+++ b/charon/tests/ui/regressions/reconstruct-fallible.out
@@ -1,5 +1,12 @@
 # Final LLBC before serialization:
 
+struct () {}
+
+struct (_, _)::<usize, bool> {
+  _0: usize,
+  _1: bool,
+}
+
 // Full name: test_crate::other
 fn other()
 {
@@ -98,7 +105,7 @@ fn can_erase_check()
     storage_dead(_2)
     storage_live(_3)
     storage_live(_4)
-    _4 = copy z.0
+    _4 = copy z._0
     _3 = sink_int(move _4)
     ↳⚡ unwind_continue
     storage_dead(_4)
@@ -127,7 +134,7 @@ fn must_preserve_overflow_flag()
     storage_dead(_2)
     storage_live(_3)
     storage_live(_4)
-    _4 = copy z.1
+    _4 = copy z._1
     _3 = sink_bool(move _4)
     ↳⚡ unwind_continue
     storage_dead(_4)
@@ -154,7 +161,7 @@ fn mixed_field0_and_cross_block_tuple()
     z = const 0usize checked.+ const 0usize
     storage_live(_2)
     storage_live(_3)
-    _3 = copy z.0
+    _3 = copy z._0
     _2 = sink_int(move _3)
     ↳⚡ unwind_continue
     storage_dead(_3)
@@ -197,7 +204,7 @@ fn can_erase_check_multi_block()
     storage_dead(_2)
     storage_live(_3)
     storage_live(_4)
-    _4 = copy z.0
+    _4 = copy z._0
     _3 = sink_int(move _4)
     ↳⚡ unwind_continue
     storage_dead(_4)
@@ -208,7 +215,7 @@ fn can_erase_check_multi_block()
     storage_dead(_5)
     storage_live(_6)
     storage_live(_7)
-    _7 = copy z.0
+    _7 = copy z._0
     _6 = sink_int(move _7)
     ↳⚡ unwind_continue
     storage_dead(_7)

--- a/charon/tests/ui/remove-dynamic-checks.out
+++ b/charon/tests/ui/remove-dynamic-checks.out
@@ -1,5 +1,29 @@
 # Final LLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::neg_test
 pub fn neg_test(x: i32) -> i32
 {

--- a/charon/tests/ui/rename_attribute.out
+++ b/charon/tests/ui/rename_attribute.out
@@ -14,6 +14,14 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::BoolTrait
 #[charon::rename("BoolTest")]
 pub trait BoolTrait<Self>

--- a/charon/tests/ui/result-unwrap.out
+++ b/charon/tests/ui/result-unwrap.out
@@ -33,6 +33,10 @@ where
   Err { _0: E },
 }
 
+struct str {
+  _0: [u8],
+}
+
 // Full name: core::result::unwrap_failed
 #[track_caller]
 fn unwrap_failed<'_0, '_1>(_1: &'_0 str, _2: &'_1 (dyn Debug + '_1)) -> !

--- a/charon/tests/ui/rust-name-matcher-tests.out
+++ b/charon/tests/ui/rust-name-matcher-tests.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -36,6 +38,18 @@ where
 // Full name: alloc::alloc::Global
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
+
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+struct str {
+  _0: [u8],
+}
 
 // Full name: test_crate::foo::bar
 #[pattern::fail("test_crate::foo::bar::_")]
@@ -72,7 +86,7 @@ trait Trait<Self, T>
     non-dyn-compatible
 }
 
-// Full name: test_crate::{impl Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::method
+// Full name: test_crate::{impl Trait<Option<T>[TraitClause0]> for Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::method
 #[pattern::pass("test_crate::{impl test_crate::Trait<_> for _}::method")]
 #[pattern::pass("{impl test_crate::Trait<_> for _}::method")]
 #[pattern::pass("test_crate::{impl test_crate::Trait<_> for _}::_")]
@@ -92,12 +106,12 @@ where
     return
 }
 
-// Full name: test_crate::{impl Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}
-impl<T> "impl_Trait_Option_for_Box_Global" Trait<Option<T>[TraitClause0]> for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+// Full name: test_crate::{impl Trait<Option<T>[TraitClause0]> for Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}
+impl<T> "impl_Trait_Option_for_Box_Global" Trait<Option<T>[TraitClause0]> for Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
 where
     TraitClause0: (T: Sized),
 {
-    proof ImpliedClause0: (alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]: MetaSized) = {built_in impl MetaSized for alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}
+    proof ImpliedClause0: (Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]: MetaSized) = {built_in impl MetaSized for Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}
     proof ImpliedClause1: (Option<T>[TraitClause0]: Sized) = {built_in impl Sized for Option<T>[TraitClause0]}
     fn method<U, TraitClause0_1: (U: Sized)> = impl_Trait_Option_for_Box_Global::method<T, U>[TraitClause0, TraitClause0_1]
     non-dyn-compatible

--- a/charon/tests/ui/rvalues.out
+++ b/charon/tests/ui/rvalues.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -97,6 +99,18 @@ pub trait Fn<Self, Args>
     proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1>;
     vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct (_,)<A> {
+  _0: A,
 }
 
 // Full name: test_crate::addr_of
@@ -298,7 +312,7 @@ fn call<'_0>(_1: &'_0 closure, tupled_args: (u8,))
     storage_live(_0)
     storage_live(_3)
     _0 = ()
-    _3 = move tupled_args.0
+    _3 = move tupled_args._0
     _0 = ()
     storage_dead(_3)
     storage_dead(tupled_args)

--- a/charon/tests/ui/scopes.out
+++ b/charon/tests/ui/scopes.out
@@ -5,6 +5,8 @@
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct () {}
+
 // Full name: test_crate::Trait
 trait Trait<'a, Self>
 {

--- a/charon/tests/ui/send_bound.out
+++ b/charon/tests/ui/send_bound.out
@@ -18,6 +18,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple-cmp.out
+++ b/charon/tests/ui/simple-cmp.out
@@ -12,6 +12,8 @@ pub enum Ordering {
 pub fn cmp<'_0, '_1>(_1: &'_0 i32, _2: &'_1 i32) -> Ordering
 = <opaque>
 
+struct () {}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/simple/addition.out
+++ b/charon/tests/ui/simple/addition.out
@@ -1,5 +1,29 @@
 # Final LLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/simple/additions.out
+++ b/charon/tests/ui/simple/additions.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -191,6 +193,14 @@ pub fn wrapping_add(self: u8, rhs: u8) -> u8
     return
 }
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: core::num::{u8}::overflowing_add
 pub fn overflowing_add(self: u8, rhs: u8) -> (u8, bool)
 {
@@ -215,9 +225,9 @@ pub fn overflowing_add(self: u8, rhs: u8) -> (u8, bool)
     storage_dead(_7)
     storage_dead(_6)
     storage_live(a)
-    a = copy _5.0
+    a = copy _5._0
     storage_live(b)
-    b = copy _5.1
+    b = copy _5._1
     storage_dead(_5)
     storage_live(_8)
     _8 = copy a

--- a/charon/tests/ui/simple/alias-ty-missing-hrtb.out
+++ b/charon/tests/ui/simple/alias-ty-missing-hrtb.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::HasLifetimeAssoc
 pub trait HasLifetimeAssoc<'a, Self>
 {

--- a/charon/tests/ui/simple/basic-mono.out
+++ b/charon/tests/ui/simple/basic-mono.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::foo::<10usize>
 fn foo::<10usize>()
 {

--- a/charon/tests/ui/simple/box-deref-elaborated.out
+++ b/charon/tests/ui/simple/box-deref-elaborated.out
@@ -18,8 +18,18 @@ pub trait Sized<Self>
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+struct () {}
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -27,8 +37,8 @@ where
     TypeOutlives1: A: '_0,
 = <opaque>
 
-// Full name: alloc::boxed::{impl Drop for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop
-pub fn impl_Drop_for_Box::drop<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::{impl Drop for Box<T>[TraitClause0, TraitClause1]}::drop
+pub fn impl_Drop_for_Box::drop<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -45,11 +55,11 @@ unsafe fn impl_Destruct_for_String::drop_glue<'_0>(_1: &'_0 mut String)
 = <opaque>
 
 // Full name: test_crate::into_inner
-fn into_inner(b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]) -> String
+fn into_inner(b: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]) -> String
 {
     let _0: String; // return
-    let b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
-    let _2: &'1 mut alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
+    let b: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
+    let _2: &'1 mut Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
     let _3: (); // anonymous local
 
     storage_live(_0)
@@ -69,10 +79,10 @@ fn into_inner(b: alloc::boxed::Box<String>[{built_in impl MetaSized for String},
 }
 
 // Full name: test_crate::write
-fn write(b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], s: String)
+fn write(b: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], s: String)
 {
     let _0: (); // return
-    let b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
+    let b: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
     let s: String; // arg #2
     let _3: String; // anonymous local
 
@@ -102,10 +112,10 @@ fn write(b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {bui
 }
 
 // Full name: test_crate::borrow
-fn borrow(b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}])
+fn borrow(b: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}])
 {
     let _0: (); // return
-    let b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
+    let b: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
     let _2: &'1 mut String; // anonymous local
 
     storage_live(_0)
@@ -122,13 +132,13 @@ fn borrow(b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {bu
 }
 
 // Full name: test_crate::reborrow
-fn reborrow<'_0>(b: &'_0 mut alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]) -> &'_0 mut String
+fn reborrow<'_0>(b: &'_0 mut Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]) -> &'_0 mut String
 {
     let _0: &'1 mut String; // return
-    let b: &'3 mut alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
+    let b: &'3 mut Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
     let _2: &'4 mut String; // anonymous local
-    let _3: &'5 mut alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
-    let _4: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
+    let _3: &'5 mut Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
+    let _4: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
 
     storage_live(_0)
     storage_live(_4)
@@ -152,11 +162,11 @@ struct Struct {
 }
 
 // Full name: test_crate::field
-fn field(b: alloc::boxed::Box<Struct>[{built_in impl MetaSized for Struct}, {built_in impl Sized for Global}]) -> String
+fn field(b: Box<Struct>[{built_in impl MetaSized for Struct}, {built_in impl Sized for Global}]) -> String
 {
     let _0: String; // return
-    let b: alloc::boxed::Box<Struct>[{built_in impl MetaSized for Struct}, {built_in impl Sized for Global}]; // arg #1
-    let _2: &'1 mut alloc::boxed::Box<Struct>[{built_in impl MetaSized for Struct}, {built_in impl Sized for Global}]; // anonymous local
+    let b: Box<Struct>[{built_in impl MetaSized for Struct}, {built_in impl Sized for Global}]; // arg #1
+    let _2: &'1 mut Box<Struct>[{built_in impl MetaSized for Struct}, {built_in impl Sized for Global}]; // anonymous local
     let _3: (); // anonymous local
 
     storage_live(_0)

--- a/charon/tests/ui/simple/box-deref-optimized.out
+++ b/charon/tests/ui/simple/box-deref-optimized.out
@@ -18,8 +18,18 @@ pub trait Sized<Self>
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+struct () {}
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -27,8 +37,8 @@ where
     TypeOutlives1: A: '_0,
 = <opaque>
 
-// Full name: alloc::boxed::{impl Drop for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop
-pub fn impl_Drop_for_Box::drop<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::{impl Drop for Box<T>[TraitClause0, TraitClause1]}::drop
+pub fn impl_Drop_for_Box::drop<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -45,11 +55,11 @@ unsafe fn impl_Destruct_for_String::drop_glue<'_0>(_1: &'_0 mut String)
 = <opaque>
 
 // Full name: test_crate::into_inner
-fn into_inner(b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]) -> String
+fn into_inner(b: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]) -> String
 {
     let _0: String; // return
-    let b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
-    let _2: &'1 mut alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
+    let b: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
+    let _2: &'1 mut Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
     let _3: (); // anonymous local
 
     storage_live(_0)
@@ -69,10 +79,10 @@ fn into_inner(b: alloc::boxed::Box<String>[{built_in impl MetaSized for String},
 }
 
 // Full name: test_crate::write
-fn write(b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], s: String)
+fn write(b: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], s: String)
 {
     let _0: (); // return
-    let b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
+    let b: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
     let s: String; // arg #2
     let _3: String; // anonymous local
 
@@ -102,10 +112,10 @@ fn write(b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {bui
 }
 
 // Full name: test_crate::borrow
-fn borrow(b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}])
+fn borrow(b: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}])
 {
     let _0: (); // return
-    let b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
+    let b: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
     let _2: &'1 mut String; // anonymous local
 
     storage_live(_0)
@@ -122,13 +132,13 @@ fn borrow(b: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {bu
 }
 
 // Full name: test_crate::reborrow
-fn reborrow<'_0>(b: &'_0 mut alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]) -> &'_0 mut String
+fn reborrow<'_0>(b: &'_0 mut Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]) -> &'_0 mut String
 {
     let _0: &'1 mut String; // return
-    let b: &'3 mut alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
+    let b: &'3 mut Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // arg #1
     let _2: &'4 mut String; // anonymous local
-    let _3: &'5 mut alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
-    let _4: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
+    let _3: &'5 mut Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
+    let _4: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
 
     storage_live(_0)
     storage_live(_4)
@@ -152,11 +162,11 @@ struct Struct {
 }
 
 // Full name: test_crate::field
-fn field(b: alloc::boxed::Box<Struct>[{built_in impl MetaSized for Struct}, {built_in impl Sized for Global}]) -> String
+fn field(b: Box<Struct>[{built_in impl MetaSized for Struct}, {built_in impl Sized for Global}]) -> String
 {
     let _0: String; // return
-    let b: alloc::boxed::Box<Struct>[{built_in impl MetaSized for Struct}, {built_in impl Sized for Global}]; // arg #1
-    let _2: &'1 mut alloc::boxed::Box<Struct>[{built_in impl MetaSized for Struct}, {built_in impl Sized for Global}]; // anonymous local
+    let b: Box<Struct>[{built_in impl MetaSized for Struct}, {built_in impl Sized for Global}]; // arg #1
+    let _2: &'1 mut Box<Struct>[{built_in impl MetaSized for Struct}, {built_in impl Sized for Global}]; // anonymous local
     let _3: (); // anonymous local
 
     storage_live(_0)

--- a/charon/tests/ui/simple/box-new.out
+++ b/charon/tests/ui/simple/box-new.out
@@ -7,6 +7,8 @@ pub opaque type Layout
 // Full name: core::alloc::AllocError
 pub struct AllocError {}
 
+struct () {}
+
 // Full name: core::marker::MetaSized
 #[fundamental]
 #[lang_item(MetaSized)]

--- a/charon/tests/ui/simple/builtin-drop-mono.out
+++ b/charon/tests/ui/simple/builtin-drop-mono.out
@@ -1,21 +1,6 @@
 # Final LLBC before serialization:
 
-// Full name: core::marker::MetaSized::{vtable}
-opaque type {vtable}
-
-// Full name: core::marker::MetaSized
-#[fundamental]
-#[lang_item(MetaSized)]
-pub trait MetaSized<Self>
-
-// Full name: core::marker::Sized
-#[fundamental]
-#[lang_item(Sized)]
-pub trait Sized<Self>
-{
-    proof ImpliedClause0: (Self: MetaSized)
-    non-dyn-compatible
-}
+struct () {}
 
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
@@ -33,7 +18,7 @@ pub opaque type String
 unsafe fn impl_Destruct_for_String::drop_glue<'_0>(_1: &'_0 mut String)
 = <opaque>
 
-// Full name: test_crate::<slice>::{impl Destruct for [String]}::drop_glue::<String>
+// Full name: {impl Destruct for [String]}::drop_glue::<String>
 unsafe fn impl_Destruct_for_slice::drop_glue::<String><'_0>(_1: &'_0 mut [String])
 {
     let _0: (); // return
@@ -140,31 +125,16 @@ unsafe fn core::ptr::drop_glue::<[String]><'_0>(_1: &'_0 mut [String])
     return
 }
 
-// Full name: alloc::alloc::Global
-#[lang_item(GlobalAlloc)]
-pub struct Global {}
+// Full name: alloc::boxed::Box::<[String]>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<[String], Global>
 
-// Full name: alloc::alloc::Global::{impl Destruct for Global}::drop_glue
-unsafe fn impl_Destruct_for_Global::drop_glue<'_0>(_1: &'_0 mut Global)
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<[String], Global>}::drop_glue::<[String], Global>
+unsafe fn {impl Destruct for Box::<[String], Global>}::drop_glue::<[String], Global><'_0>(_1: &'_0 mut Box::<[String], Global>)
 = <opaque>
 
-// Full name: alloc::alloc::Global::{impl Destruct for Global}
-impl "impl_Destruct_for_Global" Destruct for Global {
-    fn drop_glue<'_0_1> = impl_Destruct_for_Global::drop_glue<'_0_1>
-    non-dyn-compatible
-}
-
-// Full name: test_crate::<slice>::{impl Destruct for [String]}
-impl "impl_Destruct_for_slice" Destruct for [String] {
-    fn drop_glue<'_0_1> = impl_Destruct_for_slice::drop_glue::<String><'_0_1>
-    non-dyn-compatible
-}
-
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<[String]>[{built_in impl MetaSized for [String]}, {built_in impl Sized for Global}, impl_Destruct_for_slice, impl_Destruct_for_Global]}::drop_glue::<[String], Global>
-unsafe fn impl_Destruct_for_Box_slice_Global::drop_glue::<[String], Global><'_0>(_1: &'_0 mut alloc::boxed::Box<[String]>[{built_in impl MetaSized for [String]}, {built_in impl Sized for Global}, impl_Destruct_for_slice, impl_Destruct_for_Global])
-= <opaque>
-
-// Full name: test_crate::<array>::{impl Destruct for [String; 4usize]}::drop_glue::<String, 4usize>
+// Full name: {impl Destruct for [String; 4usize]}::drop_glue::<String, 4usize>
 unsafe fn impl_Destruct_for_array::drop_glue::<String, 4usize><'_0>(_1: &'_0 mut [String; 4usize])
 {
     let _0: (); // return
@@ -185,36 +155,47 @@ unsafe fn impl_Destruct_for_array::drop_glue::<String, 4usize><'_0>(_1: &'_0 mut
     return
 }
 
-// Full name: test_crate::<array>::{impl Destruct for [String; 4usize]}
+// Full name: {impl Destruct for [String; 4usize]}
 impl "impl_Destruct_for_array" Destruct for [String; 4usize] {
     fn drop_glue<'_0_1> = impl_Destruct_for_array::drop_glue::<String, 4usize><'_0_1>
     non-dyn-compatible
 }
 
-// Full name: test_crate::<tuple_2>::{impl Destruct for (String, String)}::drop_glue::<String, String>
-unsafe fn impl_Destruct_for_tuple_String_String::drop_glue::<String, String><'_0>(_1: &'_0 mut (String, String))
+struct (_, _)::<String, String> {
+  _0: String,
+  _1: String,
+}
+
+// Full name: (_, _)::{impl Destruct for (String, String)}::drop_glue::<String, String>
+unsafe fn {impl Destruct for (String, String)}::drop_glue::<String, String><'_0>(_1: &'_0 mut (String, String))
 {
     let _0: (); // return
     let _1: &'1 mut (String, String); // arg #1
 
     storage_live(_0)
     _0 = ()
-    drop[impl_Destruct_for_String::drop_glue<'2>] (*_1).0
-    ↳⚡ drop[impl_Destruct_for_String::drop_glue<'4>] (*_1).1
+    drop[impl_Destruct_for_String::drop_glue<'2>] (*_1)._0
+    ↳⚡ drop[impl_Destruct_for_String::drop_glue<'4>] (*_1)._1
         ↳⚡ storage_dead(_1)
             unwind_terminate
         storage_dead(_1)
         unwind_continue
-    drop[impl_Destruct_for_String::drop_glue<'3>] (*_1).1
+    drop[impl_Destruct_for_String::drop_glue<'3>] (*_1)._1
     ↳⚡ storage_dead(_1)
         unwind_continue
     storage_dead(_1)
     return
 }
 
-// Full name: test_crate::<tuple_2>::{impl Destruct for (String, String)}
-impl "impl_Destruct_for_tuple_String_String" Destruct for (String, String) {
-    fn drop_glue<'_0_1> = impl_Destruct_for_tuple_String_String::drop_glue::<String, String><'_0_1>
+// Full name: (_, _)::{impl Destruct for (String, String)}
+impl Destruct for (String, String) {
+    fn drop_glue<'_0_1> = {impl Destruct for (String, String)}::drop_glue::<String, String><'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: {impl Destruct for [String]}
+impl "impl_Destruct_for_slice" Destruct for [String] {
+    fn drop_glue<'_0_1> = impl_Destruct_for_slice::drop_glue::<String><'_0_1>
     non-dyn-compatible
 }
 
@@ -235,15 +216,15 @@ fn drop_array(_1: [String; 4usize])
 }
 
 // Full name: test_crate::drop_slice
-fn drop_slice(_1: alloc::boxed::Box<[String]>[{built_in impl MetaSized for [String]}, {built_in impl Sized for Global}, impl_Destruct_for_slice, impl_Destruct_for_Global])
+fn drop_slice(_1: Box::<[String], Global>)
 {
     let _0: (); // return
-    let _1: alloc::boxed::Box<[String]>[{built_in impl MetaSized for [String]}, {built_in impl Sized for Global}, impl_Destruct_for_slice, impl_Destruct_for_Global]; // arg #1
+    let _1: Box::<[String], Global>; // arg #1
 
     storage_live(_0)
     _0 = ()
     _0 = ()
-    drop[impl_Destruct_for_Box_slice_Global::drop_glue::<[String], Global><'0>] _1
+    drop[{impl Destruct for Box::<[String], Global>}::drop_glue::<[String], Global><'0>] _1
     ↳⚡ storage_dead(_1)
         unwind_continue
     storage_dead(_1)
@@ -259,7 +240,7 @@ fn drop_tuple(_1: (String, String))
     storage_live(_0)
     _0 = ()
     _0 = ()
-    drop[impl_Destruct_for_tuple_String_String::drop_glue::<String, String><'0>] _1
+    drop[{impl Destruct for (String, String)}::drop_glue::<String, String><'0>] _1
     ↳⚡ storage_dead(_1)
         unwind_continue
     storage_dead(_1)

--- a/charon/tests/ui/simple/builtin-drop.out
+++ b/charon/tests/ui/simple/builtin-drop.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -55,8 +57,18 @@ impl "impl_Destruct_for_Global" Destruct for Global {
     non-dyn-compatible
 }
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (type_error("removed allocator parameter"): Destruct),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -80,7 +92,17 @@ impl "impl_Destruct_for_String" Destruct for String {
     non-dyn-compatible
 }
 
-// Full name: test_crate::<slice>::{impl Destruct for [T]}::drop_glue
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+    TraitClause1: (A: Destruct),
+    TraitClause2: (B: Destruct),
+{
+  _0: A,
+  _1: B,
+}
+
+// Full name: {impl Destruct for [T]}::drop_glue
 unsafe fn impl_Destruct_for_slice::drop_glue<'_0, T>(_1: &'_0 mut [T])
 where
     TraitClause0: (T: Sized),
@@ -176,7 +198,7 @@ where
     return
 }
 
-// Full name: test_crate::<slice>::{impl Destruct for [T]}
+// Full name: {impl Destruct for [T]}
 impl<T> "impl_Destruct_for_slice" Destruct for [T]
 where
     TraitClause0: (T: Sized),
@@ -186,7 +208,7 @@ where
     non-dyn-compatible
 }
 
-// Full name: test_crate::<array>::{impl Destruct for [T; N]}::drop_glue
+// Full name: {impl Destruct for [T; N]}::drop_glue
 unsafe fn impl_Destruct_for_array::drop_glue<'_0, T, const N : usize>(_1: &'_0 mut [T; N])
 where
     TraitClause0: (T: Sized),
@@ -211,7 +233,7 @@ where
     return
 }
 
-// Full name: test_crate::<array>::{impl Destruct for [T; N]}
+// Full name: {impl Destruct for [T; N]}
 impl<T, const N : usize> "impl_Destruct_for_array" Destruct for [T; N]
 where
     TraitClause0: (T: Sized),
@@ -221,7 +243,7 @@ where
     non-dyn-compatible
 }
 
-// Full name: test_crate::<tuple_2>::{impl Destruct for (A, B)}::drop_glue
+// Full name: (_, _)::{impl Destruct for (A, B)}::drop_glue
 unsafe fn impl_Destruct_for_tuple::drop_glue<'_0, A, B>(_1: &'_0 mut (A, B))
 where
     TraitClause0: (A: Sized),
@@ -235,20 +257,20 @@ where
 
     storage_live(_0)
     _0 = ()
-    drop[TraitClause1::drop_glue<'2>] (*_1).0
-    ↳⚡ drop[TraitClause2::drop_glue<'4>] (*_1).1
+    drop[TraitClause1::drop_glue<'2>] (*_1)._0
+    ↳⚡ drop[TraitClause2::drop_glue<'4>] (*_1)._1
         ↳⚡ storage_dead(_1)
             unwind_terminate
         storage_dead(_1)
         unwind_continue
-    drop[TraitClause2::drop_glue<'3>] (*_1).1
+    drop[TraitClause2::drop_glue<'3>] (*_1)._1
     ↳⚡ storage_dead(_1)
         unwind_continue
     storage_dead(_1)
     return
 }
 
-// Full name: test_crate::<tuple_2>::{impl Destruct for (A, B)}
+// Full name: (_, _)::{impl Destruct for (A, B)}
 impl<A, B> "impl_Destruct_for_tuple" Destruct for (A, B)
 where
     TraitClause0: (A: Sized),
@@ -276,10 +298,10 @@ fn drop_array(_1: [String; 4usize])
 }
 
 // Full name: test_crate::drop_slice
-fn drop_slice(_1: alloc::boxed::Box<[String]>[{built_in impl MetaSized for [String]}, {built_in impl Sized for Global}, impl_Destruct_for_slice<String>[{built_in impl Sized for String}, impl_Destruct_for_String], impl_Destruct_for_Global])
+fn drop_slice(_1: Box<[String]>[{built_in impl MetaSized for [String]}, {built_in impl Sized for Global}, impl_Destruct_for_slice<String>[{built_in impl Sized for String}, impl_Destruct_for_String], impl_Destruct_for_Global])
 {
     let _0: (); // return
-    let _1: alloc::boxed::Box<[String]>[{built_in impl MetaSized for [String]}, {built_in impl Sized for Global}, impl_Destruct_for_slice<String>[{built_in impl Sized for String}, impl_Destruct_for_String], impl_Destruct_for_Global]; // arg #1
+    let _1: Box<[String]>[{built_in impl MetaSized for [String]}, {built_in impl Sized for Global}, impl_Destruct_for_slice<String>[{built_in impl Sized for String}, impl_Destruct_for_String], impl_Destruct_for_Global]; // arg #1
 
     storage_live(_0)
     _0 = ()

--- a/charon/tests/ui/simple/call-foreign-defaulted-method.out
+++ b/charon/tests/ui/simple/call-foreign-defaulted-method.out
@@ -5,6 +5,8 @@
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct () {}
+
 // Full name: test_crate::foo::{impl Trait for ()}::defaulted
 pub fn impl_Trait_for_unit::defaulted<'_0>(self: &'_0 ())
 {

--- a/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
+++ b/charon/tests/ui/simple/call-inherent-method-with-trait-bound.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/call-method-via-supertrait-bound.out
+++ b/charon/tests/ui/simple/call-method-via-supertrait-bound.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/catch-unwind.out
+++ b/charon/tests/ui/simple/catch-unwind.out
@@ -73,6 +73,8 @@ where
   Err { _0: E },
 }
 
+struct () {}
+
 // Full name: core::result::Result::{impl Destruct for Result<T, E>[TraitClause0, TraitClause1]}::drop_glue
 unsafe fn drop_glue<'_0, T, E>(_1: &'_0 mut Result<T, E>[TraitClause0, TraitClause1])
 where
@@ -82,12 +84,20 @@ where
     TypeOutlives1: E: '_0,
 = <opaque>
 
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
 // Full name: alloc::alloc::Global
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
 // Full name: std::panic::catch_unwind
-pub fn catch_unwind<F, R>(_1: F) -> Result<R, alloc::boxed::Box<(dyn Any + Send + 'static)>[{built_in impl MetaSized for (dyn Any + Send + 'static)}, {built_in impl Sized for Global}]>[TraitClause1, {built_in impl Sized for alloc::boxed::Box<(dyn Any + Send + 'static)>[{built_in impl MetaSized for (dyn Any + Send + 'static)}, {built_in impl Sized for Global}]}]
+pub fn catch_unwind<F, R>(_1: F) -> Result<R, Box<(dyn Any + Send + 'static)>[{built_in impl MetaSized for (dyn Any + Send + 'static)}, {built_in impl Sized for Global}]>[TraitClause1, {built_in impl Sized for Box<(dyn Any + Send + 'static)>[{built_in impl MetaSized for (dyn Any + Send + 'static)}, {built_in impl Sized for Global}]}]
 where
     TraitClause0: (F: Sized),
     TraitClause1: (R: Sized),
@@ -129,7 +139,7 @@ impl "impl_FnOnce_unit_for_closure" FnOnce<()> for closure {
 fn main()
 {
     let _0: (); // return
-    let _1: Result<(), alloc::boxed::Box<(dyn Any + Send + '27)>[{built_in impl MetaSized for (dyn Any + Send + '29)}, {built_in impl Sized for Global}]>[{built_in impl Sized for ()}, {built_in impl Sized for alloc::boxed::Box<(dyn Any + Send + '36)>[{built_in impl MetaSized for (dyn Any + Send + '38)}, {built_in impl Sized for Global}]}]; // anonymous local
+    let _1: Result<(), Box<(dyn Any + Send + '27)>[{built_in impl MetaSized for (dyn Any + Send + '29)}, {built_in impl Sized for Global}]>[{built_in impl Sized for ()}, {built_in impl Sized for Box<(dyn Any + Send + '36)>[{built_in impl MetaSized for (dyn Any + Send + '38)}, {built_in impl Sized for Global}]}]; // anonymous local
     let _2: closure; // anonymous local
 
     storage_live(_0)
@@ -140,7 +150,7 @@ fn main()
     _1 = catch_unwind<closure, ()>[{built_in impl Sized for closure}, {built_in impl Sized for ()}, impl_FnOnce_unit_for_closure, {built_in impl UnwindSafe for closure}](move _2)
     ↳⚡ unwind_continue
     storage_dead(_2)
-    conditional_drop[drop_glue<'100, (), alloc::boxed::Box<(dyn Any + Send + '78)>[{built_in impl MetaSized for (dyn Any + Send + '80)}, {built_in impl Sized for Global}]>[{built_in impl Sized for ()}, {built_in impl Sized for alloc::boxed::Box<(dyn Any + Send + '78)>[{built_in impl MetaSized for (dyn Any + Send + '80)}, {built_in impl Sized for Global}]}]] _1
+    conditional_drop[drop_glue<'100, (), Box<(dyn Any + Send + '78)>[{built_in impl MetaSized for (dyn Any + Send + '80)}, {built_in impl Sized for Global}]>[{built_in impl Sized for ()}, {built_in impl Sized for Box<(dyn Any + Send + '78)>[{built_in impl MetaSized for (dyn Any + Send + '80)}, {built_in impl Sized for Global}]}]] _1
     ↳⚡ unwind_continue
     storage_dead(_1)
     _0 = ()

--- a/charon/tests/ui/simple/closure-capture-ref-by-move.out
+++ b/charon/tests/ui/simple/closure-capture-ref-by-move.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -56,6 +58,14 @@ pub trait FnMut<Self, Args>
     proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1>;
     vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
 }
 
 // Full name: test_crate::foo::closure

--- a/charon/tests/ui/simple/closure-fn.out
+++ b/charon/tests/ui/simple/closure-fn.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -69,6 +71,14 @@ pub trait Fn<Self, Args>
     proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1>;
     vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
 }
 
 // Full name: test_crate::apply_to
@@ -193,8 +203,8 @@ where
     storage_live(_9)
     storage_live(_11)
     storage_live(_13)
-    x = move tupled_args.0
-    y = move tupled_args.1
+    x = move tupled_args._0
+    y = move tupled_args._1
     storage_live(_5)
     storage_live(_6)
     storage_live(_7)

--- a/charon/tests/ui/simple/closure-fnmut.out
+++ b/charon/tests/ui/simple/closure-fnmut.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -56,6 +58,18 @@ pub trait FnMut<Self, Args>
     proof ImpliedClause3: (Args: Tuple)
     fn call_mut<'_0_1>;
     vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
+}
+
+struct (_,)<A> {
+  _0: A,
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
 }
 
 // Full name: test_crate::apply_to_zero_mut
@@ -113,7 +127,7 @@ where
     storage_live(x)
     storage_live(_4)
     storage_live(_7)
-    x = move tupled_args.0
+    x = move tupled_args._0
     _4 = copy (*(*_1)._0) panic.+ const 1u8
     (*(*_1)._0) = move _4
     storage_live(_5)

--- a/charon/tests/ui/simple/closure-fnonce.out
+++ b/charon/tests/ui/simple/closure-fnonce.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -51,6 +53,18 @@ pub trait FnOnce<Self, Args>
     type Output
     fn call_once;
     vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
+}
+
+struct (_,)<A> {
+  _0: A,
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
 }
 
 // Full name: test_crate::apply_to_zero_once
@@ -129,7 +143,7 @@ fn call_once(_1: closure, tupled_args: (u8,)) -> u8
     storage_live(_0)
     storage_live(x)
     storage_live(_7)
-    x = move tupled_args.0
+    x = move tupled_args._0
     storage_live(_4)
     storage_live(_5)
     _5 = move _1._0

--- a/charon/tests/ui/simple/closure-inside-impl.out
+++ b/charon/tests/ui/simple/closure-inside-impl.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -69,6 +71,10 @@ pub trait Fn<Self, Args>
     proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1>;
     vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
+}
+
+struct (_,)<A> {
+  _0: A,
 }
 
 // Full name: test_crate::Foo
@@ -138,7 +144,7 @@ where
     storage_live(_0)
     storage_live(_x)
     _0 = ()
-    _x = move tupled_args.0
+    _x = move tupled_args._0
     _0 = ()
     storage_dead(_x)
     storage_dead(tupled_args)

--- a/charon/tests/ui/simple/closure-inside-inline-const.out
+++ b/charon/tests/ui/simple/closure-inside-inline-const.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/closure-uses-ambient-self-clause.out
+++ b/charon/tests/ui/simple/closure-uses-ambient-self-clause.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -71,7 +73,11 @@ pub trait Fn<Self, Args>
     vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
-// Full name: test_crate::<tuple_1>::{impl Destruct for (A,)}::drop_glue
+struct (_,)<A> {
+  _0: A,
+}
+
+// Full name: (_,)::{impl Destruct for (A,)}::drop_glue
 unsafe fn impl_Destruct_for_tuple::drop_glue<'_0, A>(_1: &'_0 mut (A,))
 where
     TypeOutlives0: A: '_0,
@@ -81,14 +87,14 @@ where
 
     storage_live(_0)
     _0 = ()
-    drop[{built_in impl Destruct for A}::drop_glue<'2>] (*_1).0
+    drop[{built_in impl Destruct for A}::drop_glue<'2>] (*_1)._0
     ↳⚡ storage_dead(_1)
         unwind_continue
     storage_dead(_1)
     return
 }
 
-// Full name: test_crate::<tuple_1>::{impl Destruct for (A,)}
+// Full name: (_,)::{impl Destruct for (A,)}
 impl<A> "impl_Destruct_for_tuple" Destruct for (A,) {
     fn drop_glue<'_0_1> = impl_Destruct_for_tuple::drop_glue<'_0_1, A>
     non-dyn-compatible
@@ -124,7 +130,7 @@ where
     storage_live(_0)
     storage_live(_3)
     _0 = ()
-    _3 = move tupled_args.0
+    _3 = move tupled_args._0
     _0 = ()
     conditional_drop[{built_in impl Destruct for TraitClause0::Item}::drop_glue<'2>] _3
     ↳⚡ storage_dead(_3)

--- a/charon/tests/ui/simple/closure-with-drops.out
+++ b/charon/tests/ui/simple/closure-with-drops.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/closure-with-non-upvar-lifetime.out
+++ b/charon/tests/ui/simple/closure-with-non-upvar-lifetime.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -71,6 +73,10 @@ pub trait Fn<Self, Args>
     vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: test_crate::call_fn::closure
 struct closure<'_0, '_1>
 where
@@ -97,7 +103,7 @@ where
 
     storage_live(_0)
     storage_live(i)
-    i = move tupled_args.0
+    i = move tupled_args._0
     storage_live(_4)
     _4 = &(*(*_1)._0)
     storage_live(_5)

--- a/charon/tests/ui/simple/closure-with-remove-adt-clauses.out
+++ b/charon/tests/ui/simple/closure-with-remove-adt-clauses.out
@@ -34,6 +34,8 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/comma-delimited-start-from.out
+++ b/charon/tests/ui/simple/comma-delimited-start-from.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::a
 fn a()
 {

--- a/charon/tests/ui/simple/conditional-drop.out
+++ b/charon/tests/ui/simple/conditional-drop.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -36,8 +38,18 @@ impl "impl_Destruct_for_Global" Destruct for Global {
     non-dyn-compatible
 }
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (type_error("removed allocator parameter"): Destruct),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -47,20 +59,20 @@ where
     TypeOutlives1: A: '_0,
 = <opaque>
 
-// Full name: alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, TraitClause1, impl_Destruct_for_Global]}::new
+// Full name: alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, TraitClause1, impl_Destruct_for_Global]}::new
 #[track_caller]
 #[diagnostic_item("box_new")]
-pub fn new<T>(_1: T) -> alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, TraitClause1, impl_Destruct_for_Global]
+pub fn new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}, TraitClause1, impl_Destruct_for_Global]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Destruct),
 = <opaque>
 
 // Full name: test_crate::use_box
-fn use_box(_1: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global])
+fn use_box(_1: Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global])
 {
     let _0: (); // return
-    let _1: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global]; // arg #1
+    let _1: Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global]; // arg #1
 
     storage_live(_0)
     _0 = ()
@@ -76,10 +88,10 @@ fn use_box(_1: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_
 fn main()
 {
     let _0: (); // return
-    let b: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global]; // local
+    let b: Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global]; // local
     let _2: bool; // anonymous local
     let _3: (); // anonymous local
-    let _4: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global]; // anonymous local
+    let _4: Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global]; // anonymous local
     let _5: bool; // anonymous local
 
     storage_live(_0)

--- a/charon/tests/ui/simple/const-subslice.out
+++ b/charon/tests/ui/simple/const-subslice.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/simple/default-method-with-clause-and-marker-trait.2.out
+++ b/charon/tests/ui/simple/default-method-with-clause-and-marker-trait.2.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::HasAssoc
 trait HasAssoc<Self>
 {

--- a/charon/tests/ui/simple/default-method-with-clause-and-marker-trait.out
+++ b/charon/tests/ui/simple/default-method-with-clause-and-marker-trait.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::HasAssoc
 trait HasAssoc<Self>
 {

--- a/charon/tests/ui/simple/defaulted-rpitit.2.out
+++ b/charon/tests/ui/simple/defaulted-rpitit.2.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::MyTrait
 pub trait MyTrait<Self>
 {

--- a/charon/tests/ui/simple/defaulted-rpitit.3.out
+++ b/charon/tests/ui/simple/defaulted-rpitit.3.out
@@ -49,6 +49,20 @@ pub trait Iterator<Self>
     vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: test_crate::MyTrait
 pub trait MyTrait<Self, T>
 {

--- a/charon/tests/ui/simple/double-promotion.out
+++ b/charon/tests/ui/simple/double-promotion.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Ref
 pub struct Ref<'a, B>
 where

--- a/charon/tests/ui/simple/drop-cow.out
+++ b/charon/tests/ui/simple/drop-cow.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/drop-glue-with-const-generic-silenced.out
+++ b/charon/tests/ui/simple/drop-glue-with-const-generic-silenced.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -36,13 +38,23 @@ impl "impl_Destruct_for_Global" Destruct for Global {
     non-dyn-compatible
 }
 
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (type_error("removed allocator parameter"): Destruct),
+
 // Full name: test_crate::KeccakState
 struct KeccakState {}
 
 // Full name: test_crate::PortableHash
 struct PortableHash<const K : usize> {
   shake128_state: [KeccakState; K],
-  make_non_trivial: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global],
+  make_non_trivial: Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global],
 }
 
 // Full name: test_crate::PortableHash::{impl Destruct for PortableHash<K>}::drop_glue

--- a/charon/tests/ui/simple/drop-glue-with-const-generic.out
+++ b/charon/tests/ui/simple/drop-glue-with-const-generic.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -36,8 +38,18 @@ impl "impl_Destruct_for_Global" Destruct for Global {
     non-dyn-compatible
 }
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (type_error("removed allocator parameter"): Destruct),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -53,7 +65,7 @@ struct KeccakState {}
 // Full name: test_crate::PortableHash
 struct PortableHash<const K : usize> {
   shake128_state: [KeccakState; K],
-  make_non_trivial: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global],
+  make_non_trivial: Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global],
 }
 
 // Full name: test_crate::PortableHash::{impl Destruct for PortableHash<K>}::drop_glue

--- a/charon/tests/ui/simple/drop-string-desugar.out
+++ b/charon/tests/ui/simple/drop-string-desugar.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/drop-string.out
+++ b/charon/tests/ui/simple/drop-string.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/explicit_destruct_bound.out
+++ b/charon/tests/ui/simple/explicit_destruct_bound.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.2.out
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.2.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Trait
 trait Trait<Self>
 {

--- a/charon/tests/ui/simple/fewer-clauses-in-method-impl.out
+++ b/charon/tests/ui/simple/fewer-clauses-in-method-impl.out
@@ -34,6 +34,8 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Trait
 trait Trait<Self>
 {

--- a/charon/tests/ui/simple/fn-ptr.out
+++ b/charon/tests/ui/simple/fn-ptr.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::foo
 fn foo()
 {

--- a/charon/tests/ui/simple/fn_ptr_trait.out
+++ b/charon/tests/ui/simple/fn_ptr_trait.out
@@ -34,6 +34,8 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::FnPtr
 #[fundamental]
 #[lang_item(FnPtrTrait)]

--- a/charon/tests/ui/simple/foreign-inline-const.out
+++ b/charon/tests/ui/simple/foreign-inline-const.out
@@ -52,6 +52,8 @@ where
     return
 }
 
+struct () {}
+
 // Full name: test_crate::bar
 fn bar<T>()
 where

--- a/charon/tests/ui/simple/gat-check-binder-levels.out
+++ b/charon/tests/ui/simple/gat-check-binder-levels.out
@@ -25,6 +25,14 @@ where
   Some { _0: T },
 }
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::Link
 pub trait Link<Self, T>
 {

--- a/charon/tests/ui/simple/gat-complex-lifetimes.out
+++ b/charon/tests/ui/simple/gat-complex-lifetimes.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/gat-default.out
+++ b/charon/tests/ui/simple/gat-default.out
@@ -25,6 +25,8 @@ where
     TraitClause0: (T: Sized),
     TraitClause1: (type_error("removed allocator parameter"): Sized),
 
+struct () {}
+
 // Full name: test_crate::Collection
 trait Collection<Self>
 {

--- a/charon/tests/ui/simple/gat-implied-clause.out
+++ b/charon/tests/ui/simple/gat-implied-clause.out
@@ -24,6 +24,8 @@ pub trait Clone<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/generic-discriminant.out
+++ b/charon/tests/ui/simple/generic-discriminant.out
@@ -41,6 +41,8 @@ pub trait Eq<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::hash::Hasher
 pub trait Hasher<Self>
 {
@@ -128,6 +130,10 @@ where
     storage_dead(_2)
     storage_dead(v)
     return
+}
+
+struct str {
+  _0: [u8],
 }
 
 // Full name: test_crate::f

--- a/charon/tests/ui/simple/generic-impl-with-defaulted-method.out
+++ b/charon/tests/ui/simple/generic-impl-with-defaulted-method.out
@@ -25,6 +25,8 @@ where
   Some { _0: T },
 }
 
+struct () {}
+
 // Full name: test_crate::BoolTrait
 pub trait BoolTrait<Self>
 {

--- a/charon/tests/ui/simple/generic-impl-with-method.out
+++ b/charon/tests/ui/simple/generic-impl-with-method.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Trait
 pub trait Trait<Self>
 {

--- a/charon/tests/ui/simple/generic-offset-of.out
+++ b/charon/tests/ui/simple/generic-offset-of.out
@@ -14,6 +14,16 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::B
 struct B<T>
 where

--- a/charon/tests/ui/simple/hello-world.out
+++ b/charon/tests/ui/simple/hello-world.out
@@ -4,9 +4,15 @@
 #[lang_item(String)]
 pub opaque type String
 
+struct () {}
+
 // Full name: alloc::string::String::{impl Destruct for String}::drop_glue
 unsafe fn drop_glue<'_0>(_1: &'_0 mut String)
 = <opaque>
+
+struct str {
+  _0: [u8],
+}
 
 // Full name: alloc::string::{impl ToString for str}::to_string::<str>
 pub fn to_string::<str><'_0>(_1: &'_0 str) -> String

--- a/charon/tests/ui/simple/hide-drops.out
+++ b/charon/tests/ui/simple/hide-drops.out
@@ -4,6 +4,8 @@
 #[lang_item(String)]
 pub opaque type String
 
+struct () {}
+
 // Full name: alloc::string::String::{impl Destruct for String}::drop_glue
 unsafe fn drop_glue<'_0>(_1: &'_0 mut String)
 = <opaque>

--- a/charon/tests/ui/simple/impl-trait-in-arg.out
+++ b/charon/tests/ui/simple/impl-trait-in-arg.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/inline-asm.out
+++ b/charon/tests/ui/simple/inline-asm.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/simple/intrinsic-same-name-across-modules.out
+++ b/charon/tests/ui/simple/intrinsic-same-name-across-modules.out
@@ -59,6 +59,8 @@ impl "impl_Copy_for_u8" Copy for u8 {
     non-dyn-compatible
 }
 
+struct () {}
+
 #[rustc_intrinsic]
 #[inline(hint)]
 pub fn test_crate::first::nested::wrapping_add<T>(lhs_1: T, rhs_2: T) -> T

--- a/charon/tests/ui/simple/issue-1040-closure-upvar-lifetime.out
+++ b/charon/tests/ui/simple/issue-1040-closure-upvar-lifetime.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/issue-988-closure-outlives.out
+++ b/charon/tests/ui/simple/issue-988-closure-outlives.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -71,6 +73,10 @@ pub trait Fn<Self, Args>
     vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: test_crate::call_fn_shared::closure
 struct closure<'_0> {
   _0: &'_0 [u8],
@@ -91,7 +97,7 @@ where
 
     storage_live(_0)
     storage_live(i)
-    i = move tupled_args.0
+    i = move tupled_args._0
     storage_live(_4)
     _4 = copy i
     storage_live(_5)

--- a/charon/tests/ui/simple/lending-iterator-gat.out
+++ b/charon/tests/ui/simple/lending-iterator-gat.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -83,7 +85,19 @@ pub enum AssertKind {
   Match,
 }
 
-// Full name: test_crate::<tuple_1>::{impl Destruct for (A,)}::drop_glue
+struct (_,)<A> {
+  _0: A,
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+// Full name: (_,)::{impl Destruct for (A,)}::drop_glue
 unsafe fn impl_Destruct_for_tuple::drop_glue<'_0, A>(_1: &'_0 mut (A,))
 where
     TypeOutlives0: A: '_0,
@@ -93,14 +107,14 @@ where
 
     storage_live(_0)
     _0 = ()
-    drop[{built_in impl Destruct for A}::drop_glue<'2>] (*_1).0
+    drop[{built_in impl Destruct for A}::drop_glue<'2>] (*_1)._0
     ↳⚡ storage_dead(_1)
         unwind_continue
     storage_dead(_1)
     return
 }
 
-// Full name: test_crate::<tuple_1>::{impl Destruct for (A,)}
+// Full name: (_,)::{impl Destruct for (A,)}
 impl<A> "impl_Destruct_for_tuple" Destruct for (A,) {
     fn drop_glue<'_0_1> = impl_Destruct_for_tuple::drop_glue<'_0_1, A>
     non-dyn-compatible
@@ -235,23 +249,23 @@ where
         storage_live(_9)
         _9 = move item
         _8 = (move _9,)
-        _3 = TraitClause3::call_mut<'33>(move _7, move _8)
-        ↳⚡ conditional_drop[impl_Destruct_for_tuple::drop_glue<'39, TraitClause2::Item<'38>>] _8
+        _3 = TraitClause3::call_mut<'34>(move _7, move _8)
+        ↳⚡ conditional_drop[impl_Destruct_for_tuple::drop_glue<'40, TraitClause2::Item<'39>>] _8
             ↳⚡ storage_dead(_3)
                 storage_dead(f)
                 storage_dead(iter)
                 unwind_terminate
-            conditional_drop[{built_in impl Destruct for TraitClause2::Item<'45>}::drop_glue<'46>] _9
+            conditional_drop[{built_in impl Destruct for TraitClause2::Item<'46>}::drop_glue<'47>] _9
             ↳⚡ storage_dead(_3)
                 storage_dead(f)
                 storage_dead(iter)
                 unwind_terminate
-            conditional_drop[{built_in impl Destruct for TraitClause2::Item<'51>}::drop_glue<'52>] item
+            conditional_drop[{built_in impl Destruct for TraitClause2::Item<'52>}::drop_glue<'53>] item
             ↳⚡ storage_dead(_3)
                 storage_dead(f)
                 storage_dead(iter)
                 unwind_terminate
-            conditional_drop[impl_Destruct_for_Option::drop_glue<'72, TraitClause2::Item<'69>>[TraitClause2::Item::ImpliedClause0]] _4
+            conditional_drop[impl_Destruct_for_Option::drop_glue<'73, TraitClause2::Item<'70>>[TraitClause2::Item::ImpliedClause0]] _4
             ↳⚡ storage_dead(_3)
                 storage_dead(f)
                 storage_dead(iter)
@@ -270,13 +284,13 @@ where
             storage_dead(f)
             storage_dead(iter)
             unwind_continue
-        conditional_drop[{built_in impl Destruct for TraitClause2::Item<'41>}::drop_glue<'42>] _9
-        ↳⚡ conditional_drop[{built_in impl Destruct for TraitClause2::Item<'51>}::drop_glue<'52>] item
+        conditional_drop[{built_in impl Destruct for TraitClause2::Item<'42>}::drop_glue<'43>] _9
+        ↳⚡ conditional_drop[{built_in impl Destruct for TraitClause2::Item<'52>}::drop_glue<'53>] item
             ↳⚡ storage_dead(_3)
                 storage_dead(f)
                 storage_dead(iter)
                 unwind_terminate
-            conditional_drop[impl_Destruct_for_Option::drop_glue<'72, TraitClause2::Item<'69>>[TraitClause2::Item::ImpliedClause0]] _4
+            conditional_drop[impl_Destruct_for_Option::drop_glue<'73, TraitClause2::Item<'70>>[TraitClause2::Item::ImpliedClause0]] _4
             ↳⚡ storage_dead(_3)
                 storage_dead(f)
                 storage_dead(iter)
@@ -298,8 +312,8 @@ where
         storage_dead(_9)
         storage_dead(_8)
         storage_dead(_7)
-        conditional_drop[{built_in impl Destruct for TraitClause2::Item<'48>}::drop_glue<'49>] item
-        ↳⚡ conditional_drop[impl_Destruct_for_Option::drop_glue<'72, TraitClause2::Item<'69>>[TraitClause2::Item::ImpliedClause0]] _4
+        conditional_drop[{built_in impl Destruct for TraitClause2::Item<'49>}::drop_glue<'50>] item
+        ↳⚡ conditional_drop[impl_Destruct_for_Option::drop_glue<'73, TraitClause2::Item<'70>>[TraitClause2::Item::ImpliedClause0]] _4
             ↳⚡ storage_dead(_3)
                 storage_dead(f)
                 storage_dead(iter)
@@ -319,7 +333,7 @@ where
             storage_dead(iter)
             unwind_continue
         storage_dead(item)
-        conditional_drop[impl_Destruct_for_Option::drop_glue<'62, TraitClause2::Item<'59>>[TraitClause2::Item::ImpliedClause0]] _4
+        conditional_drop[impl_Destruct_for_Option::drop_glue<'63, TraitClause2::Item<'60>>[TraitClause2::Item::ImpliedClause0]] _4
         ↳⚡ conditional_drop[{built_in impl Destruct for T1}::drop_glue<'15>] f
             ↳⚡ storage_dead(_3)
                 storage_dead(f)
@@ -354,7 +368,7 @@ where
         storage_dead(iter)
         unwind_continue
     storage_dead(_4)
-    conditional_drop[{built_in impl Destruct for T1}::drop_glue<'34>] f
+    conditional_drop[{built_in impl Destruct for T1}::drop_glue<'35>] f
     ↳⚡ conditional_drop[{built_in impl Destruct for I}::drop_glue<'16>] iter
         ↳⚡ storage_dead(_3)
             storage_dead(f)
@@ -364,7 +378,7 @@ where
         storage_dead(f)
         storage_dead(iter)
         unwind_continue
-    conditional_drop[{built_in impl Destruct for I}::drop_glue<'43>] iter
+    conditional_drop[{built_in impl Destruct for I}::drop_glue<'44>] iter
     ↳⚡ storage_dead(_3)
         storage_dead(f)
         storage_dead(iter)
@@ -396,7 +410,7 @@ where
     storage_live(item)
     storage_live(_5)
     _0 = ()
-    item = move tupled_args.0
+    item = move tupled_args._0
     storage_live(_4)
     _4 = copy (*item)
     _5 = copy (*(*_1)._0) panic.+ copy _4
@@ -490,28 +504,28 @@ pub fn main()
     let _6: Option<&'12 i32>[{built_in impl Sized for &'12 i32}]; // anonymous local
     let _7: closure<'17>; // anonymous local
     let _8: &'19 mut i32; // anonymous local
-    let _9: (&'22 i32, &'23 i32); // anonymous local
-    let _10: &'24 i32; // anonymous local
-    let _11: &'25 i32; // anonymous local
-    let left_val: &'26 i32; // local
-    let right_val: &'27 i32; // local
+    let _9: (&'27 i32, &'28 i32); // anonymous local
+    let _10: &'32 i32; // anonymous local
+    let _11: &'33 i32; // anonymous local
+    let left_val: &'34 i32; // local
+    let right_val: &'35 i32; // local
     let _14: bool; // anonymous local
     let _15: i32; // anonymous local
     let _16: i32; // anonymous local
     let kind: AssertKind; // local
     let _18: AssertKind; // anonymous local
-    let _19: &'28 i32; // anonymous local
-    let _20: &'29 i32; // anonymous local
-    let _21: &'30 i32; // anonymous local
-    let _22: &'31 i32; // anonymous local
-    let _23: Option<Arguments<'39>>[{built_in impl Sized for Arguments<'39>}]; // anonymous local
-    let _24: &'43 i32; // anonymous local
-    let _25: &'44 i32; // anonymous local
-    let _26: &'45 i32; // anonymous local
-    let _27: &'114 i32; // anonymous local
-    let _28: &'123 i32; // anonymous local
+    let _19: &'36 i32; // anonymous local
+    let _20: &'37 i32; // anonymous local
+    let _21: &'38 i32; // anonymous local
+    let _22: &'39 i32; // anonymous local
+    let _23: Option<Arguments<'47>>[{built_in impl Sized for Arguments<'47>}]; // anonymous local
+    let _24: &'51 i32; // anonymous local
+    let _25: &'52 i32; // anonymous local
+    let _26: &'53 i32; // anonymous local
+    let _27: &'122 i32; // anonymous local
+    let _28: &'136 i32; // anonymous local
     let _29: i32; // anonymous local
-    let _30: &'124 i32; // anonymous local
+    let _30: &'137 i32; // anonymous local
     let _31: i32; // anonymous local
 
     storage_live(_26)
@@ -545,7 +559,7 @@ pub fn main()
     _8 = &mut sum
     _7 = closure { _0: move _8 }
     storage_dead(_8)
-    _5 = for_each<Option<&'63 i32>[{built_in impl Sized for &'63 i32}], closure<'65>>[{built_in impl Sized for Option<&'63 i32>[{built_in impl Sized for &'63 i32}]}, {built_in impl Sized for closure<'65>}, impl_LendingIterator_for_Option<'63, i32>[{built_in impl Sized for i32}], impl_FnMut_tuple_for_closure<'65, '112>](move _6, move _7)
+    _5 = for_each<Option<&'71 i32>[{built_in impl Sized for &'71 i32}], closure<'73>>[{built_in impl Sized for Option<&'71 i32>[{built_in impl Sized for &'71 i32}]}, {built_in impl Sized for closure<'73>}, impl_LendingIterator_for_Option<'71, i32>[{built_in impl Sized for i32}], impl_FnMut_tuple_for_closure<'73, '120>](move _6, move _7)
     ↳⚡ storage_dead(_25)
         storage_dead(_24)
         storage_dead(_23)
@@ -575,9 +589,9 @@ pub fn main()
     storage_dead(_11)
     storage_dead(_10)
     storage_live(left_val)
-    left_val = copy _9.0
+    left_val = copy _9._0
     storage_live(right_val)
-    right_val = copy _9.1
+    right_val = copy _9._1
     storage_live(_14)
     storage_live(_15)
     _15 = copy (*left_val)

--- a/charon/tests/ui/simple/manual-drop-impl.out
+++ b/charon/tests/ui/simple/manual-drop-impl.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/match-on-char.out
+++ b/charon/tests/ui/simple/match-on-char.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/simple/match-on-float.out
+++ b/charon/tests/ui/simple/match-on-float.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/simple/min.out
+++ b/charon/tests/ui/simple/min.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/mono-enum-with-single-variant.out
+++ b/charon/tests/ui/simple/mono-enum-with-single-variant.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::Never
 enum Never {
 }

--- a/charon/tests/ui/simple/monomorphized-intrinsic.out
+++ b/charon/tests/ui/simple/monomorphized-intrinsic.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::E1
 enum E1 {
   A,

--- a/charon/tests/ui/simple/multiple-promoteds.out
+++ b/charon/tests/ui/simple/multiple-promoteds.out
@@ -5,6 +5,28 @@
 pub fn add<'_0, '_1>(_1: &'_1 u32, _2: &'_0 u32) -> u32
 = <opaque>
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::six
 fn six() -> u32
 {

--- a/charon/tests/ui/simple/nested-closure-lifetime.out
+++ b/charon/tests/ui/simple/nested-closure-lifetime.out
@@ -24,6 +24,8 @@ pub trait Clone<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/nested-closure-trait-ref.out
+++ b/charon/tests/ui/simple/nested-closure-trait-ref.out
@@ -24,6 +24,8 @@ pub trait Clone<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/nested-closure.out
+++ b/charon/tests/ui/simple/nested-closure.out
@@ -24,6 +24,8 @@ pub trait Clone<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -81,6 +83,10 @@ pub trait Fn<Self, Args>
     vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: test_crate::Foo
 struct Foo<'a, T>
 where
@@ -117,7 +123,7 @@ where
 
     storage_live(_0)
     storage_live(_z)
-    _z = move tupled_args.0
+    _z = move tupled_args._0
     storage_live(_4)
     _4 = &(*(*_1)._0)
     _0 = TraitClause1::clone<'5>(move _4)
@@ -159,7 +165,7 @@ where
 
     storage_live(_0)
     storage_live(_y)
-    _y = move tupled_args.0
+    _y = move tupled_args._0
     storage_live(_4)
     _4 = &(*(*_1)._0)
     _0 = test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure { _0: move _4 }
@@ -231,10 +237,10 @@ where
     let _16: &'44 u32; // anonymous local
     let _17: &'45 u32; // anonymous local
     let _18: &'61 u32; // anonymous local
-    let _19: &'76 u32; // anonymous local
-    let _20: &'88 u32; // anonymous local
+    let _19: &'77 u32; // anonymous local
+    let _20: &'90 u32; // anonymous local
     let _21: u32; // anonymous local
-    let _22: &'89 u32; // anonymous local
+    let _22: &'91 u32; // anonymous local
     let _23: u32; // anonymous local
 
     storage_live(_0)
@@ -275,7 +281,7 @@ where
     _12 = &(*_17)
     _11 = &(*_12)
     _10 = (move _11,)
-    _5 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'69, '70, '71, '72, '73, '74, T>[TraitClause0, TraitClause1](move _6, move _10)
+    _5 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'70, '71, '72, '73, '74, '75, T>[TraitClause0, TraitClause1](move _6, move _10)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(x)
@@ -297,7 +303,7 @@ where
     _15 = &(*_16)
     _14 = &(*_15)
     _13 = (move _14,)
-    _0 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'84, '85, '86, '87, T>[TraitClause0, TraitClause1](move _4, move _13)
+    _0 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::closure::closure::closure<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'86, '87, '88, '89, T>[TraitClause0, TraitClause1](move _4, move _13)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(x)

--- a/charon/tests/ui/simple/nested-inline-const.out
+++ b/charon/tests/ui/simple/nested-inline-const.out
@@ -1,5 +1,29 @@
 # Final LLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/simple/non-lifetime-gats.out
+++ b/charon/tests/ui/simple/non-lifetime-gats.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -37,8 +39,16 @@ pub trait Deref<Self>
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_glue
-unsafe fn drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -48,13 +58,13 @@ where
 
 #[track_caller]
 #[diagnostic_item("box_new")]
-pub fn alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<T>(_1: T) -> alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+pub fn alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
 where
     TraitClause0: (T: Sized),
 = <opaque>
 
-// Full name: alloc::boxed::{impl Deref for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::deref
-pub fn deref<'_0, T, A>(_1: &'_0 alloc::boxed::Box<T>[TraitClause0, TraitClause1]) -> &'_0 T
+// Full name: alloc::boxed::{impl Deref for Box<T>[TraitClause0, TraitClause1]}::deref
+pub fn deref<'_0, T, A>(_1: &'_0 Box<T>[TraitClause0, TraitClause1]) -> &'_0 T
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -62,8 +72,8 @@ where
     TypeOutlives1: A: '_0,
 = <opaque>
 
-// Full name: alloc::boxed::{impl Deref for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}
-impl<T, A> "impl_Deref_for_Box" Deref for alloc::boxed::Box<T>[TraitClause0, TraitClause1]
+// Full name: alloc::boxed::{impl Deref for Box<T>[TraitClause0, TraitClause1]}
+impl<T, A> "impl_Deref_for_Box" Deref for Box<T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -92,18 +102,18 @@ pub trait PointerFamily<Self>
 pub struct BoxFamily {}
 
 // Full name: test_crate::{impl PointerFamily for BoxFamily}::new
-pub fn impl_PointerFamily_for_BoxFamily::new<T>(value: T) -> alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+pub fn impl_PointerFamily_for_BoxFamily::new<T>(value: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
 where
     TraitClause0: (T: Sized),
 {
-    let _0: alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]; // return
+    let _0: Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]; // return
     let value: T; // arg #1
     let _2: T; // anonymous local
 
     storage_live(_0)
     storage_live(_2)
     _2 = move value
-    _0 = alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<T>[TraitClause0](move _2)
+    _0 = alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<T>[TraitClause0](move _2)
     ↳⚡ conditional_drop[{built_in impl Destruct for T}::drop_glue<'0>] _2
         ↳⚡ storage_dead(value)
             unwind_terminate
@@ -123,11 +133,11 @@ where
 // Full name: test_crate::{impl PointerFamily for BoxFamily}
 impl "impl_PointerFamily_for_BoxFamily" PointerFamily for BoxFamily {
     proof ImpliedClause0: (BoxFamily: MetaSized) = {built_in impl MetaSized for BoxFamily}
-    type Pointer<T> = alloc::boxed::Box<T>[TraitClause0_1::ImpliedClause0, {built_in impl Sized for Global}]
+    type Pointer<T> = Box<T>[TraitClause0_1::ImpliedClause0, {built_in impl Sized for Global}]
     where
         TraitClause0_1: (T: Sized),
-        proof ImpliedClause0: (alloc::boxed::Box<T>[TraitClause0_1::ImpliedClause0, {built_in impl Sized for Global}]: Sized) = {built_in impl Sized for alloc::boxed::Box<T>[TraitClause0_1::ImpliedClause0, {built_in impl Sized for Global}]},
-        proof ImpliedClause1: (alloc::boxed::Box<T>[TraitClause0_1::ImpliedClause0, {built_in impl Sized for Global}]: Deref) = impl_Deref_for_Box<T, Global>[TraitClause0_1::ImpliedClause0, {built_in impl Sized for Global}];
+        proof ImpliedClause0: (Box<T>[TraitClause0_1::ImpliedClause0, {built_in impl Sized for Global}]: Sized) = {built_in impl Sized for Box<T>[TraitClause0_1::ImpliedClause0, {built_in impl Sized for Global}]},
+        proof ImpliedClause1: (Box<T>[TraitClause0_1::ImpliedClause0, {built_in impl Sized for Global}]: Deref) = impl_Deref_for_Box<T, Global>[TraitClause0_1::ImpliedClause0, {built_in impl Sized for Global}];
     fn new<T, TraitClause0_1: (T: Sized)> = impl_PointerFamily_for_BoxFamily::new<T>[TraitClause0_1]
     non-dyn-compatible
 }
@@ -167,14 +177,14 @@ where
 pub fn main()
 {
     let _0: (); // return
-    let _1: alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}]; // anonymous local
+    let _1: Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
     storage_live(_1)
     _1 = make_pointer<BoxFamily, i32>[{built_in impl Sized for BoxFamily}, {built_in impl Sized for i32}, impl_PointerFamily_for_BoxFamily](const 42i32)
     ↳⚡ unwind_continue
-    set_type(typeof(_1) <= alloc::boxed::Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}])
+    set_type(typeof(_1) <= Box<i32>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}])
     conditional_drop[drop_glue<'0, i32, Global>[{built_in impl MetaSized for i32}, {built_in impl Sized for Global}]] _1
     ↳⚡ unwind_continue
     storage_dead(_1)

--- a/charon/tests/ui/simple/offset-of.out
+++ b/charon/tests/ui/simple/offset-of.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::B
 struct B {
   y: u32,

--- a/charon/tests/ui/simple/opaque-trait-with-clause-in-method.out
+++ b/charon/tests/ui/simple/opaque-trait-with-clause-in-method.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::opaque::Product
 pub trait Product<Self>
 {

--- a/charon/tests/ui/simple/partial-drop.out
+++ b/charon/tests/ui/simple/partial-drop.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -30,8 +32,16 @@ impl "impl_Destruct_for_Global" Destruct for Global {
     non-dyn-compatible
 }
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: Destruct),
+    TraitClause1: (type_error("removed allocator parameter"): Destruct),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: Destruct),
     TraitClause1: (A: Destruct),
@@ -39,8 +49,8 @@ where
     TypeOutlives1: A: '_0,
 = <opaque>
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}
-impl<T, A> "impl_Destruct_for_Box" Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}
+impl<T, A> "impl_Destruct_for_Box" Destruct for Box<T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Destruct),
     TraitClause1: (A: Destruct),
@@ -51,9 +61,9 @@ where
 
 // Full name: test_crate::Foo
 struct Foo {
-  x: alloc::boxed::Box<u32>[{built_in impl Destruct for u32}, impl_Destruct_for_Global],
-  y: alloc::boxed::Box<u32>[{built_in impl Destruct for u32}, impl_Destruct_for_Global],
-  z: alloc::boxed::Box<u32>[{built_in impl Destruct for u32}, impl_Destruct_for_Global],
+  x: Box<u32>[{built_in impl Destruct for u32}, impl_Destruct_for_Global],
+  y: Box<u32>[{built_in impl Destruct for u32}, impl_Destruct_for_Global],
+  z: Box<u32>[{built_in impl Destruct for u32}, impl_Destruct_for_Global],
 }
 
 // Full name: test_crate::foo
@@ -62,14 +72,14 @@ fn foo(f: Foo)
     let _0: (); // return
     let f: Foo; // arg #1
     let _2: (); // anonymous local
-    let _3: alloc::boxed::Box<u32>[{built_in impl Destruct for u32}, impl_Destruct_for_Global]; // anonymous local
+    let _3: Box<u32>[{built_in impl Destruct for u32}, impl_Destruct_for_Global]; // anonymous local
 
     storage_live(_0)
     _0 = ()
     storage_live(_2)
     storage_live(_3)
     _3 = move f.x
-    _2 = drop<alloc::boxed::Box<u32>[{built_in impl Destruct for u32}, impl_Destruct_for_Global]>[impl_Destruct_for_Box<u32, Global>[{built_in impl Destruct for u32}, impl_Destruct_for_Global], impl_Destruct_for_Box<u32, Global>[{built_in impl Destruct for u32}, impl_Destruct_for_Global]](move _3)
+    _2 = drop<Box<u32>[{built_in impl Destruct for u32}, impl_Destruct_for_Global]>[impl_Destruct_for_Box<u32, Global>[{built_in impl Destruct for u32}, impl_Destruct_for_Global], impl_Destruct_for_Box<u32, Global>[{built_in impl Destruct for u32}, impl_Destruct_for_Global]](move _3)
     ↳⚡ // Only `y` and `z` should be dropped here
         drop[impl_Destruct_for_Box::drop_glue<'0, u32, Global>[{built_in impl Destruct for u32}, impl_Destruct_for_Global]] f.y
         ↳⚡ storage_dead(f)

--- a/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
+++ b/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -70,6 +72,10 @@ pub trait Fn<Self, Args, Self_Clause1_Clause1_Output>
     vtable: core::ops::function::Fn::{vtable}<Args, Self_Clause1_Clause1_Output>
 }
 
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: test_crate::flabada
 pub fn flabada<'a>(x: &'a ()) -> &'a ()
 {
@@ -90,7 +96,7 @@ pub fn {impl Fn<(&'a (),), &'a ()> for for<'a> flabada<'a>}::call<'a, '_1>(state
     let args: (&'a (),); // arg #2
 
     storage_live(_0)
-    _0 = flabada<'a>(move args.0)
+    _0 = flabada<'a>(move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -107,7 +113,7 @@ pub fn call_mut<'a, '_1>(state: &'_1 mut for<'a> flabada<'a>, args: (&'a (),)) -
     let args: (&'a (),); // arg #2
 
     storage_live(_0)
-    _0 = flabada<'a>(move args.0)
+    _0 = flabada<'a>(move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -124,7 +130,7 @@ pub fn call_once<'a>(state: for<'a> flabada<'a>, args: (&'a (),)) -> &'a ()
     let args: (&'a (),); // arg #2
 
     storage_live(_0)
-    _0 = flabada<'a>(move args.0)
+    _0 = flabada<'a>(move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue

--- a/charon/tests/ui/simple/place_mention.out
+++ b/charon/tests/ui/simple/place_mention.out
@@ -1,5 +1,29 @@
 # Final LLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::main
 fn main()
 {
@@ -23,7 +47,7 @@ fn main()
     _2 = move _3
     x = &(*_2)
     fake_read(x)
-    _ = (*x).0
+    _ = (*x)._0
     _0 = ()
     storage_dead(x)
     storage_dead(_2)

--- a/charon/tests/ui/simple/promoted-closure-no-warns.out
+++ b/charon/tests/ui/simple/promoted-closure-no-warns.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -69,6 +71,10 @@ pub trait Fn<Self, Args>
     proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1>;
     vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
+}
+
+struct (_,)<A> {
+  _0: A,
 }
 
 // Full name: test_crate::foo::closure
@@ -130,7 +136,7 @@ fn call<'_0>(_1: &'_0 closure, tupled_args: (u32,)) -> u32
 
     storage_live(_0)
     storage_live(x)
-    x = move tupled_args.0
+    x = move tupled_args._0
     _0 = copy x
     storage_dead(x)
     storage_dead(tupled_args)

--- a/charon/tests/ui/simple/promoted-closure.out
+++ b/charon/tests/ui/simple/promoted-closure.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -69,6 +71,10 @@ pub trait Fn<Self, Args>
     proof ImpliedClause3: (Args: Tuple)
     fn call<'_0_1>;
     vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
+}
+
+struct (_,)<A> {
+  _0: A,
 }
 
 // Full name: test_crate::foo::closure
@@ -130,7 +136,7 @@ fn call<'_0>(_1: &'_0 closure, tupled_args: (u32,)) -> u32
 
     storage_live(_0)
     storage_live(x)
-    x = move tupled_args.0
+    x = move tupled_args._0
     _0 = copy x
     storage_dead(x)
     storage_dead(tupled_args)

--- a/charon/tests/ui/simple/promoted-in-generic-fn.out
+++ b/charon/tests/ui/simple/promoted-in-generic-fn.out
@@ -21,6 +21,8 @@ where
     TraitClause0: (T: Sized),
 = <opaque>
 
+struct () {}
+
 // Full name: test_crate::f
 fn f<T>()
 where

--- a/charon/tests/ui/simple/promoted-inside-impl.out
+++ b/charon/tests/ui/simple/promoted-inside-impl.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Foo
 pub struct Foo<F>
 where

--- a/charon/tests/ui/simple/promoted-literal-addition-overflow.out
+++ b/charon/tests/ui/simple/promoted-literal-addition-overflow.out
@@ -1,11 +1,33 @@
 # Final LLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
 // Full name: core::num::{u32}::MAX
 pub fn MAX() -> u32
 = <opaque>
 
 // Full name: core::num::{u32}::MAX
 pub const MAX: u32 = MAX()
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
 
 // Full name: test_crate::overflow
 #[allow(arithmetic_overflow)]

--- a/charon/tests/ui/simple/promoted-literal-addition.out
+++ b/charon/tests/ui/simple/promoted-literal-addition.out
@@ -1,5 +1,27 @@
 # Final LLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::two
 fn two() -> &'static u32
 {

--- a/charon/tests/ui/simple/promoted.out
+++ b/charon/tests/ui/simple/promoted.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::foo
 fn foo()
 {

--- a/charon/tests/ui/simple/promoted_in_closure.out
+++ b/charon/tests/ui/simple/promoted_in_closure.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/promoted_in_default_method.out
+++ b/charon/tests/ui/simple/promoted_in_default_method.out
@@ -5,6 +5,8 @@
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+struct () {}
+
 // Full name: test_crate::Thing
 trait Thing<Self>
 {

--- a/charon/tests/ui/simple/ptr-from-raw-parts.out
+++ b/charon/tests/ui/simple/ptr-from-raw-parts.out
@@ -80,6 +80,8 @@ pub trait Ord<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::cmp::impls::{impl PartialEq<()> for ()}::eq
 pub fn eq<'_0, '_1>(_1: &'_0 (), _2: &'_1 ()) -> bool
 = <opaque>
@@ -201,6 +203,10 @@ where
     storage_dead(metadata)
     storage_dead(data_pointer)
     return
+}
+
+struct str {
+  _0: [u8],
 }
 
 // Full name: test_crate::main

--- a/charon/tests/ui/simple/ptr_metadata.out
+++ b/charon/tests/ui/simple/ptr_metadata.out
@@ -80,6 +80,8 @@ pub trait Ord<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::cmp::impls::{impl PartialEq<()> for ()}::eq
 pub fn eq<'_0, '_1>(_1: &'_0 (), _2: &'_1 ()) -> bool
 = <opaque>
@@ -219,6 +221,10 @@ pub fn null<T>() -> *const T
 where
     TraitClause0: (T: Thin),
 = <opaque>
+
+struct str {
+  _0: [u8],
+}
 
 // Full name: test_crate::main
 fn main()

--- a/charon/tests/ui/simple/ptr_to_promoted.out
+++ b/charon/tests/ui/simple/ptr_to_promoted.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/simple/range-iter.out
+++ b/charon/tests/ui/simple/range-iter.out
@@ -75,6 +75,11 @@ impl "impl_PartialOrd_usize_for_usize" PartialOrd<usize> for usize {
     vtable: impl_PartialOrd_usize_for_usize::{vtable}
 }
 
+struct (_, _)<A, B> {
+  _0: A,
+  _1: B,
+}
+
 // Full name: core::iter::range::Step
 #[diagnostic_item("range_step")]
 pub trait Step<Self>
@@ -158,6 +163,12 @@ pub fn into_iter<I, Clause0_Item>(_1: I) -> I
 where
     TraitClause0: (I: Iterator<Clause0_Item>),
 = <opaque>
+
+struct () {}
+
+struct (_,)<A> {
+  _0: A,
+}
 
 // Full name: test_crate::iter
 fn iter(n: usize)

--- a/charon/tests/ui/simple/remove-adt-clauses-closure-keep-assoc.out
+++ b/charon/tests/ui/simple/remove-adt-clauses-closure-keep-assoc.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/remove-adt-clauses-keep-assoc.out
+++ b/charon/tests/ui/simple/remove-adt-clauses-keep-assoc.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/remove-adt-clauses-supertrait.out
+++ b/charon/tests/ui/simple/remove-adt-clauses-supertrait.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/remove-adt-clauses.out
+++ b/charon/tests/ui/simple/remove-adt-clauses.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Trait
 trait Trait<Self, Self_Type>
 {

--- a/charon/tests/ui/simple/rpitit-with-lifetime.out
+++ b/charon/tests/ui/simple/rpitit-with-lifetime.out
@@ -37,6 +37,20 @@ pub trait Iterator<Self>
     vtable: core::iter::traits::iterator::Iterator::{vtable}<Self::Item>
 }
 
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: test_crate::Foo
 trait Foo<Self, T>
 {

--- a/charon/tests/ui/simple/single-variant-enum-drop-glue.out
+++ b/charon/tests/ui/simple/single-variant-enum-drop-glue.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -26,8 +28,16 @@ pub trait Destruct<Self>
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -37,7 +47,7 @@ where
 
 // Full name: test_crate::Thing
 pub enum Thing {
-  A { _0: alloc::boxed::Box<()>[{built_in impl MetaSized for ()}, {built_in impl Sized for Global}] },
+  A { _0: Box<()>[{built_in impl MetaSized for ()}, {built_in impl Sized for Global}] },
 }
 
 // Full name: test_crate::Thing::{impl Destruct for Thing}::drop_glue

--- a/charon/tests/ui/simple/slice_increment.out
+++ b/charon/tests/ui/simple/slice_increment.out
@@ -1,5 +1,29 @@
 # Final LLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::incr
 pub fn incr<'_0>(s: &'_0 mut [u32])
 {

--- a/charon/tests/ui/simple/slice_index_range.out
+++ b/charon/tests/ui/simple/slice_index_range.out
@@ -1,5 +1,15 @@
 # Final LLBC before serialization:
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct () {}
+
 #[track_caller]
 fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: usize) -> !
 {
@@ -7,22 +17,22 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     let start: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'5 usize, &'6 usize); // local
-    let _5: &'7 usize; // anonymous local
-    let _6: &'8 usize; // anonymous local
-    let args_7: [Argument<'11>; 2usize]; // local
-    let _8: Argument<'12>; // anonymous local
-    let _9: &'13 usize; // anonymous local
-    let _10: Argument<'14>; // anonymous local
-    let _11: &'15 usize; // anonymous local
-    let _12: &'17 [u8; 57usize]; // anonymous local
-    let _13: &'18 [u8; 57usize]; // anonymous local
-    let _14: &'21 [Argument<'22>; 2usize]; // anonymous local
-    let _15: &'23 [Argument<'24>; 2usize]; // anonymous local
-    let _16: &'25 usize; // anonymous local
-    let _17: &'26 usize; // anonymous local
+    let args_4: (&'10 usize, &'11 usize); // local
+    let _5: &'15 usize; // anonymous local
+    let _6: &'16 usize; // anonymous local
+    let args_7: [Argument<'19>; 2usize]; // local
+    let _8: Argument<'20>; // anonymous local
+    let _9: &'21 usize; // anonymous local
+    let _10: Argument<'22>; // anonymous local
+    let _11: &'23 usize; // anonymous local
+    let _12: &'25 [u8; 57usize]; // anonymous local
+    let _13: &'26 [u8; 57usize]; // anonymous local
+    let _14: &'29 [Argument<'30>; 2usize]; // anonymous local
+    let _15: &'31 [Argument<'32>; 2usize]; // anonymous local
+    let _16: &'33 usize; // anonymous local
+    let _17: &'34 usize; // anonymous local
     let _18: [u8; 57usize]; // anonymous local
-    let _19: &'36 [u8; 57usize]; // anonymous local
+    let _19: &'49 [u8; 57usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -39,9 +49,9 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(args_7)
     storage_live(_8)
     storage_live(_9)
-    _16 = copy args_4.0
+    _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'28, '30, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
+    _8 = new_display<'41, '43, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -53,9 +63,9 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_dead(_9)
     storage_live(_10)
     storage_live(_11)
-    _17 = copy args_4.1
+    _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'32, '34, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
+    _10 = new_display<'45, '47, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -80,7 +90,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = core::fmt::{Arguments<'a>}::new<'38, 57usize, 2usize>(move _12, move _14)
+    _3 = core::fmt::{Arguments<'a>}::new<'51, 57usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -112,22 +122,22 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     let end: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'5 usize, &'6 usize); // local
-    let _5: &'7 usize; // anonymous local
-    let _6: &'8 usize; // anonymous local
-    let args_7: [Argument<'11>; 2usize]; // local
-    let _8: Argument<'12>; // anonymous local
-    let _9: &'13 usize; // anonymous local
-    let _10: Argument<'14>; // anonymous local
-    let _11: &'15 usize; // anonymous local
-    let _12: &'17 [u8; 55usize]; // anonymous local
-    let _13: &'18 [u8; 55usize]; // anonymous local
-    let _14: &'21 [Argument<'22>; 2usize]; // anonymous local
-    let _15: &'23 [Argument<'24>; 2usize]; // anonymous local
-    let _16: &'25 usize; // anonymous local
-    let _17: &'26 usize; // anonymous local
+    let args_4: (&'10 usize, &'11 usize); // local
+    let _5: &'15 usize; // anonymous local
+    let _6: &'16 usize; // anonymous local
+    let args_7: [Argument<'19>; 2usize]; // local
+    let _8: Argument<'20>; // anonymous local
+    let _9: &'21 usize; // anonymous local
+    let _10: Argument<'22>; // anonymous local
+    let _11: &'23 usize; // anonymous local
+    let _12: &'25 [u8; 55usize]; // anonymous local
+    let _13: &'26 [u8; 55usize]; // anonymous local
+    let _14: &'29 [Argument<'30>; 2usize]; // anonymous local
+    let _15: &'31 [Argument<'32>; 2usize]; // anonymous local
+    let _16: &'33 usize; // anonymous local
+    let _17: &'34 usize; // anonymous local
     let _18: [u8; 55usize]; // anonymous local
-    let _19: &'36 [u8; 55usize]; // anonymous local
+    let _19: &'49 [u8; 55usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -144,9 +154,9 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(args_7)
     storage_live(_8)
     storage_live(_9)
-    _16 = copy args_4.0
+    _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'28, '30, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
+    _8 = new_display<'41, '43, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -158,9 +168,9 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_dead(_9)
     storage_live(_10)
     storage_live(_11)
-    _17 = copy args_4.1
+    _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'32, '34, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
+    _10 = new_display<'45, '47, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -185,7 +195,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = core::fmt::{Arguments<'a>}::new<'38, 55usize, 2usize>(move _12, move _14)
+    _3 = core::fmt::{Arguments<'a>}::new<'51, 55usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -217,22 +227,22 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     let start: usize; // arg #1
     let end: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'5 usize, &'6 usize); // local
-    let _5: &'7 usize; // anonymous local
-    let _6: &'8 usize; // anonymous local
-    let args_7: [Argument<'11>; 2usize]; // local
-    let _8: Argument<'12>; // anonymous local
-    let _9: &'13 usize; // anonymous local
-    let _10: Argument<'14>; // anonymous local
-    let _11: &'15 usize; // anonymous local
-    let _12: &'17 [u8; 40usize]; // anonymous local
-    let _13: &'18 [u8; 40usize]; // anonymous local
-    let _14: &'21 [Argument<'22>; 2usize]; // anonymous local
-    let _15: &'23 [Argument<'24>; 2usize]; // anonymous local
-    let _16: &'25 usize; // anonymous local
-    let _17: &'26 usize; // anonymous local
+    let args_4: (&'10 usize, &'11 usize); // local
+    let _5: &'15 usize; // anonymous local
+    let _6: &'16 usize; // anonymous local
+    let args_7: [Argument<'19>; 2usize]; // local
+    let _8: Argument<'20>; // anonymous local
+    let _9: &'21 usize; // anonymous local
+    let _10: Argument<'22>; // anonymous local
+    let _11: &'23 usize; // anonymous local
+    let _12: &'25 [u8; 40usize]; // anonymous local
+    let _13: &'26 [u8; 40usize]; // anonymous local
+    let _14: &'29 [Argument<'30>; 2usize]; // anonymous local
+    let _15: &'31 [Argument<'32>; 2usize]; // anonymous local
+    let _16: &'33 usize; // anonymous local
+    let _17: &'34 usize; // anonymous local
     let _18: [u8; 40usize]; // anonymous local
-    let _19: &'36 [u8; 40usize]; // anonymous local
+    let _19: &'49 [u8; 40usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -249,9 +259,9 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(args_7)
     storage_live(_8)
     storage_live(_9)
-    _16 = copy args_4.0
+    _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'28, '30, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
+    _8 = new_display<'41, '43, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -263,9 +273,9 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_dead(_9)
     storage_live(_10)
     storage_live(_11)
-    _17 = copy args_4.1
+    _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'32, '34, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
+    _10 = new_display<'45, '47, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -290,7 +300,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = core::fmt::{Arguments<'a>}::new<'38, 40usize, 2usize>(move _12, move _14)
+    _3 = core::fmt::{Arguments<'a>}::new<'51, 40usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -322,22 +332,22 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     let end: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'5 usize, &'6 usize); // local
-    let _5: &'7 usize; // anonymous local
-    let _6: &'8 usize; // anonymous local
-    let args_7: [Argument<'11>; 2usize]; // local
-    let _8: Argument<'12>; // anonymous local
-    let _9: &'13 usize; // anonymous local
-    let _10: Argument<'14>; // anonymous local
-    let _11: &'15 usize; // anonymous local
-    let _12: &'17 [u8; 55usize]; // anonymous local
-    let _13: &'18 [u8; 55usize]; // anonymous local
-    let _14: &'21 [Argument<'22>; 2usize]; // anonymous local
-    let _15: &'23 [Argument<'24>; 2usize]; // anonymous local
-    let _16: &'25 usize; // anonymous local
-    let _17: &'26 usize; // anonymous local
+    let args_4: (&'10 usize, &'11 usize); // local
+    let _5: &'15 usize; // anonymous local
+    let _6: &'16 usize; // anonymous local
+    let args_7: [Argument<'19>; 2usize]; // local
+    let _8: Argument<'20>; // anonymous local
+    let _9: &'21 usize; // anonymous local
+    let _10: Argument<'22>; // anonymous local
+    let _11: &'23 usize; // anonymous local
+    let _12: &'25 [u8; 55usize]; // anonymous local
+    let _13: &'26 [u8; 55usize]; // anonymous local
+    let _14: &'29 [Argument<'30>; 2usize]; // anonymous local
+    let _15: &'31 [Argument<'32>; 2usize]; // anonymous local
+    let _16: &'33 usize; // anonymous local
+    let _17: &'34 usize; // anonymous local
     let _18: [u8; 55usize]; // anonymous local
-    let _19: &'36 [u8; 55usize]; // anonymous local
+    let _19: &'49 [u8; 55usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -354,9 +364,9 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(args_7)
     storage_live(_8)
     storage_live(_9)
-    _16 = copy args_4.0
+    _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'28, '30, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
+    _8 = new_display<'41, '43, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -368,9 +378,9 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_dead(_9)
     storage_live(_10)
     storage_live(_11)
-    _17 = copy args_4.1
+    _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'32, '34, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
+    _10 = new_display<'45, '47, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -395,7 +405,7 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = core::fmt::{Arguments<'a>}::new<'38, 55usize, 2usize>(move _12, move _14)
+    _3 = core::fmt::{Arguments<'a>}::new<'51, 55usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -450,7 +460,7 @@ fn core::slice::index::slice_index_fail::do_panic(start: usize, len: usize) -> !
     _3 = (move _4, move _5)
     storage_dead(_5)
     storage_dead(_4)
-    _0 = core::slice::index::slice_index_fail::do_panic::runtime(move _3.0, move _3.1)
+    _0 = core::slice::index::slice_index_fail::do_panic::runtime(move _3._0, move _3._1)
     ↳⚡ storage_dead(_3)
         storage_dead(len)
         storage_dead(start)
@@ -476,7 +486,7 @@ fn core::slice::index::slice_index_fail::do_panic#1(end: usize, len: usize) -> !
     _3 = (move _4, move _5)
     storage_dead(_5)
     storage_dead(_4)
-    _0 = core::slice::index::slice_index_fail::do_panic#1::runtime(move _3.0, move _3.1)
+    _0 = core::slice::index::slice_index_fail::do_panic#1::runtime(move _3._0, move _3._1)
     ↳⚡ storage_dead(_3)
         storage_dead(len)
         storage_dead(end)
@@ -502,7 +512,7 @@ fn core::slice::index::slice_index_fail::do_panic#2(start: usize, end: usize) ->
     _3 = (move _4, move _5)
     storage_dead(_5)
     storage_dead(_4)
-    _0 = core::slice::index::slice_index_fail::do_panic#2::runtime(move _3.0, move _3.1)
+    _0 = core::slice::index::slice_index_fail::do_panic#2::runtime(move _3._0, move _3._1)
     ↳⚡ storage_dead(_3)
         storage_dead(end)
         storage_dead(start)
@@ -528,7 +538,7 @@ fn core::slice::index::slice_index_fail::do_panic#3(end: usize, len: usize) -> !
     _3 = (move _4, move _5)
     storage_dead(_5)
     storage_dead(_4)
-    _0 = core::slice::index::slice_index_fail::do_panic#3::runtime(move _3.0, move _3.1)
+    _0 = core::slice::index::slice_index_fail::do_panic#3::runtime(move _3._0, move _3._1)
     ↳⚡ storage_dead(_3)
         storage_dead(len)
         storage_dead(end)
@@ -1068,6 +1078,10 @@ where
     storage_dead(slice)
     storage_dead(self)
     return
+}
+
+struct str {
+  _0: [u8],
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked::precondition_check

--- a/charon/tests/ui/simple/struct-with-drops.out
+++ b/charon/tests/ui/simple/struct-with-drops.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -52,8 +54,18 @@ impl "impl_Destruct_for_Global" Destruct for Global {
     non-dyn-compatible
 }
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (type_error("removed allocator parameter"): Destruct),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1, TraitClause2, TraitClause3])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -65,13 +77,13 @@ where
 
 // Full name: test_crate::B
 struct B {
-  x: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global],
-  y: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global],
+  x: Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global],
+  y: Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global],
 }
 
 // Full name: test_crate::A
 struct A {
-  x: alloc::boxed::Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global],
+  x: Box<u32>[{built_in impl MetaSized for u32}, {built_in impl Sized for Global}, {built_in impl Destruct for u32}, impl_Destruct_for_Global],
   b: B,
 }
 

--- a/charon/tests/ui/simple/supertrait-impl-with-assoc-type-constraint.out
+++ b/charon/tests/ui/simple/supertrait-impl-with-assoc-type-constraint.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::HasAssoc
 trait HasAssoc<Self>
 {

--- a/charon/tests/ui/simple/thread-local.out
+++ b/charon/tests/ui/simple/thread-local.out
@@ -52,6 +52,8 @@ impl Copy for ! {
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -206,6 +208,10 @@ where
     TypeOutlives0: T: 'static,
 = <opaque>
 
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: test_crate::FOO::__rust_std_internal_init_fn
 #[inline(hint)]
 fn __rust_std_internal_init_fn() -> u32
@@ -285,7 +291,7 @@ fn {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_i
 
     storage_live(_0)
     storage_live(__rust_std_internal_init)
-    __rust_std_internal_init = move tupled_args.0
+    __rust_std_internal_init = move tupled_args._0
     storage_live(_4)
     storage_live(_5)
     _5 = &test_crate::FOO::{const}::closure::__RUST_STD_INTERNAL_VAL
@@ -459,7 +465,7 @@ fn {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_i
 
     storage_live(_0)
     storage_live(__rust_std_internal_init)
-    __rust_std_internal_init = move tupled_args.0
+    __rust_std_internal_init = move tupled_args._0
     storage_live(_4)
     storage_live(_5)
     _5 = &test_crate::FOO::{const}::closure#1::__RUST_STD_INTERNAL_VAL

--- a/charon/tests/ui/simple/trait-alias.out
+++ b/charon/tests/ui/simple/trait-alias.out
@@ -24,6 +24,8 @@ pub trait Clone<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/trait-default-const-cross-crate.out
+++ b/charon/tests/ui/simple/trait-default-const-cross-crate.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: trait_default_const::Trait
 trait Trait<Self>
 {

--- a/charon/tests/ui/simple/trivial_generic_function.out
+++ b/charon/tests/ui/simple/trivial_generic_function.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/uncheck-ops.out
+++ b/charon/tests/ui/simple/uncheck-ops.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/simple/vec-push.out
+++ b/charon/tests/ui/simple/vec-push.out
@@ -18,6 +18,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/simple/vec-with-capacity.out
+++ b/charon/tests/ui/simple/vec-with-capacity.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -90,7 +92,7 @@ where
   len: usize,
 }
 
-// Full name: test_crate::<slice>::{impl Destruct for [T]}::drop_glue
+// Full name: {impl Destruct for [T]}::drop_glue
 unsafe fn impl_Destruct_for_slice::drop_glue<'_0, T>(_1: &'_0 mut [T])
 where
     TraitClause0: (T: Sized),
@@ -185,7 +187,7 @@ where
     return
 }
 
-// Full name: test_crate::<slice>::{impl Destruct for [T]}
+// Full name: {impl Destruct for [T]}
 impl<T> "impl_Destruct_for_slice" Destruct for [T]
 where
     TraitClause0: (T: Sized),

--- a/charon/tests/ui/simple/wrapping-ops.out
+++ b/charon/tests/ui/simple/wrapping-ops.out
@@ -66,6 +66,8 @@ pub fn wrapping_mul(self: u8, rhs: u8) -> u8
     return
 }
 
+struct () {}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/skip-borrowck.out
+++ b/charon/tests/ui/skip-borrowck.out
@@ -14,6 +14,16 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::choose
 fn choose<'a, T>(b: bool, x: &'a mut T, y: &'a mut T) -> &'a mut T
 where

--- a/charon/tests/ui/slice-index-range.out
+++ b/charon/tests/ui/slice-index-range.out
@@ -38,6 +38,16 @@ where
     TypeOutlives2: I: '_0,
 = <opaque>
 
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct () {}
+
 #[track_caller]
 fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: usize) -> !
 {
@@ -45,22 +55,22 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     let start: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'5 usize, &'6 usize); // local
-    let _5: &'7 usize; // anonymous local
-    let _6: &'8 usize; // anonymous local
-    let args_7: [Argument<'11>; 2usize]; // local
-    let _8: Argument<'12>; // anonymous local
-    let _9: &'13 usize; // anonymous local
-    let _10: Argument<'14>; // anonymous local
-    let _11: &'15 usize; // anonymous local
-    let _12: &'17 [u8; 57usize]; // anonymous local
-    let _13: &'18 [u8; 57usize]; // anonymous local
-    let _14: &'21 [Argument<'22>; 2usize]; // anonymous local
-    let _15: &'23 [Argument<'24>; 2usize]; // anonymous local
-    let _16: &'25 usize; // anonymous local
-    let _17: &'26 usize; // anonymous local
+    let args_4: (&'10 usize, &'11 usize); // local
+    let _5: &'15 usize; // anonymous local
+    let _6: &'16 usize; // anonymous local
+    let args_7: [Argument<'19>; 2usize]; // local
+    let _8: Argument<'20>; // anonymous local
+    let _9: &'21 usize; // anonymous local
+    let _10: Argument<'22>; // anonymous local
+    let _11: &'23 usize; // anonymous local
+    let _12: &'25 [u8; 57usize]; // anonymous local
+    let _13: &'26 [u8; 57usize]; // anonymous local
+    let _14: &'29 [Argument<'30>; 2usize]; // anonymous local
+    let _15: &'31 [Argument<'32>; 2usize]; // anonymous local
+    let _16: &'33 usize; // anonymous local
+    let _17: &'34 usize; // anonymous local
     let _18: [u8; 57usize]; // anonymous local
-    let _19: &'36 [u8; 57usize]; // anonymous local
+    let _19: &'49 [u8; 57usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -77,9 +87,9 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(args_7)
     storage_live(_8)
     storage_live(_9)
-    _16 = copy args_4.0
+    _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'28, '30, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
+    _8 = new_display<'41, '43, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -91,9 +101,9 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_dead(_9)
     storage_live(_10)
     storage_live(_11)
-    _17 = copy args_4.1
+    _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'32, '34, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
+    _10 = new_display<'45, '47, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -118,7 +128,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = new<'38, 57usize, 2usize>(move _12, move _14)
+    _3 = new<'51, 57usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -150,22 +160,22 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     let end: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'5 usize, &'6 usize); // local
-    let _5: &'7 usize; // anonymous local
-    let _6: &'8 usize; // anonymous local
-    let args_7: [Argument<'11>; 2usize]; // local
-    let _8: Argument<'12>; // anonymous local
-    let _9: &'13 usize; // anonymous local
-    let _10: Argument<'14>; // anonymous local
-    let _11: &'15 usize; // anonymous local
-    let _12: &'17 [u8; 55usize]; // anonymous local
-    let _13: &'18 [u8; 55usize]; // anonymous local
-    let _14: &'21 [Argument<'22>; 2usize]; // anonymous local
-    let _15: &'23 [Argument<'24>; 2usize]; // anonymous local
-    let _16: &'25 usize; // anonymous local
-    let _17: &'26 usize; // anonymous local
+    let args_4: (&'10 usize, &'11 usize); // local
+    let _5: &'15 usize; // anonymous local
+    let _6: &'16 usize; // anonymous local
+    let args_7: [Argument<'19>; 2usize]; // local
+    let _8: Argument<'20>; // anonymous local
+    let _9: &'21 usize; // anonymous local
+    let _10: Argument<'22>; // anonymous local
+    let _11: &'23 usize; // anonymous local
+    let _12: &'25 [u8; 55usize]; // anonymous local
+    let _13: &'26 [u8; 55usize]; // anonymous local
+    let _14: &'29 [Argument<'30>; 2usize]; // anonymous local
+    let _15: &'31 [Argument<'32>; 2usize]; // anonymous local
+    let _16: &'33 usize; // anonymous local
+    let _17: &'34 usize; // anonymous local
     let _18: [u8; 55usize]; // anonymous local
-    let _19: &'36 [u8; 55usize]; // anonymous local
+    let _19: &'49 [u8; 55usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -182,9 +192,9 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(args_7)
     storage_live(_8)
     storage_live(_9)
-    _16 = copy args_4.0
+    _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'28, '30, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
+    _8 = new_display<'41, '43, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -196,9 +206,9 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_dead(_9)
     storage_live(_10)
     storage_live(_11)
-    _17 = copy args_4.1
+    _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'32, '34, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
+    _10 = new_display<'45, '47, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -223,7 +233,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = new<'38, 55usize, 2usize>(move _12, move _14)
+    _3 = new<'51, 55usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -255,22 +265,22 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     let start: usize; // arg #1
     let end: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'5 usize, &'6 usize); // local
-    let _5: &'7 usize; // anonymous local
-    let _6: &'8 usize; // anonymous local
-    let args_7: [Argument<'11>; 2usize]; // local
-    let _8: Argument<'12>; // anonymous local
-    let _9: &'13 usize; // anonymous local
-    let _10: Argument<'14>; // anonymous local
-    let _11: &'15 usize; // anonymous local
-    let _12: &'17 [u8; 40usize]; // anonymous local
-    let _13: &'18 [u8; 40usize]; // anonymous local
-    let _14: &'21 [Argument<'22>; 2usize]; // anonymous local
-    let _15: &'23 [Argument<'24>; 2usize]; // anonymous local
-    let _16: &'25 usize; // anonymous local
-    let _17: &'26 usize; // anonymous local
+    let args_4: (&'10 usize, &'11 usize); // local
+    let _5: &'15 usize; // anonymous local
+    let _6: &'16 usize; // anonymous local
+    let args_7: [Argument<'19>; 2usize]; // local
+    let _8: Argument<'20>; // anonymous local
+    let _9: &'21 usize; // anonymous local
+    let _10: Argument<'22>; // anonymous local
+    let _11: &'23 usize; // anonymous local
+    let _12: &'25 [u8; 40usize]; // anonymous local
+    let _13: &'26 [u8; 40usize]; // anonymous local
+    let _14: &'29 [Argument<'30>; 2usize]; // anonymous local
+    let _15: &'31 [Argument<'32>; 2usize]; // anonymous local
+    let _16: &'33 usize; // anonymous local
+    let _17: &'34 usize; // anonymous local
     let _18: [u8; 40usize]; // anonymous local
-    let _19: &'36 [u8; 40usize]; // anonymous local
+    let _19: &'49 [u8; 40usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -287,9 +297,9 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(args_7)
     storage_live(_8)
     storage_live(_9)
-    _16 = copy args_4.0
+    _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'28, '30, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
+    _8 = new_display<'41, '43, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -301,9 +311,9 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_dead(_9)
     storage_live(_10)
     storage_live(_11)
-    _17 = copy args_4.1
+    _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'32, '34, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
+    _10 = new_display<'45, '47, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -328,7 +338,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = new<'38, 40usize, 2usize>(move _12, move _14)
+    _3 = new<'51, 40usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -360,22 +370,22 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     let end: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'5 usize, &'6 usize); // local
-    let _5: &'7 usize; // anonymous local
-    let _6: &'8 usize; // anonymous local
-    let args_7: [Argument<'11>; 2usize]; // local
-    let _8: Argument<'12>; // anonymous local
-    let _9: &'13 usize; // anonymous local
-    let _10: Argument<'14>; // anonymous local
-    let _11: &'15 usize; // anonymous local
-    let _12: &'17 [u8; 55usize]; // anonymous local
-    let _13: &'18 [u8; 55usize]; // anonymous local
-    let _14: &'21 [Argument<'22>; 2usize]; // anonymous local
-    let _15: &'23 [Argument<'24>; 2usize]; // anonymous local
-    let _16: &'25 usize; // anonymous local
-    let _17: &'26 usize; // anonymous local
+    let args_4: (&'10 usize, &'11 usize); // local
+    let _5: &'15 usize; // anonymous local
+    let _6: &'16 usize; // anonymous local
+    let args_7: [Argument<'19>; 2usize]; // local
+    let _8: Argument<'20>; // anonymous local
+    let _9: &'21 usize; // anonymous local
+    let _10: Argument<'22>; // anonymous local
+    let _11: &'23 usize; // anonymous local
+    let _12: &'25 [u8; 55usize]; // anonymous local
+    let _13: &'26 [u8; 55usize]; // anonymous local
+    let _14: &'29 [Argument<'30>; 2usize]; // anonymous local
+    let _15: &'31 [Argument<'32>; 2usize]; // anonymous local
+    let _16: &'33 usize; // anonymous local
+    let _17: &'34 usize; // anonymous local
     let _18: [u8; 55usize]; // anonymous local
-    let _19: &'36 [u8; 55usize]; // anonymous local
+    let _19: &'49 [u8; 55usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -392,9 +402,9 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(args_7)
     storage_live(_8)
     storage_live(_9)
-    _16 = copy args_4.0
+    _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'28, '30, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
+    _8 = new_display<'41, '43, usize>[{built_in impl Sized for usize}, {impl#3}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -406,9 +416,9 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_dead(_9)
     storage_live(_10)
     storage_live(_11)
-    _17 = copy args_4.1
+    _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'32, '34, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
+    _10 = new_display<'45, '47, usize>[{built_in impl Sized for usize}, {impl#3}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -433,7 +443,7 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = new<'38, 55usize, 2usize>(move _12, move _14)
+    _3 = new<'51, 55usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -502,7 +512,7 @@ fn core::slice::index::slice_index_fail::do_panic(start: usize, len: usize) -> !
     _3 = (move _4, move _5)
     storage_dead(_5)
     storage_dead(_4)
-    _0 = core::slice::index::slice_index_fail::do_panic::runtime(move _3.0, move _3.1)
+    _0 = core::slice::index::slice_index_fail::do_panic::runtime(move _3._0, move _3._1)
     ↳⚡ storage_dead(_3)
         storage_dead(len)
         storage_dead(start)
@@ -528,7 +538,7 @@ fn core::slice::index::slice_index_fail::do_panic#1(end: usize, len: usize) -> !
     _3 = (move _4, move _5)
     storage_dead(_5)
     storage_dead(_4)
-    _0 = core::slice::index::slice_index_fail::do_panic#1::runtime(move _3.0, move _3.1)
+    _0 = core::slice::index::slice_index_fail::do_panic#1::runtime(move _3._0, move _3._1)
     ↳⚡ storage_dead(_3)
         storage_dead(len)
         storage_dead(end)
@@ -554,7 +564,7 @@ fn core::slice::index::slice_index_fail::do_panic#2(start: usize, end: usize) ->
     _3 = (move _4, move _5)
     storage_dead(_5)
     storage_dead(_4)
-    _0 = core::slice::index::slice_index_fail::do_panic#2::runtime(move _3.0, move _3.1)
+    _0 = core::slice::index::slice_index_fail::do_panic#2::runtime(move _3._0, move _3._1)
     ↳⚡ storage_dead(_3)
         storage_dead(end)
         storage_dead(start)
@@ -580,7 +590,7 @@ fn core::slice::index::slice_index_fail::do_panic#3(end: usize, len: usize) -> !
     _3 = (move _4, move _5)
     storage_dead(_5)
     storage_dead(_4)
-    _0 = core::slice::index::slice_index_fail::do_panic#3::runtime(move _3.0, move _3.1)
+    _0 = core::slice::index::slice_index_fail::do_panic#3::runtime(move _3._0, move _3._1)
     ↳⚡ storage_dead(_3)
         storage_dead(len)
         storage_dead(end)
@@ -1226,6 +1236,10 @@ where
         storage_dead(slice)
         storage_dead(self)
         unwind_continue
+}
+
+struct str {
+  _0: [u8],
 }
 
 // Full name: core::slice::index::{impl SliceIndex<[T]> for Range<usize>[{built_in impl Sized for usize}]}::get_unchecked_mut::precondition_check

--- a/charon/tests/ui/statics.out
+++ b/charon/tests/ui/statics.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::constant::CONST
 fn CONST() -> usize
 {

--- a/charon/tests/ui/stealing.out
+++ b/charon/tests/ui/stealing.out
@@ -1,5 +1,29 @@
 # Final LLBC before serialization:
 
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
 // Full name: test_crate::SLICE
 fn SLICE() -> [(); 4usize]
 {

--- a/charon/tests/ui/string-literal.out
+++ b/charon/tests/ui/string-literal.out
@@ -9,6 +9,8 @@ pub trait MetaSized<Self>
 #[lang_item(String)]
 pub opaque type String
 
+struct () {}
+
 // Full name: alloc::string::String::{impl Destruct for String}::drop_glue
 unsafe fn drop_glue<'_0>(_1: &'_0 mut String)
 = <opaque>
@@ -20,6 +22,10 @@ where
     TraitClause1: (T: Display),
     TypeOutlives0: T: '_0,
 = <opaque>
+
+struct str {
+  _0: [u8],
+}
 
 // Full name: test_crate::FOO
 fn FOO() -> &'static str

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -104,7 +106,19 @@ where
 #[lang_item(String)]
 pub opaque type String
 
-// Full name: test_crate::<tuple_2>::{impl Destruct for (A, B)}::drop_glue
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct (_,)<A> {
+  _0: A,
+}
+
+// Full name: (_, _)::{impl Destruct for (A, B)}::drop_glue
 unsafe fn impl_Destruct_for_tuple::drop_glue<'_0, A, B>(_1: &'_0 mut (A, B))
 where
     TraitClause0: (A: Sized),
@@ -116,20 +130,20 @@ where
 
     storage_live(_0)
     _0 = ()
-    drop[{built_in impl Destruct for A}::drop_glue<'2>] (*_1).0
-    ↳⚡ drop[{built_in impl Destruct for B}::drop_glue<'4>] (*_1).1
+    drop[{built_in impl Destruct for A}::drop_glue<'2>] (*_1)._0
+    ↳⚡ drop[{built_in impl Destruct for B}::drop_glue<'4>] (*_1)._1
         ↳⚡ storage_dead(_1)
             unwind_terminate
         storage_dead(_1)
         unwind_continue
-    drop[{built_in impl Destruct for B}::drop_glue<'3>] (*_1).1
+    drop[{built_in impl Destruct for B}::drop_glue<'3>] (*_1)._1
     ↳⚡ storage_dead(_1)
         unwind_continue
     storage_dead(_1)
     return
 }
 
-// Full name: test_crate::<tuple_2>::{impl Destruct for (A, B)}
+// Full name: (_, _)::{impl Destruct for (A, B)}
 impl<A, B> "impl_Destruct_for_tuple" Destruct for (A, B)
 where
     TraitClause0: (A: Sized),
@@ -395,7 +409,7 @@ where
     storage_live(_6)
     storage_live(_2)
     storage_live(_3)
-    _3 = move self.0
+    _3 = move self._0
     _2 = TraitClause1::to_u64(move _3)
     ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'0>] _3
         ↳⚡ storage_dead(_6)
@@ -411,7 +425,7 @@ where
     storage_dead(_3)
     storage_live(_4)
     storage_live(_5)
-    _5 = move self.1
+    _5 = move self._1
     _4 = TraitClause1::to_u64(move _5)
     ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'2>] _5
         ↳⚡ storage_dead(_6)
@@ -1550,7 +1564,7 @@ pub fn {impl Fn<(&'a (),)> for for<'a> flabada<'a>}::call<'a, '_1>(state: &'_1 f
     let args: (&'a (),); // arg #2
 
     storage_live(_0)
-    _0 = flabada<'a>(move args.0)
+    _0 = flabada<'a>(move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -1567,7 +1581,7 @@ pub fn call_mut<'a, '_1>(state: &'_1 mut for<'a> flabada<'a>, args: (&'a (),)) -
     let args: (&'a (),); // arg #2
 
     storage_live(_0)
-    _0 = flabada<'a>(move args.0)
+    _0 = flabada<'a>(move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue
@@ -1584,7 +1598,7 @@ pub fn call_once<'a>(state: for<'a> flabada<'a>, args: (&'a (),)) -> Wrapper<(bo
     let args: (&'a (),); // arg #2
 
     storage_live(_0)
-    _0 = flabada<'a>(move args.0)
+    _0 = flabada<'a>(move args._0)
     ↳⚡ storage_dead(args)
         storage_dead(state)
         unwind_continue

--- a/charon/tests/ui/traits/default-method-with-item-bound.2.out
+++ b/charon/tests/ui/traits/default-method-with-item-bound.2.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::HasAssoc1
 pub trait HasAssoc1<Self>
 {

--- a/charon/tests/ui/traits/default-method-with-item-bound.3.out
+++ b/charon/tests/ui/traits/default-method-with-item-bound.3.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::HasAssoc
 trait HasAssoc<Self, T>
 {

--- a/charon/tests/ui/traits/default-method-with-item-bound.4.out
+++ b/charon/tests/ui/traits/default-method-with-item-bound.4.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Has
 trait Has<Self, T>
 {

--- a/charon/tests/ui/traits/default-method-with-item-bound.5.out
+++ b/charon/tests/ui/traits/default-method-with-item-bound.5.out
@@ -50,6 +50,12 @@ pub trait FnMut<Self, Args>
     vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
 }
 
+struct () {}
+
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: test_crate::Iterator
 trait Iterator<Self>
 {

--- a/charon/tests/ui/traits/default-method-with-item-bound.6.out
+++ b/charon/tests/ui/traits/default-method-with-item-bound.6.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Takes
 trait Takes<Self, T>
 {

--- a/charon/tests/ui/traits/default-method-with-item-bound.out
+++ b/charon/tests/ui/traits/default-method-with-item-bound.out
@@ -49,6 +49,8 @@ where
 #[lang_item(String)]
 pub opaque type String
 
+struct () {}
+
 // Full name: test_crate::Trait
 pub trait Trait<Self>
 {

--- a/charon/tests/ui/traits/issue-513-gat-clause-mismatch-use-clause.out
+++ b/charon/tests/ui/traits/issue-513-gat-clause-mismatch-use-clause.out
@@ -33,6 +33,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::HasAssoc
 trait HasAssoc<Self>
 {

--- a/charon/tests/ui/traits/issue-513-gat-clause-mismatch.out
+++ b/charon/tests/ui/traits/issue-513-gat-clause-mismatch.out
@@ -34,6 +34,8 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Trait
 trait Trait<Self>
 {

--- a/charon/tests/ui/traits/issue-513-method-clause-mismatch-and-default-call.out
+++ b/charon/tests/ui/traits/issue-513-method-clause-mismatch-and-default-call.out
@@ -34,6 +34,8 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Trait
 trait Trait<Self>
 {

--- a/charon/tests/ui/traits/issue-513-method-clause-mismatch.out
+++ b/charon/tests/ui/traits/issue-513-method-clause-mismatch.out
@@ -34,6 +34,8 @@ pub trait Copy<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/traits/issue-513-method-late-bound-mismatch.out
+++ b/charon/tests/ui/traits/issue-513-method-late-bound-mismatch.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Trait
 trait Trait<Self>
 {

--- a/charon/tests/ui/traits/pointee-metadata-bounds.out
+++ b/charon/tests/ui/traits/pointee-metadata-bounds.out
@@ -80,6 +80,8 @@ pub trait Ord<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::hash::Hasher
 pub trait Hasher<Self>
 {
@@ -139,6 +141,10 @@ pub trait Pointee<Self>
     proof ImpliedClause8: (Self::Metadata: Freeze)
     type Metadata
     non-dyn-compatible
+}
+
+struct str {
+  _0: [u8],
 }
 
 // Full name: test_crate::assert_copy

--- a/charon/tests/ui/traits/remove-self-clause-on-closure.out
+++ b/charon/tests/ui/traits/remove-self-clause-on-closure.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>

--- a/charon/tests/ui/traits/remove-unused-clauses.out
+++ b/charon/tests/ui/traits/remove-unused-clauses.out
@@ -14,6 +14,8 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Trait
 trait Trait<Self>
 {

--- a/charon/tests/ui/traits_special.out
+++ b/charon/tests/ui/traits_special.out
@@ -25,6 +25,8 @@ where
   Err { _0: E },
 }
 
+struct () {}
+
 // Full name: test_crate::From
 pub trait From<Self, T>
 {

--- a/charon/tests/ui/type-id.out
+++ b/charon/tests/ui/type-id.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: core::any::TypeId
 #[lang_item(TypeId)]
 pub struct TypeId {

--- a/charon/tests/ui/type_alias.out
+++ b/charon/tests/ui/type_alias.out
@@ -113,6 +113,8 @@ where
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: test_crate::Usize
 pub type Usize = usize
 

--- a/charon/tests/ui/type_inference_is_order_dependent.out
+++ b/charon/tests/ui/type_inference_is_order_dependent.out
@@ -34,6 +34,8 @@ impl "impl_Default_for_bool" Default for bool {
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -45,6 +47,10 @@ pub trait Destruct<Self>
 // Full name: std::io::stdio::_print
 pub fn _print<'_0>(_1: Arguments<'_0>)
 = <opaque>
+
+struct (_,)<A> {
+  _0: A,
+}
 
 // Full name: test_crate::Left
 trait Left<Self, T>
@@ -95,7 +101,7 @@ where
     let _11: &'16 [Argument<'17>; 1usize]; // anonymous local
     let _12: &'18 [Argument<'19>; 1usize]; // anonymous local
     let _13: [u8; 4usize]; // anonymous local
-    let _14: &'26 [u8; 4usize]; // anonymous local
+    let _14: &'27 [u8; 4usize]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -113,9 +119,9 @@ where
     storage_live(args_6)
     storage_live(_7)
     storage_live(_8)
-    _8 = &(*args_3.0)
-    _7 = new_debug<'21, '23, U>[TraitClause1, TraitClause5](move _8)
-    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'24>] _5
+    _8 = &(*args_3._0)
+    _7 = new_debug<'22, '24, U>[TraitClause1, TraitClause5](move _8)
+    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'25>] _5
         ↳⚡ storage_dead(_14)
             storage_dead(_13)
             unwind_terminate
@@ -136,8 +142,8 @@ where
     storage_live(_12)
     _12 = &args_6
     _11 = &(*_12)
-    _2 = new<'28, 4usize, 1usize>(move _9, move _11)
-    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'24>] _5
+    _2 = new<'29, 4usize, 1usize>(move _9, move _11)
+    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'25>] _5
         ↳⚡ storage_dead(_14)
             storage_dead(_13)
             unwind_terminate
@@ -146,15 +152,15 @@ where
     storage_dead(_11)
     storage_dead(_10)
     storage_dead(_9)
-    _1 = _print<'30>(move _2)
-    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'24>] _5
+    _1 = _print<'31>(move _2)
+    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'25>] _5
         ↳⚡ storage_dead(_14)
             storage_dead(_13)
             unwind_terminate
         unwind_continue
     storage_dead(_2)
     storage_dead(args_6)
-    conditional_drop[{built_in impl Destruct for U}::drop_glue<'31>] _5
+    conditional_drop[{built_in impl Destruct for U}::drop_glue<'32>] _5
     ↳⚡ unwind_continue
     storage_dead(_5)
     storage_dead(args_3)

--- a/charon/tests/ui/typenum.out
+++ b/charon/tests/ui/typenum.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::UInt
 pub struct UInt<U, B> {
   _0: U,

--- a/charon/tests/ui/unions.out
+++ b/charon/tests/ui/unions.out
@@ -1,5 +1,7 @@
 # Final LLBC before serialization:
 
+struct () {}
+
 // Full name: test_crate::Foo
 union Foo {
   one: u64,

--- a/charon/tests/ui/unsafe-impl-send.out
+++ b/charon/tests/ui/unsafe-impl-send.out
@@ -4,6 +4,8 @@
 #[diagnostic_item("Send")]
 pub trait Send<Self>
 
+struct () {}
+
 // Full name: test_crate::Foo
 struct Foo {
   _0: *const (),

--- a/charon/tests/ui/unsafe.out
+++ b/charon/tests/ui/unsafe.out
@@ -80,6 +80,8 @@ pub trait Ord<Self>
     non-dyn-compatible
 }
 
+struct () {}
+
 // Full name: core::cmp::impls::{impl PartialEq<()> for ()}::eq
 pub fn eq<'_0, '_1>(_1: &'_0 (), _2: &'_1 ()) -> bool
 = <opaque>
@@ -211,6 +213,18 @@ pub fn null<T>() -> *const T
 where
     TraitClause0: (T: Thin),
 = <opaque>
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct str {
+  _0: [u8],
+}
 
 // Full name: test_crate::call_unsafe_fn
 fn call_unsafe_fn()

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -18,8 +18,18 @@ pub trait Sized<Self>
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+struct () {}
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -29,7 +39,7 @@ where
 
 #[track_caller]
 #[diagnostic_item("box_new")]
-pub fn alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<T>(_1: T) -> alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+pub fn alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
 where
     TraitClause0: (T: Sized),
 = <opaque>
@@ -91,8 +101,8 @@ fn foo()
     let _2: &'1 [i32]; // anonymous local
     let _3: &'3 [i32; 2usize]; // anonymous local
     let _4: &'4 [i32; 2usize]; // anonymous local
-    let _5: alloc::boxed::Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]; // anonymous local
-    let _6: alloc::boxed::Box<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _5: Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]; // anonymous local
+    let _6: Box<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]; // anonymous local
     let _7: [i32; 2usize]; // anonymous local
     let _8: Rc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]; // anonymous local
     let _9: Rc<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]; // anonymous local
@@ -101,8 +111,8 @@ fn foo()
     let _12: &'8 (dyn Display + '9); // anonymous local
     let _13: &'11 String; // anonymous local
     let _14: &'12 String; // anonymous local
-    let _15: alloc::boxed::Box<(dyn Display + '17)>[{built_in impl MetaSized for (dyn Display + '19)}, {built_in impl Sized for Global}]; // anonymous local
-    let _16: alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
+    let _15: Box<(dyn Display + '17)>[{built_in impl MetaSized for (dyn Display + '19)}, {built_in impl Sized for Global}]; // anonymous local
+    let _16: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
     let _17: String; // anonymous local
     let _18: &'20 String; // anonymous local
     let _19: Rc<(dyn Display + '25)>[{built_in impl MetaSized for (dyn Display + '27)}, {built_in impl Sized for Global}]; // anonymous local
@@ -132,16 +142,16 @@ fn foo()
     storage_live(_6)
     storage_live(_7)
     _7 = copy array
-    _6 = alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<[i32; 2usize]>[{built_in impl Sized for [i32; 2usize]}](move _7)
+    _6 = alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<[i32; 2usize]>[{built_in impl Sized for [i32; 2usize]}](move _7)
     ↳⚡ unwind_continue
-    _5 = unsize_cast<alloc::boxed::Box<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 2usize>(move _6)
+    _5 = unsize_cast<Box<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}], Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 2usize>(move _6)
     conditional_drop[impl_Destruct_for_Box::drop_glue<'31, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _6
     ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'33, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_7)
     storage_dead(_6)
-    set_type(typeof(_5) <= alloc::boxed::Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}])
+    set_type(typeof(_5) <= Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}])
     conditional_drop[impl_Destruct_for_Box::drop_glue<'32, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
     ↳⚡ unwind_continue
     storage_dead(_5)
@@ -186,13 +196,13 @@ fn foo()
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_18)
-    _16 = alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<String>[{built_in impl Sized for String}](move _17)
+    _16 = alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<String>[{built_in impl Sized for String}](move _17)
     ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'44>] _17
         ↳⚡ unwind_terminate
         conditional_drop[impl_Destruct_for_String::drop_glue<'43>] string
         ↳⚡ unwind_terminate
         unwind_continue
-    _15 = unsize_cast<alloc::boxed::Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], alloc::boxed::Box<(dyn Display + '45)>[{built_in impl MetaSized for (dyn Display + '47)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _16)
+    _15 = unsize_cast<Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Box<(dyn Display + '45)>[{built_in impl MetaSized for (dyn Display + '47)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _16)
     conditional_drop[impl_Destruct_for_Box::drop_glue<'48, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _16
     ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] _17
         ↳⚡ unwind_terminate
@@ -203,7 +213,7 @@ fn foo()
         unwind_continue
     storage_dead(_17)
     storage_dead(_16)
-    set_type(typeof(_15) <= alloc::boxed::Box<(dyn Display + '49)>[{built_in impl MetaSized for (dyn Display + '51)}, {built_in impl Sized for Global}])
+    set_type(typeof(_15) <= Box<(dyn Display + '49)>[{built_in impl MetaSized for (dyn Display + '51)}, {built_in impl Sized for Global}])
     conditional_drop[impl_Destruct_for_Box::drop_glue<'64, (dyn Display + '60), Global>[{built_in impl MetaSized for (dyn Display + '60)}, {built_in impl Sized for Global}]] _15
     ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'43>] string
         ↳⚡ unwind_terminate

--- a/charon/tests/ui/unsized-string-consts.out
+++ b/charon/tests/ui/unsized-string-consts.out
@@ -9,6 +9,8 @@ pub trait MetaSized<Self>
 #[lang_item(String)]
 pub opaque type String
 
+struct () {}
+
 // Full name: alloc::string::String::{impl Destruct for String}::drop_glue
 unsafe fn drop_glue<'_0>(_1: &'_0 mut String)
 = <opaque>
@@ -20,6 +22,10 @@ where
     TraitClause1: (T: Display),
     TypeOutlives0: T: '_0,
 = <opaque>
+
+struct str {
+  _0: [u8],
+}
 
 // Full name: test_crate::FOO
 fn FOO() -> &'static str

--- a/charon/tests/ui/unsupported/issue-79-bound-regions.out
+++ b/charon/tests/ui/unsupported/issue-79-bound-regions.out
@@ -50,6 +50,20 @@ where
     TypeOutlives0: T: '_0,
 = <opaque>
 
+struct () {}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct (_,)<A> {
+  _0: A,
+}
+
 // Full name: test_crate::main
 fn main()
 {

--- a/charon/tests/ui/unwind-llbc.out
+++ b/charon/tests/ui/unwind-llbc.out
@@ -5,6 +5,17 @@
 #[lang_item(MetaSized)]
 pub trait MetaSized<Self>
 
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
 // Full name: core::marker::Destruct
 #[lang_item(Destruct)]
 pub trait Destruct<Self>
@@ -27,6 +38,14 @@ where
     TraitClause0: (Self: Drop),
     TypeOutlives0: Self: '_0,
 = <opaque>
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
 
 // Full name: test_crate::Foo
 struct Foo {}
@@ -109,11 +128,11 @@ fn main()
     storage_dead(_2)
     storage_live(_3)
     _4 = const 255u8 checked.+ const 1u8
-    assert(move _4.1 == false) (overflow) else panic
+    assert(move _4._1 == false) (overflow) else panic
     ↳⚡ conditional_drop[drop_glue<'2>] f
         ↳⚡ unwind_terminate
         unwind_continue
-    _3 = move _4.0
+    _3 = move _4._0
     storage_dead(_3)
     storage_live(_5)
     _5 = &f

--- a/charon/tests/ui/variadics.out
+++ b/charon/tests/ui/variadics.out
@@ -4,6 +4,8 @@
 #[lang_item(VaList)]
 pub opaque type VaList<'a>
 
+struct () {}
+
 // Full name: core::ffi::va_list::VaList::{impl Destruct for VaList<'a>}::drop_glue
 unsafe fn drop_glue<'a, '_1>(_1: &'_1 mut VaList<'a>)
 where
@@ -46,6 +48,14 @@ where
     TraitClause1: (T: VaArgSafe),
     RegionOutlives0: 'f: '_1,
 = <opaque>
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
 
 // Full name: test_crate::sum
 pub unsafe extern "C" fn sum(...) -> i32

--- a/charon/tests/ui/vec-reconstruct-move-values.out
+++ b/charon/tests/ui/vec-reconstruct-move-values.out
@@ -24,8 +24,18 @@ where
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+struct () {}
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -33,10 +43,10 @@ where
     TypeOutlives1: A: '_0,
 = <opaque>
 
-// Full name: alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
+// Full name: alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
 #[track_caller]
 #[diagnostic_item("box_new")]
-pub fn new<T>(_1: T) -> alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+pub fn new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
 where
     TraitClause0: (T: Sized),
 = <opaque>
@@ -49,7 +59,7 @@ where
     TraitClause1: (type_error("removed allocator parameter"): Sized),
 
 // Full name: alloc::slice::{[T]}::into_vec
-pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
+pub fn into_vec<T, A>(_1: Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (A: Sized),
@@ -76,23 +86,23 @@ fn move_values(flag: bool)
     let flag: bool; // arg #1
     let x_2: NoCopy; // local
     let _v: Vec<NoCopy>[{built_in impl Sized for NoCopy}, {built_in impl Sized for Global}]; // local
-    let _4: alloc::boxed::Box<MaybeUninit<[NoCopy; 1usize]>[{built_in impl Sized for [NoCopy; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[NoCopy; 1usize]>[{built_in impl Sized for [NoCopy; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _4: Box<MaybeUninit<[NoCopy; 1usize]>[{built_in impl Sized for [NoCopy; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[NoCopy; 1usize]>[{built_in impl Sized for [NoCopy; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let _5: NoCopy; // anonymous local
     let _6: bool; // anonymous local
     let y_7: NoCopy; // local
     let _w: Vec<NoCopy>[{built_in impl Sized for NoCopy}, {built_in impl Sized for Global}]; // local
-    let _9: alloc::boxed::Box<MaybeUninit<[NoCopy; 1usize]>[{built_in impl Sized for [NoCopy; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[NoCopy; 1usize]>[{built_in impl Sized for [NoCopy; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _9: Box<MaybeUninit<[NoCopy; 1usize]>[{built_in impl Sized for [NoCopy; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[NoCopy; 1usize]>[{built_in impl Sized for [NoCopy; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let _10: NoCopy; // anonymous local
     let ret_11: Vec<NoCopy>[{built_in impl Sized for NoCopy}, {built_in impl Sized for Global}]; // local
-    let x_12: alloc::boxed::Box<[NoCopy; 1usize]>[{built_in impl MetaSized for [NoCopy; 1usize]}, {built_in impl Sized for Global}]; // local
-    let y_13: alloc::boxed::Box<[NoCopy]>[{built_in impl MetaSized for [NoCopy]}, {built_in impl Sized for Global}]; // local
+    let x_12: Box<[NoCopy; 1usize]>[{built_in impl MetaSized for [NoCopy; 1usize]}, {built_in impl Sized for Global}]; // local
+    let y_13: Box<[NoCopy]>[{built_in impl MetaSized for [NoCopy]}, {built_in impl Sized for Global}]; // local
     let ret_14: Vec<NoCopy>[{built_in impl Sized for NoCopy}, {built_in impl Sized for Global}]; // local
-    let x_15: alloc::boxed::Box<[NoCopy; 1usize]>[{built_in impl MetaSized for [NoCopy; 1usize]}, {built_in impl Sized for Global}]; // local
-    let y_16: alloc::boxed::Box<[NoCopy]>[{built_in impl MetaSized for [NoCopy]}, {built_in impl Sized for Global}]; // local
+    let x_15: Box<[NoCopy; 1usize]>[{built_in impl MetaSized for [NoCopy; 1usize]}, {built_in impl Sized for Global}]; // local
+    let y_16: Box<[NoCopy]>[{built_in impl MetaSized for [NoCopy]}, {built_in impl Sized for Global}]; // local
     let _17: [NoCopy; 1usize]; // anonymous local
-    let _18: alloc::boxed::Box<[NoCopy; 1usize]>[{built_in impl MetaSized for [NoCopy; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _18: Box<[NoCopy; 1usize]>[{built_in impl MetaSized for [NoCopy; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
     let _19: [NoCopy; 1usize]; // anonymous local
-    let _20: alloc::boxed::Box<[NoCopy; 1usize]>[{built_in impl MetaSized for [NoCopy; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _20: Box<[NoCopy; 1usize]>[{built_in impl MetaSized for [NoCopy; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -121,7 +131,7 @@ fn move_values(flag: bool)
     storage_dead(_17)
     x_12 = move _18
     storage_dead(_18)
-    y_13 = unsize_cast<alloc::boxed::Box<[NoCopy; 1usize]>[{built_in impl MetaSized for [NoCopy; 1usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[NoCopy]>[{built_in impl MetaSized for [NoCopy]}, {built_in impl Sized for Global}], 1usize>(move x_12)
+    y_13 = unsize_cast<Box<[NoCopy; 1usize]>[{built_in impl MetaSized for [NoCopy; 1usize]}, {built_in impl Sized for Global}], Box<[NoCopy]>[{built_in impl MetaSized for [NoCopy]}, {built_in impl Sized for Global}], 1usize>(move x_12)
     ret_11 = into_vec<NoCopy, Global>[{built_in impl Sized for NoCopy}, {built_in impl Sized for Global}](move y_13)
     ↳⚡ storage_dead(y_13)
         storage_dead(x_12)
@@ -170,7 +180,7 @@ fn move_values(flag: bool)
         storage_dead(_19)
         x_15 = move _20
         storage_dead(_20)
-        y_16 = unsize_cast<alloc::boxed::Box<[NoCopy; 1usize]>[{built_in impl MetaSized for [NoCopy; 1usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[NoCopy]>[{built_in impl MetaSized for [NoCopy]}, {built_in impl Sized for Global}], 1usize>(move x_15)
+        y_16 = unsize_cast<Box<[NoCopy; 1usize]>[{built_in impl MetaSized for [NoCopy; 1usize]}, {built_in impl Sized for Global}], Box<[NoCopy]>[{built_in impl MetaSized for [NoCopy]}, {built_in impl Sized for Global}], 1usize>(move x_15)
         ret_14 = into_vec<NoCopy, Global>[{built_in impl Sized for NoCopy}, {built_in impl Sized for Global}](move y_16)
         ↳⚡ storage_dead(y_16)
             storage_dead(x_15)

--- a/charon/tests/ui/vec-reconstruct-multiple-adjacent.out
+++ b/charon/tests/ui/vec-reconstruct-multiple-adjacent.out
@@ -45,8 +45,18 @@ where
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+struct () {}
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -54,10 +64,10 @@ where
     TypeOutlives1: A: '_0,
 = <opaque>
 
-// Full name: alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
+// Full name: alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
 #[track_caller]
 #[diagnostic_item("box_new")]
-pub fn new<T>(_1: T) -> alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+pub fn new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
 where
     TraitClause0: (T: Sized),
 = <opaque>
@@ -70,7 +80,7 @@ where
     TraitClause1: (type_error("removed allocator parameter"): Sized),
 
 // Full name: alloc::slice::{[T]}::into_vec
-pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
+pub fn into_vec<T, A>(_1: Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (A: Sized),
@@ -98,26 +108,26 @@ fn multiple_adjacent()
 {
     let _0: (); // return
     let _a: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // local
-    let _2: alloc::boxed::Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _2: Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let _b: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // local
-    let _4: alloc::boxed::Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _4: Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let _c: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // local
-    let _6: alloc::boxed::Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _6: Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let ret_7: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // local
-    let x_8: alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // local
-    let y_9: alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
+    let x_8: Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // local
+    let y_9: Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
     let ret_10: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // local
-    let x_11: alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // local
-    let y_12: alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
+    let x_11: Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // local
+    let y_12: Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
     let ret_13: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // local
-    let x_14: alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // local
-    let y_15: alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
+    let x_14: Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // local
+    let y_15: Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
     let _16: [u8; 1usize]; // anonymous local
-    let _17: alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _17: Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
     let _18: [u8; 1usize]; // anonymous local
-    let _19: alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _19: Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
     let _20: [u8; 1usize]; // anonymous local
-    let _21: alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _21: Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -139,7 +149,7 @@ fn multiple_adjacent()
     storage_dead(_16)
     x_8 = move _17
     storage_dead(_17)
-    y_9 = unsize_cast<alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 1usize>(move x_8)
+    y_9 = unsize_cast<Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}], Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 1usize>(move x_8)
     ret_7 = into_vec<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}](move y_9)
     ↳⚡ storage_dead(y_9)
         storage_dead(x_8)
@@ -177,7 +187,7 @@ fn multiple_adjacent()
     storage_dead(_18)
     x_11 = move _19
     storage_dead(_19)
-    y_12 = unsize_cast<alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 1usize>(move x_11)
+    y_12 = unsize_cast<Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}], Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 1usize>(move x_11)
     ret_10 = into_vec<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}](move y_12)
     ↳⚡ storage_dead(y_12)
         storage_dead(x_11)
@@ -225,7 +235,7 @@ fn multiple_adjacent()
     storage_dead(_20)
     x_14 = move _21
     storage_dead(_21)
-    y_15 = unsize_cast<alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 1usize>(move x_14)
+    y_15 = unsize_cast<Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}], Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 1usize>(move x_14)
     ret_13 = into_vec<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}](move y_15)
     ↳⚡ storage_dead(y_15)
         storage_dead(x_14)
@@ -286,12 +296,12 @@ fn multiple_values()
 {
     let _0: (); // return
     let _a: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // local
-    let _2: alloc::boxed::Box<MaybeUninit<[u8; 3usize]>[{built_in impl Sized for [u8; 3usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 3usize]>[{built_in impl Sized for [u8; 3usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _2: Box<MaybeUninit<[u8; 3usize]>[{built_in impl Sized for [u8; 3usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 3usize]>[{built_in impl Sized for [u8; 3usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let ret: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // local
-    let x: alloc::boxed::Box<[u8; 3usize]>[{built_in impl MetaSized for [u8; 3usize]}, {built_in impl Sized for Global}]; // local
-    let y: alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
+    let x: Box<[u8; 3usize]>[{built_in impl MetaSized for [u8; 3usize]}, {built_in impl Sized for Global}]; // local
+    let y: Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
     let _6: [u8; 3usize]; // anonymous local
-    let _7: alloc::boxed::Box<[u8; 3usize]>[{built_in impl MetaSized for [u8; 3usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _7: Box<[u8; 3usize]>[{built_in impl MetaSized for [u8; 3usize]}, {built_in impl Sized for Global}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -311,7 +321,7 @@ fn multiple_values()
     storage_dead(_6)
     x = move _7
     storage_dead(_7)
-    y = unsize_cast<alloc::boxed::Box<[u8; 3usize]>[{built_in impl MetaSized for [u8; 3usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 3usize>(move x)
+    y = unsize_cast<Box<[u8; 3usize]>[{built_in impl MetaSized for [u8; 3usize]}, {built_in impl Sized for Global}], Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 3usize>(move x)
     ret = into_vec<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}](move y)
     ↳⚡ storage_dead(y)
         storage_dead(x)
@@ -347,15 +357,15 @@ fn with_fn_calls()
 {
     let _0: (); // return
     let _a: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // local
-    let _2: alloc::boxed::Box<MaybeUninit<[u8; 2usize]>[{built_in impl Sized for [u8; 2usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 2usize]>[{built_in impl Sized for [u8; 2usize]}]}, {built_in impl Sized for Global}]; // anonymous local
-    let _3: alloc::boxed::Box<MaybeUninit<[u8; 2usize]>[{built_in impl Sized for [u8; 2usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 2usize]>[{built_in impl Sized for [u8; 2usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _2: Box<MaybeUninit<[u8; 2usize]>[{built_in impl Sized for [u8; 2usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 2usize]>[{built_in impl Sized for [u8; 2usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _3: Box<MaybeUninit<[u8; 2usize]>[{built_in impl Sized for [u8; 2usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 2usize]>[{built_in impl Sized for [u8; 2usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let _4: u8; // anonymous local
     let _5: u8; // anonymous local
     let ret: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // local
-    let x: alloc::boxed::Box<[u8; 2usize]>[{built_in impl MetaSized for [u8; 2usize]}, {built_in impl Sized for Global}]; // local
-    let y: alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
+    let x: Box<[u8; 2usize]>[{built_in impl MetaSized for [u8; 2usize]}, {built_in impl Sized for Global}]; // local
+    let y: Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
     let _9: [u8; 2usize]; // anonymous local
-    let _10: alloc::boxed::Box<[u8; 2usize]>[{built_in impl MetaSized for [u8; 2usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _10: Box<[u8; 2usize]>[{built_in impl MetaSized for [u8; 2usize]}, {built_in impl Sized for Global}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -391,7 +401,7 @@ fn with_fn_calls()
     storage_dead(_9)
     x = move _10
     storage_dead(_10)
-    y = unsize_cast<alloc::boxed::Box<[u8; 2usize]>[{built_in impl MetaSized for [u8; 2usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 2usize>(move x)
+    y = unsize_cast<Box<[u8; 2usize]>[{built_in impl MetaSized for [u8; 2usize]}, {built_in impl Sized for Global}], Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 2usize>(move x)
     ret = into_vec<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}](move y)
     ↳⚡ storage_dead(y)
         storage_dead(x)

--- a/charon/tests/ui/vec-reconstruct-nested.out
+++ b/charon/tests/ui/vec-reconstruct-nested.out
@@ -24,8 +24,18 @@ where
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
 
-// Full name: alloc::boxed::Box::{impl Destruct for alloc::boxed::Box<T>[TraitClause0, TraitClause1]}::drop_glue
-unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut alloc::boxed::Box<T>[TraitClause0, TraitClause1])
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+struct () {}
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (A: Sized),
@@ -33,10 +43,10 @@ where
     TypeOutlives1: A: '_0,
 = <opaque>
 
-// Full name: alloc::boxed::{alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
+// Full name: alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
 #[track_caller]
 #[diagnostic_item("box_new")]
-pub fn new<T>(_1: T) -> alloc::boxed::Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+pub fn new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
 where
     TraitClause0: (T: Sized),
 = <opaque>
@@ -49,7 +59,7 @@ where
     TraitClause1: (type_error("removed allocator parameter"): Sized),
 
 // Full name: alloc::slice::{[T]}::into_vec
-pub fn into_vec<T, A>(_1: alloc::boxed::Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
+pub fn into_vec<T, A>(_1: Box<[T]>[{built_in impl MetaSized for [T]}, TraitClause1]) -> Vec<T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (A: Sized),
@@ -69,27 +79,27 @@ fn nested_vecs()
 {
     let _0: (); // return
     let _nested: Vec<Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]>[{built_in impl Sized for Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]}, {built_in impl Sized for Global}]; // local
-    let _2: alloc::boxed::Box<MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]}]>[{built_in impl MetaSized for MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]}]}, {built_in impl Sized for Global}]; // anonymous local
-    let _3: alloc::boxed::Box<MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]}]>[{built_in impl MetaSized for MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _2: Box<MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]}]>[{built_in impl MetaSized for MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _3: Box<MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]}]>[{built_in impl MetaSized for MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let _4: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // anonymous local
-    let _5: alloc::boxed::Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _5: Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let _6: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // anonymous local
-    let _7: alloc::boxed::Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _7: Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let ret_8: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // local
-    let x_9: alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // local
-    let y_10: alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
+    let x_9: Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // local
+    let y_10: Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
     let ret_11: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // local
-    let x_12: alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // local
-    let y_13: alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
+    let x_12: Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // local
+    let y_13: Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
     let ret_14: Vec<Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]>[{built_in impl Sized for Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]}, {built_in impl Sized for Global}]; // local
-    let x_15: alloc::boxed::Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]}, {built_in impl Sized for Global}]; // local
-    let y_16: alloc::boxed::Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]}, {built_in impl Sized for Global}]; // local
+    let x_15: Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]}, {built_in impl Sized for Global}]; // local
+    let y_16: Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]}, {built_in impl Sized for Global}]; // local
     let _17: [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]; // anonymous local
-    let _18: alloc::boxed::Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _18: Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]}, {built_in impl Sized for Global}]; // anonymous local
     let _19: [u8; 1usize]; // anonymous local
-    let _20: alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _20: Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
     let _21: [u8; 1usize]; // anonymous local
-    let _22: alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _22: Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -119,7 +129,7 @@ fn nested_vecs()
     storage_dead(_19)
     x_9 = move _20
     storage_dead(_20)
-    y_10 = unsize_cast<alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 1usize>(move x_9)
+    y_10 = unsize_cast<Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}], Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 1usize>(move x_9)
     ret_8 = into_vec<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}](move y_10)
     ↳⚡ storage_dead(y_10)
         storage_dead(x_9)
@@ -166,7 +176,7 @@ fn nested_vecs()
     storage_dead(_21)
     x_12 = move _22
     storage_dead(_22)
-    y_13 = unsize_cast<alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 1usize>(move x_12)
+    y_13 = unsize_cast<Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}], Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 1usize>(move x_12)
     ret_11 = into_vec<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}](move y_13)
     ↳⚡ storage_dead(y_13)
         storage_dead(x_12)
@@ -228,7 +238,7 @@ fn nested_vecs()
     storage_dead(_17)
     x_15 = move _18
     storage_dead(_18)
-    y_16 = unsize_cast<alloc::boxed::Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]}, {built_in impl Sized for Global}], 2usize>(move x_15)
+    y_16 = unsize_cast<Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 2usize]}, {built_in impl Sized for Global}], Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]}, {built_in impl Sized for Global}], 2usize>(move x_15)
     ret_14 = into_vec<Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}], Global>[{built_in impl Sized for Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]}, {built_in impl Sized for Global}](move y_16)
     ↳⚡ storage_dead(y_16)
         storage_dead(x_15)
@@ -258,20 +268,20 @@ fn nested_single()
 {
     let _0: (); // return
     let _nested: Vec<Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]>[{built_in impl Sized for Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]}, {built_in impl Sized for Global}]; // local
-    let _2: alloc::boxed::Box<MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
-    let _3: alloc::boxed::Box<MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _2: Box<MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _3: Box<MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]>[{built_in impl Sized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let _4: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // anonymous local
-    let _5: alloc::boxed::Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
+    let _5: Box<MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]>[{built_in impl MetaSized for MaybeUninit<[u8; 1usize]>[{built_in impl Sized for [u8; 1usize]}]}, {built_in impl Sized for Global}]; // anonymous local
     let ret_6: Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; // local
-    let x_7: alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // local
-    let y_8: alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
+    let x_7: Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // local
+    let y_8: Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}]; // local
     let ret_9: Vec<Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]>[{built_in impl Sized for Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]}, {built_in impl Sized for Global}]; // local
-    let x_10: alloc::boxed::Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]}, {built_in impl Sized for Global}]; // local
-    let y_11: alloc::boxed::Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]}, {built_in impl Sized for Global}]; // local
+    let x_10: Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]}, {built_in impl Sized for Global}]; // local
+    let y_11: Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]}, {built_in impl Sized for Global}]; // local
     let _12: [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]; // anonymous local
-    let _13: alloc::boxed::Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _13: Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
     let _14: [u8; 1usize]; // anonymous local
-    let _15: alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _15: Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -299,7 +309,7 @@ fn nested_single()
     storage_dead(_14)
     x_7 = move _15
     storage_dead(_15)
-    y_8 = unsize_cast<alloc::boxed::Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 1usize>(move x_7)
+    y_8 = unsize_cast<Box<[u8; 1usize]>[{built_in impl MetaSized for [u8; 1usize]}, {built_in impl Sized for Global}], Box<[u8]>[{built_in impl MetaSized for [u8]}, {built_in impl Sized for Global}], 1usize>(move x_7)
     ret_6 = into_vec<u8, Global>[{built_in impl Sized for u8}, {built_in impl Sized for Global}](move y_8)
     ↳⚡ storage_dead(y_8)
         storage_dead(x_7)
@@ -339,7 +349,7 @@ fn nested_single()
     storage_dead(_12)
     x_10 = move _13
     storage_dead(_13)
-    y_11 = unsize_cast<alloc::boxed::Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]}, {built_in impl Sized for Global}], alloc::boxed::Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]}, {built_in impl Sized for Global}], 1usize>(move x_10)
+    y_11 = unsize_cast<Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]; 1usize]}, {built_in impl Sized for Global}], Box<[Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]>[{built_in impl MetaSized for [Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]]}, {built_in impl Sized for Global}], 1usize>(move x_10)
     ret_9 = into_vec<Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}], Global>[{built_in impl Sized for Vec<u8>[{built_in impl Sized for u8}, {built_in impl Sized for Global}]}, {built_in impl Sized for Global}](move y_11)
     ↳⚡ storage_dead(y_11)
         storage_dead(x_10)

--- a/charon/tests/util/mod.rs
+++ b/charon/tests/util/mod.rs
@@ -118,6 +118,8 @@ pub fn repr_name(crate_data: &TranslatedCrate, n: &Name) -> String {
             },
             PathElem::Instantiated(..) => "<mono>".to_string(),
             PathElem::Target(target) => target.clone(),
+            PathElem::Builtin(BuiltinPathElem::Tuple(n)) => format!("<tuple_{n}>"),
+            PathElem::Builtin(BuiltinPathElem::Str) => "<str>".to_string(),
         })
         .join("::")
 }

--- a/rebase-fix.diff
+++ b/rebase-fix.diff
@@ -1,0 +1,197 @@
+diff --git a/charon/src/bin/charon-driver/hax/types/new/full_def.rs b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+index e10088088..218b61f4d 100644
+--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
++++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+@@ -365,6 +365,9 @@ pub enum FullDefKind<'tcx> {
+         inline: InlineAttr,
+         is_const: bool,
+         sig: PolyFnSig,
++        /// The arguments of this function, tupled as the `Fn*` traits take them, e.g. `(A, B, C)`.
++        /// Binds the same variables as `sig`. `None` if this function doesn't implement `Fn*`.
++        tupled_args_ty: Option<Binder<Ty>>,
+         /// Info required to construct a virtual `FnOnce` impl for this function, if compatible.
+         fn_once_impl: Option<Box<VirtualTraitImpl>>,
+         /// Info required to construct a virtual `FnMut` impl for this function, if compatible.
+@@ -384,6 +387,9 @@ pub enum FullDefKind<'tcx> {
+         /// signature with `Self` replaced by `dyn Trait` and associated types normalized.
+         vtable_sig: Option<PolyFnSig>,
+         sig: PolyFnSig,
++        /// The arguments of this function, tupled as the `Fn*` traits take them, e.g. `(A, B, C)`.
++        /// Binds the same variables as `sig`. `None` if this function doesn't implement `Fn*`.
++        tupled_args_ty: Option<Binder<Ty>>,
+         /// Info required to construct a virtual `FnOnce` impl for this function, if compatible.
+         fn_once_impl: Option<Box<VirtualTraitImpl>>,
+         /// Info required to construct a virtual `FnMut` impl for this function, if compatible.
+@@ -848,11 +854,15 @@ where
+         RDefKind::Fn { .. } => {
+             let sig = tcx.fn_sig(def_id);
+             let fn_trait_impls = fn_def_trait_impls(def_id, sig);
++            let sig = inst_binder(tcx, s.typing_env(), args, sig);
+             FullDefKind::Fn {
+                 param_env: get_param_env(s, args),
+                 inline: tcx.codegen_fn_attrs(def_id).inline.sinto(s),
+                 is_const: matches!(tcx.constness(def_id), rustc_hir::Constness::Const { .. }),
+-                sig: inst_binder(tcx, s.typing_env(), args, sig).sinto(s),
++                tupled_args_ty: fn_trait_impls
++                    .is_some()
++                    .then(|| tupled_args_ty(s, sig).sinto(s)),
++                sig: sig.sinto(s),
+                 fn_once_impl: fn_trait_impls.as_ref().map(|(vimpl, _, _)| vimpl.clone()),
+                 fn_mut_impl: fn_trait_impls.as_ref().map(|(_, vimpl, _)| vimpl.clone()),
+                 fn_impl: fn_trait_impls.map(|(_, _, vimpl)| vimpl),
+@@ -861,13 +871,17 @@ where
+         RDefKind::AssocFn { .. } => {
+             let item = tcx.associated_item(def_id);
+             let fn_trait_impls = fn_def_trait_impls(def_id, tcx.fn_sig(def_id));
++            let sig = get_method_sig(tcx, s.typing_env(), def_id, args);
+             FullDefKind::AssocFn {
+                 param_env: get_param_env(s, args),
+                 associated_item: AssocItem::sfrom_instantiated(s, &item, args),
+                 inline: tcx.codegen_fn_attrs(def_id).inline.sinto(s),
+                 is_const: matches!(tcx.constness(def_id), rustc_hir::Constness::Const { .. }),
+                 vtable_sig: gen_vtable_sig(s, args),
+-                sig: get_method_sig(tcx, s.typing_env(), def_id, args).sinto(s),
++                tupled_args_ty: fn_trait_impls
++                    .is_some()
++                    .then(|| tupled_args_ty(s, sig).sinto(s)),
++                sig: sig.sinto(s),
+                 fn_once_impl: fn_trait_impls.as_ref().map(|(vimpl, _, _)| vimpl.clone()),
+                 fn_mut_impl: fn_trait_impls.as_ref().map(|(_, vimpl, _)| vimpl.clone()),
+                 fn_impl: fn_trait_impls.map(|(_, _, vimpl)| vimpl),
+diff --git a/charon/src/bin/charon-driver/hax/types/ty.rs b/charon/src/bin/charon-driver/hax/types/ty.rs
+index b65e76f1b..4209dbd80 100644
+--- a/charon/src/bin/charon-driver/hax/types/ty.rs
++++ b/charon/src/bin/charon-driver/hax/types/ty.rs
+@@ -1440,6 +1440,17 @@ pub struct CoercePredicate {
+     pub b: Ty,
+ }
+ 
++/// The arguments of the given signature, tupled as the `Fn*` traits take them, e.g. `(A, B, C)`.
++/// The result binds the same variables as the signature it comes from, so that the two agree on
++/// the regions they use.
++pub fn tupled_args_ty<'tcx>(
++    s: &impl UnderOwnerState<'tcx>,
++    sig: ty::PolyFnSig<'tcx>,
++) -> ty::Binder<'tcx, ty::Ty<'tcx>> {
++    let tcx = s.base().tcx;
++    sig.map_bound(|sig| ty::Ty::new_tup(tcx, sig.inputs()))
++}
++
+ /// Reflects [`ty::ClosureArgs`]
+ #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+ 
+@@ -1541,7 +1552,7 @@ impl ClosureArgs {
+         let sig = closure.sig();
+         let sig = tcx.signature_unclosure(sig, rustc_hir::Safety::Safe);
+         // Add bound variables for each erased region in the signature.
+-        let (sig, tupled_args_ty) = {
++        let sig = {
+             let mut visitor = RegionUnEraserVisitor {
+                 tcx,
+                 depth: 0,
+@@ -1549,17 +1560,13 @@ impl ClosureArgs {
+             };
+             let unbound_sig = sig.skip_binder().fold_with(&mut visitor);
+             let bound_vars = tcx.mk_bound_variable_kinds(&visitor.bound_vars);
+-            let tupled_args_ty = ty::Ty::new_tup(tcx, unbound_sig.inputs());
+-            (
+-                ty::Binder::bind_with_vars(unbound_sig, bound_vars),
+-                ty::Binder::bind_with_vars(tupled_args_ty, bound_vars),
+-            )
++            ty::Binder::bind_with_vars(unbound_sig, bound_vars)
+         };
+         ClosureArgs {
+             item,
+             kind: closure.kind().sinto(s),
++            tupled_args_ty: tupled_args_ty(s, sig).sinto(s),
+             fn_sig: sig.sinto(s),
+-            tupled_args_ty: tupled_args_ty.sinto(s),
+             upvar_tys: closure.upvar_tys().sinto(s),
+         }
+     }
+diff --git a/charon/src/bin/charon-driver/translate/translate_closures.rs b/charon/src/bin/charon-driver/translate/translate_closures.rs
+index e79538441..e1ee3ab11 100644
+--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
++++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
+@@ -63,6 +63,8 @@ enum Callable<'a> {
+     FnDef {
+         item: &'a hax::ItemRef,
+         sig: &'a hax::PolyFnSig,
++        /// The arguments, tupled as the `Fn*` traits take them. Binds the same variables as `sig`.
++        tupled_args_ty: &'a hax::Binder<hax::Ty>,
+     },
+ }
+ 
+@@ -80,6 +82,15 @@ impl<'a> Callable<'a> {
+             Callable::FnDef { sig, .. } => sig,
+         }
+     }
++
++    /// The arguments, tupled as the `Fn*` traits take them, e.g. `(A, B, C)`. This is under the
++    /// same binder as `sig`.
++    fn tupled_args_ty(self) -> &'a hax::Ty {
++        match self {
++            Callable::Closure(args) => args.tupled_args_ty.hax_skip_binder_ref(),
++            Callable::FnDef { tupled_args_ty, .. } => tupled_args_ty.hax_skip_binder_ref(),
++        }
++    }
+ }
+ 
+ #[derive(Clone, Copy)]
+@@ -107,6 +118,7 @@ impl<'a> CallableFnImpls<'a> {
+             }),
+             hax::FullDefKind::Fn {
+                 sig,
++                tupled_args_ty,
+                 fn_once_impl,
+                 fn_mut_impl,
+                 fn_impl,
+@@ -114,6 +126,7 @@ impl<'a> CallableFnImpls<'a> {
+             }
+             | hax::FullDefKind::AssocFn {
+                 sig,
++                tupled_args_ty,
+                 fn_once_impl,
+                 fn_mut_impl,
+                 fn_impl,
+@@ -122,6 +135,9 @@ impl<'a> CallableFnImpls<'a> {
+                 callable: Callable::FnDef {
+                     item: def.this(),
+                     sig,
++                    // `None` if the function doesn't implement the `Fn*` traits, in which case
++                    // there's no callable method to translate.
++                    tupled_args_ty: tupled_args_ty.as_ref()?,
+                 },
+                 fn_once_impl: fn_once_impl.as_deref(),
+                 fn_mut_impl: fn_mut_impl.as_deref(),
+@@ -400,8 +416,9 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
+             }
+         };
+ 
++        // The method takes `self` and the callable's inputs as a tuple.
+         let tupled_args_ty = self
+-            .translate_ty(span, args.tupled_args_ty.hax_skip_binder_ref())?
++            .translate_ty(span, callable.tupled_args_ty())?
+             .move_under_binder();
+         fun_sig.inputs = vec![state_ty, tupled_args_ty];
+ 
+@@ -606,11 +623,15 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
+ 
+         let output = builder.new_var(None, signature.output.clone());
+         let _state = builder.new_var(Some("state".to_string()), signature.inputs[0].clone());
+-        let tupled_args = builder.new_var(Some("args".to_string()), signature.inputs[1].clone());
+-        let arg_tys = signature.inputs[1].as_tuple().unwrap();
++        let tupled_args_ty = &signature.inputs[1];
++        let tupled_args = builder.new_var(Some("args".to_string()), tupled_args_ty.clone());
++        // The tuple declaration is where we find the field types when it was monomorphized, so
++        // make sure it is translated.
++        let tuple_id = tupled_args_ty.as_adt().unwrap().id;
++        let _ = self.get_or_translate(ItemId::Type(tuple_id))?;
++        let arg_tys = tupled_args_ty.as_tuple_fields(&self.t_ctx.translated);
+         let args = arg_tys
+-            .iter()
+-            .cloned()
++            .into_iter()
+             .enumerate()
+             .map(|(i, ty)| {
+                 let nth_field = tupled_args


### PR DESCRIPTION
Closes https://github.com/AeneasVerif/charon/issues/1163

Generate an ADT for tuples, `str`, and `Box` (when `--treat-box-as-builtin`)! This means we actually get the layout of tuples, and overall can treat more things uniformly.
This simplifies a bunch of code, and also lets us remove `FieldProjKind` since it's only variant is now `FieldProjKind::Adt`!

Removed `TypeId`; a `TypeDeclRef` is always a `TypeDeclId` + generics, and instead we have `TyKind::Adt(TypeDeclRef, Option<BuiltinTy>)`.

Had to update the transformations that remove clauses, since we have to remove them from the `Box` type decl too.

I wanted to keep the trait clauses of tuples in the translation: all fields of a tuple are `Sized`, except the last. That revealed an infinite recursion with self-referential clauses, that i fixed along the way (im not convinced by the fix though)

This is best reviewed commit by commit

ci: use https://github.com/AeneasVerif/aeneas/pull/1289

ci: use https://github.com/AeneasVerif/eurydice/pull/441