### PR TITLE
Update the popular-crates test harness

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "indoc",
  "itertools 0.13.0",
  "lazy_static",
+ "libc",
  "libtest-mimic",
  "log",
  "macros",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+exclude = ["tests/popular-crates"]
 members = [
     "adt-into",
     "macros",
@@ -136,6 +137,7 @@ popular-crates-test = [
 [dev-dependencies]
 ignore = "0.4"
 indoc = "2"
+libc = "0.2"
 libtest-mimic = "0.8"
 regex = "1"
 snapbox = "0.6"

--- a/charon/Makefile
+++ b/charon/Makefile
@@ -30,7 +30,7 @@ clippy:
 
 .PHONY: test-popular-crates
 test-popular-crates:
-	cargo test --release --features popular-crates-test --test popular-crates -- --test-threads 8
+	cargo test --release --features popular-crates-test --test popular-crates -- --test-threads 4
 
 # Build the doc.
 # For some reason, I don't manage to build all the packages in one command.

--- a/charon/tests/popular-crates.rs
+++ b/charon/tests/popular-crates.rs
@@ -20,31 +20,66 @@ use wait_timeout::ChildExt;
 
 static TESTS_DIR: &str = "tests/popular-crates";
 
-const NUMBER_OF_CRATES: u64 = 50;
+const NUMBER_OF_CRATES: u64 = 500;
+const CRATES_PER_PAGE: u64 = 100;
 
-/// List of crates that we know we can't extract.
-static BLACKLIST: &[&str] = &[
-    "aho-corasick",
-    "base64",
-    "bitflags",
-    "cc",
-    "clap",
-    "crossbeam-utils",
-    "getrandom",
-    "idna",
-    "itertools",
-    "num-traits",
-    "parking_lot",
-    "parking_lot_core",
-    "proc-macro2",
-    "rand",
-    "regex-automata",
-    "regex-syntax",
-    "semver",
-    "serde",
-    "serde_json",
-    "syn",
-    "time",
+#[cfg(target_os = "linux")]
+fn limit_memory_usage(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+
+    const MEMORY_LIMIT: libc::rlim_t = 4 * 1024 * 1024 * 1024;
+
+    unsafe {
+        command.pre_exec(|| {
+            let limit = libc::rlimit {
+                rlim_cur: MEMORY_LIMIT,
+                rlim_max: MEMORY_LIMIT,
+            };
+            if libc::setrlimit(libc::RLIMIT_AS, &limit) == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        });
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn limit_memory_usage(_: &mut Command) {}
+
+/// Crates that don't `cargo build` on my machine.
+static BUILD_FAILURES: &[&str] = &[
+    // Errors with our pinned rustc.
+    "is_terminal_polyfill",
+    "mime",
+    "serde_yaml",
+    "tokio-native-tls",
+    "try-lock",
+    "unsafe-libyaml",
+    "wait-timeout",
+    // Requires a feature to be selected.
+    "derive_more",
+    "tiny-keccak",
+    // Requires system library.
+    "clang-sys",
+    "plotters",
+    "zstd-sys",
+    // Intentionally emits a compile error.
+    "bincode",
+    // Doesn't build on Linux.
+    "windows",
+    "winreg",
+];
+
+/// Crates that error because of charon.
+static CHARON_FAILURES: &[&str] = &[
+    // See `closure-nested-dyn-ice` test.
+    "rayon-core",
+    // See `impossible-recursive-trait-proof` test
+    "windows-core",
+    // Timeout
+    "cexpr",
+    "generic-array",
 ];
 
 /// Downloads and extracts the crate into a subdirectory of `TESTS_DIR` and returns the path to
@@ -96,27 +131,35 @@ fn process_crate(version: &Version) -> Result<()> {
     };
 
     // Call charon
-    let mut child = Command::cargo_bin("charon")?
-        .stdout(Stdio::piped())
+    let mut command = Command::cargo_bin("charon")?;
+    command
+        .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .current_dir(&crate_dir)
-        .arg("--hide-marker-traits")
+        .env("CARGO_BUILD_JOBS", "1")
+        .arg("cargo")
+        // Removing either of these options hits a lot more timeouts/crashes.
+        .args(["--ullbc", "--hide-marker-traits"])
         .arg("--dest-file")
-        .arg(&llbc_path)
-        .spawn()?;
+        .arg(&llbc_path);
+    limit_memory_usage(&mut command);
+    let mut child = command.spawn()?;
+    // Drain stderr while Charon runs: waiting before reading can fill the pipe buffer and deadlock
+    // the child process.
+    let stderr = child.stderr.take().unwrap();
+    let stderr_reader = std::thread::spawn(move || std::io::read_to_string(stderr));
     let timeout = Duration::from_secs(30);
     let status_code = match child.wait_timeout(timeout)? {
         Some(status) => status,
         None => {
             child.kill()?;
-            eprintln!("Compilation timed out");
-            child.wait()?
+            child.wait()?;
+            bail!("Compilation timed out after {}s", timeout.as_secs())
         }
     };
-    // let output = cmd.output()?;
 
+    let stderr = stderr_reader.join().expect("stderr reader panicked")?;
     if !status_code.success() {
-        let stderr = std::io::read_to_string(child.stderr.unwrap())?;
         bail!("Compilation failed: {stderr}")
     }
 
@@ -134,17 +177,22 @@ pub fn test_popular_crates() -> Result<()> {
         .unwrap(),
     );
 
-    let q = CratesQuery::builder()
-        .sort(Sort::Downloads)
-        .page_size(NUMBER_OF_CRATES)
-        .build();
-    let crates = client.crates(q)?;
+    let mut crates = Vec::new();
+    for page in 1..=NUMBER_OF_CRATES.div_ceil(CRATES_PER_PAGE) {
+        let q = CratesQuery::builder()
+            .sort(Sort::Downloads)
+            .page_size(CRATES_PER_PAGE)
+            .page(page)
+            .build();
+        crates.extend(client.crates(q)?.crates);
+    }
+    crates.truncate(NUMBER_OF_CRATES as usize);
 
     let tests: Vec<_> = crates
-        .crates
         .into_iter()
         .map(|krate| {
-            let known_failure = BLACKLIST.contains(&krate.name.as_str());
+            let known_failure = BUILD_FAILURES.contains(&krate.name.as_str())
+                || CHARON_FAILURES.contains(&krate.name.as_str());
             let name = format!("{}-{}", krate.name, krate.max_version);
             let client = Arc::clone(&client);
             let test = libtest_mimic::Trial::test(name, move || {

--- a/charon/tests/ui/regressions/closure-nested-dyn-ice.out
+++ b/charon/tests/ui/regressions/closure-nested-dyn-ice.out
@@ -1,0 +1,15 @@
+error: internal compiler error: /rustc-dev/14210df0e27ccd7d9e6a05b8085cbd438e4bbc65/compiler/rustc_infer/src/infer/region_constraints/mod.rs:492:21: cannot relate bound region: '{erased} == '^1_1
+
+
+thread 'rustc' panicked at /rustc-dev/14210df0e27ccd7d9e6a05b8085cbd438e4bbc65/compiler/rustc_infer/src/infer/region_constraints/mod.rs:492:21:
+Box<dyn Any>
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+error: Hax panicked when translating `Closure(test_crate::closure::{closure#0}, [i8, Binder { value: extern "RustCall" fn((&'^0.Named(test_crate::closure::'_) dyn [Binder { value: Trait(std::ops::Fn<(std::boxed::Box<dyn std::marker::Send>,)>), bound_vars: [] }, Binder { value: Projection(ExistentialProjection { def_id: core::ops::function::FnOnce::Output, args: [(std::boxed::Box<dyn [Binder { value: AutoTrait(core::marker::Send), bound_vars: [] }] + '{erased}, std::alloc::Global>,)], term: Term::Ty(()), .. }), bound_vars: [] }] + '^0.Named(test_crate::closure::'_),)), bound_vars: [Region(BrNamed(test_crate::closure::'_))] }, ()])`.
+ --> tests/ui/regressions/closure-nested-dyn-ice.rs:3:13
+  |
+3 |     let _ = |_: &dyn Fn(Box<dyn Send + 'static>)| ();
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+ERROR Code failed to compile

--- a/charon/tests/ui/regressions/closure-nested-dyn-ice.rs
+++ b/charon/tests/ui/regressions/closure-nested-dyn-ice.rs
@@ -1,0 +1,4 @@
+//@ known-failure
+pub fn closure() {
+    let _ = |_: &dyn Fn(Box<dyn Send + 'static>)| ();
+}

--- a/charon/tests/ui/traits/impossible-recursive-trait-proof.out
+++ b/charon/tests/ui/traits/impossible-recursive-trait-proof.out
@@ -1,0 +1,3 @@
+
+thread 'rustc' has overflowed its stack
+fatal runtime error: stack overflow, aborting

--- a/charon/tests/ui/traits/impossible-recursive-trait-proof.rs
+++ b/charon/tests/ui/traits/impossible-recursive-trait-proof.rs
@@ -1,0 +1,8 @@
+//@ known-failure
+pub trait HasAssoc {
+    type Assoc;
+}
+
+pub trait Trait<X>: HasAssoc {}
+
+fn foo<T: Trait<<T as HasAssoc>::Assoc>>() {}


### PR DESCRIPTION
I hadn't run it in a while; this PR makes it run with latest charon. It passes 481 of the top 500 crates on crates.io on my machine, with only 4 failures due to charon (the rest is build settings).