### PR TITLE
Use zipping visitors instead of `PartialEq` for AST comparisons

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -499,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "derive_generic_visitor"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113505c87000bf21b0bce35e7b9a381c220aba032d4a99a37e4ff90bb47e0e40"
+checksum = "39b33555faa5eba9aeec762080cad4c9debd88f36e085829993a4376e4577e81"
 dependencies = [
  "derive_generic_visitor_macros",
  "itertools 0.14.0",
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "derive_generic_visitor_macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31474cd9f8a0a127e855afe40e8d9c6bd99c5e6538b3f8715214ee06036954ee"
+checksum = "99c627c3a2729eea79e71c31482abb026752df6d09bce92c3b2c1e9e5b6fde9c"
 dependencies = [
  "convert_case",
  "darling",

--- a/charon/src/ast/bodies.rs
+++ b/charon/src/ast/bodies.rs
@@ -23,8 +23,6 @@ pub use values::*;
 /// The body of a function.
 #[derive(
     Debug,
-    PartialEq,
-    Eq,
     Clone,
     SerializeState,
     DeserializeState,
@@ -74,18 +72,7 @@ pub enum Body {
 generate_index_type!(LocalId, "");
 
 /// The local variables of a body.
-#[derive(
-    Debug,
-    PartialEq,
-    Eq,
-    Default,
-    Clone,
-    SerializeState,
-    DeserializeState,
-    Drive,
-    DriveMut,
-    DriveTwo,
-)]
+#[derive(Debug, Default, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 pub struct Locals {
     /// The number of local variables used for the input arguments.
     pub arg_count: usize,
@@ -98,9 +85,7 @@ pub struct Locals {
 }
 
 /// A variable
-#[derive(
-    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 pub struct Local {
     /// Unique index identifying the variable
     pub index: LocalId,
@@ -117,9 +102,7 @@ pub struct Local {
 /// An expression body.
 /// TODO: arg_count should be stored in GFunDecl below. But then,
 ///       the print is obfuscated and Aeneas may need some refactoring.
-#[derive(
-    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 #[cfg_attr(feature = "charon_on_charon", charon::rename("GexprBody"))]
 pub struct GExprBody<T> {
     pub span: Span,

--- a/charon/src/ast/items.rs
+++ b/charon/src/ast/items.rs
@@ -1,5 +1,5 @@
 use crate::ast::*;
-use derive_generic_visitor::{ControlFlow, Drive, DriveMut, DriveTwo};
+use derive_generic_visitor::{ControlFlow, Drive, DriveMut, DriveTwo, VisitTwo, Visitor};
 use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
 
 pub mod fun_decl;
@@ -140,6 +140,24 @@ impl<'ctx> ItemRef<'ctx> {
             ItemRef::TraitDecl(d) => visitor.visit(d),
             ItemRef::TraitImpl(d) => visitor.visit(d),
         }
+    }
+
+    /// Visit two items in lockstep.
+    pub fn drive_two<V: ZipAst>(&self, other: &Self, visitor: &mut V) -> ControlFlow<V::Break> {
+        /// Adapter needed because `ZipAst => Any => 'static` so `&'ctx X` can't be `ZipAst`.
+        struct ItemRefZipVisitor<'a, V>(&'a mut V);
+
+        impl<V: Visitor> Visitor for ItemRefZipVisitor<'_, V> {
+            type Break = V::Break;
+        }
+
+        impl<'s, 'ctx, T: AstVisitable, V: ZipAst> VisitTwo<'s, &'ctx T> for ItemRefZipVisitor<'_, V> {
+            fn visit(&mut self, left: &'s &'ctx T, right: &'s &'ctx T) -> ControlFlow<Self::Break> {
+                self.0.visit(*left, *right)
+            }
+        }
+
+        DriveTwo::drive_two_inner(self, other, &mut ItemRefZipVisitor(visitor))
     }
 
     /// Visit all occurrences of that type inside `self`, in pre-order traversal.

--- a/charon/src/ast/items.rs
+++ b/charon/src/ast/items.rs
@@ -20,16 +20,7 @@ pub use type_decl::*;
 
 /// A translated item.
 #[derive(
-    Debug,
-    PartialEq,
-    Eq,
-    EnumIsA,
-    EnumAsGetters,
-    VariantName,
-    VariantIndexArity,
-    Drive,
-    DriveMut,
-    DriveTwo,
+    Debug, EnumIsA, EnumAsGetters, VariantName, VariantIndexArity, Drive, DriveMut, DriveTwo,
 )]
 pub enum ItemByVal {
     Type(TypeDecl),
@@ -62,16 +53,7 @@ pub enum ItemRef<'ctx> {
 
 /// A mutable reference to a translated item.
 #[derive(
-    Debug,
-    PartialEq,
-    Eq,
-    EnumIsA,
-    EnumAsGetters,
-    VariantName,
-    VariantIndexArity,
-    Drive,
-    DriveMut,
-    DriveTwo,
+    Debug, EnumIsA, EnumAsGetters, VariantName, VariantIndexArity, Drive, DriveMut, DriveTwo,
 )]
 pub enum ItemRefMut<'ctx> {
     Type(&'ctx mut TypeDecl),

--- a/charon/src/ast/items/fun_decl.rs
+++ b/charon/src/ast/items/fun_decl.rs
@@ -6,9 +6,7 @@ use serde_state::DeserializeState;
 use serde_state::SerializeState;
 
 /// A function definition
-#[derive(
-    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 pub struct FunDecl {
     pub def_id: FunDeclId,
     /// The meta data associated with the declaration.
@@ -74,9 +72,7 @@ pub enum Abi {
 }
 
 /// Where a given function came from.
-#[derive(
-    Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo, PartialEq, Eq,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 #[cfg_attr(feature = "charon_on_charon", charon::variants_suffix("Fun"))]
 pub enum FunSource {
     /// A normal function.

--- a/charon/src/ast/items/global_decl.rs
+++ b/charon/src/ast/items/global_decl.rs
@@ -4,9 +4,7 @@ use serde_state::DeserializeState;
 use serde_state::SerializeState;
 
 /// A global variable definition (constant or static).
-#[derive(
-    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 pub struct GlobalDecl {
     pub def_id: GlobalDeclId,
     /// The meta data associated with the declaration.
@@ -42,9 +40,7 @@ pub enum GlobalKind {
 }
 
 /// Where a given global came from.
-#[derive(
-    Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo, PartialEq, Eq,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 #[cfg_attr(feature = "charon_on_charon", charon::variants_suffix("Global"))]
 pub enum GlobalSource {
     /// A normal global.

--- a/charon/src/ast/items/trait_decl.rs
+++ b/charon/src/ast/items/trait_decl.rs
@@ -60,9 +60,7 @@ generate_index_type!(AssocConstId, "AssocConst");
 /// Of course, this forbids other useful use cases such as visitors implemented
 /// by means of traits.
 #[allow(clippy::type_complexity)]
-#[derive(
-    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 pub struct TraitDecl {
     pub def_id: TraitDeclId,
     pub item_meta: ItemMeta,
@@ -103,9 +101,7 @@ pub struct TraitDecl {
 }
 
 /// An associated constant in a trait.
-#[derive(
-    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 pub struct TraitAssocConst {
     pub name: TraitItemName,
     #[serde_state(stateless)]
@@ -115,9 +111,7 @@ pub struct TraitAssocConst {
 }
 
 /// An associated type in a trait.
-#[derive(
-    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 pub struct TraitAssocTy {
     pub name: TraitItemName,
     #[serde_state(stateless)]
@@ -128,9 +122,7 @@ pub struct TraitAssocTy {
 }
 
 /// A trait method.
-#[derive(
-    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 pub struct TraitMethod {
     pub name: TraitItemName,
     pub item_meta: ItemMeta,
@@ -140,9 +132,7 @@ pub struct TraitMethod {
 }
 
 /// Where the trait comes from.
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Clone, Copy, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 #[cfg_attr(feature = "charon_on_charon", charon::variants_suffix("TraitDecl"))]
 pub enum TraitDeclSource {
     /// A regular trait.

--- a/charon/src/ast/items/trait_impl.rs
+++ b/charon/src/ast/items/trait_impl.rs
@@ -14,9 +14,7 @@ use serde_state::SerializeState;
 ///   fn baz(...) { ... }
 /// }
 /// ```
-#[derive(
-    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 pub struct TraitImpl {
     pub def_id: TraitImplId,
     pub item_meta: ItemMeta,
@@ -62,9 +60,7 @@ pub struct TraitAssocTyImpl {
 }
 
 /// Where the impl comes from.
-#[derive(
-    Debug, Clone, PartialEq, Eq, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 #[cfg_attr(feature = "charon_on_charon", charon::variants_suffix("TraitImpl"))]
 pub enum TraitImplSource {
     /// A regular trait implementation.

--- a/charon/src/ast/items/type_decl.rs
+++ b/charon/src/ast/items/type_decl.rs
@@ -20,9 +20,7 @@ use crate::utils::serialize_map_to_array::SeqHashMapToArray;
 ///
 /// A type can only be an ADT (structure or enumeration), as type aliases are
 /// inlined in MIR.
-#[derive(
-    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 #[serde_state(state_implements = HashConsSerializerState)]
 pub struct TypeDecl {
     pub def_id: TypeDeclId,
@@ -46,8 +44,6 @@ generate_index_type!(FieldId, "Field");
 
 #[derive(
     Debug,
-    PartialEq,
-    Eq,
     Clone,
     EnumIsA,
     EnumAsGetters,
@@ -74,9 +70,7 @@ pub enum TypeDeclKind {
     Error(String),
 }
 
-#[derive(
-    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 #[serde_state(stateless)]
 pub struct Variant {
     pub id: VariantId,
@@ -92,9 +86,7 @@ pub struct Variant {
     pub discriminant: Literal,
 }
 
-#[derive(
-    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 #[serde_state(stateless)]
 pub struct Field {
     pub span: Span,
@@ -146,9 +138,7 @@ pub enum PtrMetadata {
 }
 
 /// Where a given type came from.
-#[derive(
-    Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo, PartialEq, Eq,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 #[cfg_attr(feature = "charon_on_charon", charon::variants_suffix("Type"))]
 pub enum TypeSource {
     /// A normal type declaration.

--- a/charon/src/ast/meta.rs
+++ b/charon/src/ast/meta.rs
@@ -53,9 +53,7 @@ pub enum ItemOpacity {
 }
 
 /// Meta information about an item (function, trait decl, trait impl, type decl, global).
-#[derive(
-    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
 #[serde_state(stateless)]
 pub struct ItemMeta {
     #[serde_state(stateful)]

--- a/charon/src/ast/meta/attrs.rs
+++ b/charon/src/ast/meta/attrs.rs
@@ -76,9 +76,7 @@ pub struct RawAttribute {
 }
 
 /// Information about the attributes and visibility of an item, field or variant..
-#[derive(
-    Debug, PartialEq, Eq, Default, Clone, Serialize, Deserialize, Drive, DriveMut, DriveTwo,
-)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Drive, DriveMut, DriveTwo)]
 pub struct AttrInfo {
     /// Attributes (`#[...]`).
     pub attributes: Vec<Attribute>,

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -42,13 +42,18 @@ use derive_generic_visitor::*;
     visitor(drive(&VisitAst)),
     visitor(drive_mut(&mut VisitAstMut)),
     visitor(drive_two(&two ZipAst)),
-    // Types that we ignore.
-    skip(
+    // Types that are skipped by normal visitors but compared for equality by `ZipAst`.
+    skip_but_eq(
         (), String, PathBuf, bool, char, i128, u8, u64, u128, usize, ustr::Ustr,
         crate::options::CliOpts,
-        Abi, AttributeKind, BuiltinImplData, Byte, DeclarationGroup, Discriminator, DropKind, Error,
-        FileName, GlobalKind, ItemOpacity, LangItem, LifetimeMutability, OverflowMode,
-        PredicateOrigin, ReprOptions, TargetInfo, Variance, WithRetag,
+        Abi, AttributeKind, BuiltinImplData, Byte, Discriminator, DropKind, Error, FileName,
+        GlobalKind, ItemOpacity, LangItem, LifetimeMutability, OverflowMode, ReprOptions, Variance,
+        WithRetag,
+    ),
+    // Types that are completely skipped, even by `ZipAst`.
+    skip(
+        DeclarationGroup, PredicateOrigin, TargetInfo,
+        llbc_ast::BlockId, llbc_ast::StatementId,
     ),
     // Types that we unconditionally explore.
     drive(
@@ -60,7 +65,6 @@ use derive_generic_visitor::*;
         Loc, Locals, NullOp, Operand, PathElem, PlaceKind, ConstantExprKind,
         RawAttribute, RefKind, RegionId, RegionParam, ScalarValue, TraitItemName, TraitMethodId, AssocTypeId, AssocConstId, AssocItemId, MaybeAssocItemId,
         TranslatedCrate, TypeDeclKind, TypeId, TypeParam, TypePattern, TypeVarId,
-        llbc_ast::BlockId, llbc_ast::StatementId,
         ullbc_ast::BlockData, ullbc_ast::BlockId, ullbc_ast::ExprBody, ullbc_ast::StatementKind,
         ullbc_ast::TerminatorKind, ullbc_ast::SwitchTargets,
         UnOp, UnsizingMetadata, Local, Variant, VariantId, LocalId, Layout, VariantLayout, PtrMetadata,
@@ -188,6 +192,7 @@ impl<K: BodyVisitable + Hash + Eq, T: BodyVisitable> BodyVisitable for SeqHashMa
         NullOp, RefKind, ScalarValue, Span, Ty, TypeDeclId, TypeId, UnOp, VariantId,
         TraitRef, LiteralTy, Literal, Region, RegionId, (), String, PathBuf, bool, usize,
         DropKind, Error, Variance, WithRetag,
+        llbc_ast::BlockId, llbc_ast::StatementId,
     ),
     // Types that we unconditionally explore.
     drive(
@@ -195,7 +200,6 @@ impl<K: BodyVisitable + Hash + Eq, T: BodyVisitable> BodyVisitable for SeqHashMa
         llbc_ast::ExprBody, llbc_ast::StatementKind, llbc_ast::Switch,
         ullbc_ast::BlockData, ullbc_ast::ExprBody, ullbc_ast::StatementKind,
         ullbc_ast::TerminatorKind, ullbc_ast::SwitchTargets,
-        llbc_ast::BlockId, llbc_ast::StatementId,
         Body, Local,
         for<T: BodyVisitable> Box<T>,
         for<T: BodyVisitable> Option<T>,

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -57,7 +57,7 @@ use derive_generic_visitor::*;
     ),
     // Types that we unconditionally explore.
     drive(
-        Assert, AttrInfo, BinderKind, BinOp, BorrowckStatement, BorrowKind, BuiltinAssertKind, BuiltinFunId, BuiltinIndexOp, BuiltinTy,
+        Assert, BinderKind, BinOp, BorrowckStatement, BorrowKind, BuiltinAssertKind, BuiltinFunId, BuiltinIndexOp, BuiltinTy,
         Call, CastKind, ClosureInfo, ClosureKind, ConstGenericParam, ConstGenericVarId,
         Disambiguator, DynPredicate, Field, FieldId, File, FloatTy, FloatValue,
         FnOperand, FunId, FnPtrKind, FunSig, InlineAttr, IntegerTy, IntTy, UIntTy, Literal, LiteralTy,
@@ -88,7 +88,7 @@ use derive_generic_visitor::*;
         FunDeclId, GlobalDeclId, TypeDeclId, TraitDeclId, TraitImplId, FileId,
         TypeDeclRef, FunDeclRef, GlobalDeclRef, TraitDeclRef, TraitImplRef, ImplElem,
         FunDecl, GlobalDecl, TypeDecl, TraitDecl, TraitImpl,
-        ItemMeta, Name, Span, Attribute,
+        ItemMeta, Name, Span, Attribute, AttrInfo,
         TypeSource, FunSource, GlobalSource, TraitDeclSource, TraitImplSource,
         TraitAssocTy, TraitAssocConst, TraitMethod, TraitAssocTyImpl,
         DeBruijnId, Ty, TyKind, Region, TraitRef, TraitRefContents, TraitRefKind,

--- a/charon/src/export/multi_target.rs
+++ b/charon/src/export/multi_target.rs
@@ -221,14 +221,192 @@ enum MergeDecision {
     Facade,
 }
 
-struct ItemComparer;
+/// Compares items modulo the target-specific differences we want to ignore.
+struct ItemComparer<'a> {
+    remap: &'a HashMap<ItemId, ItemId>,
+}
 
-impl Visitor for ItemComparer {
+impl Visitor for ItemComparer<'_> {
     type Break = ();
 }
 
+impl<'a, T: AstVisitable> derive_generic_visitor::VisitTwo<'a, T> for ItemComparer<'_> {
+    fn visit(&mut self, left: &'a T, right: &'a T) -> ControlFlow<Self::Break> {
+        ZipAst::visit(self, left, right)
+    }
+}
+
+impl ItemComparer<'_> {
+    fn compare_items(&mut self, left: ItemRef<'_>, right: ItemRef<'_>) -> ControlFlow<()> {
+        left.drive_two(&right, self)
+    }
+
+    fn compare_fun_interface(&mut self, left: &FunDecl, right: &FunDecl) -> ControlFlow<()> {
+        self.visit(&left.item_meta.name, &right.item_meta.name)?;
+        self.visit(&left.generics, &right.generics)?;
+        self.visit(&left.signature, &right.signature)
+    }
+
+    fn compare_ids<Id: Copy + Into<ItemId>>(&self, left: &Id, right: &Id) -> ControlFlow<()> {
+        let remap = |id: &Id| {
+            let id = (*id).into();
+            self.remap.get(&id).copied().unwrap_or(id)
+        };
+        if remap(left) == remap(right) {
+            ControlFlow::Continue(())
+        } else {
+            ControlFlow::Break(())
+        }
+    }
+
+    fn compare_iters<'a, T: AstVisitable + 'a>(
+        &mut self,
+        left: impl Iterator<Item = &'a T>,
+        right: impl Iterator<Item = &'a T>,
+    ) -> ControlFlow<()> {
+        derive_generic_visitor::drive_iter_two(left, right, self)
+    }
+}
+
 // Use lockstep visitation for "equality modulo" comparison.
-impl ZipAst for ItemComparer {}
+impl ZipAst for ItemComparer<'_> {
+    fn visit_type_decl_id(
+        &mut self,
+        left: &TypeDeclId,
+        right: &TypeDeclId,
+    ) -> ControlFlow<Self::Break> {
+        self.compare_ids(left, right)
+    }
+
+    fn visit_fun_decl_id(
+        &mut self,
+        left: &FunDeclId,
+        right: &FunDeclId,
+    ) -> ControlFlow<Self::Break> {
+        self.compare_ids(left, right)
+    }
+
+    fn visit_global_decl_id(
+        &mut self,
+        left: &GlobalDeclId,
+        right: &GlobalDeclId,
+    ) -> ControlFlow<Self::Break> {
+        self.compare_ids(left, right)
+    }
+
+    fn visit_trait_decl_id(
+        &mut self,
+        left: &TraitDeclId,
+        right: &TraitDeclId,
+    ) -> ControlFlow<Self::Break> {
+        self.compare_ids(left, right)
+    }
+
+    fn visit_trait_impl_id(
+        &mut self,
+        left: &TraitImplId,
+        right: &TraitImplId,
+    ) -> ControlFlow<Self::Break> {
+        self.compare_ids(left, right)
+    }
+
+    fn visit_name(&mut self, left: &Name, right: &Name) -> ControlFlow<Self::Break> {
+        let without_target = |elem: &&PathElem| !matches!(elem, PathElem::Target(_));
+        self.compare_iters(
+            left.name.iter().filter(without_target),
+            right.name.iter().filter(without_target),
+        )
+    }
+
+    fn visit_span(&mut self, _left: &Span, _right: &Span) -> ControlFlow<Self::Break> {
+        ControlFlow::Continue(())
+    }
+
+    fn visit_attr_info(&mut self, left: &AttrInfo, right: &AttrInfo) -> ControlFlow<Self::Break> {
+        let AttrInfo {
+            attributes: left_attributes,
+            inline: left_inline,
+            rename: left_rename,
+            public: left_public,
+        } = left;
+        let AttrInfo {
+            attributes: right_attributes,
+            inline: right_inline,
+            rename: right_rename,
+            public: right_public,
+        } = right;
+
+        let is_stable = |attr: &&Attribute| !matches!(attr, Attribute::Unknown(attr) if attr.path.starts_with("rustc_"));
+        self.compare_iters(
+            left_attributes.iter().filter(is_stable),
+            right_attributes.iter().filter(is_stable),
+        )?;
+        self.visit(left_inline, right_inline)?;
+        self.visit(left_rename, right_rename)?;
+        self.visit(left_public, right_public)
+    }
+
+    fn visit_item_meta(&mut self, left: &ItemMeta, right: &ItemMeta) -> ControlFlow<Self::Break> {
+        let ItemMeta {
+            name: left_name,
+            span: left_span,
+            // Source text isn't relevant to cross-target identity.
+            source_text: _,
+            attr_info: left_attr_info,
+            is_local: left_is_local,
+            opacity: left_opacity,
+            lang_item: left_lang_item,
+            diagnostic_item: left_diagnostic_item,
+        } = left;
+        let ItemMeta {
+            name: right_name,
+            span: right_span,
+            source_text: _,
+            attr_info: right_attr_info,
+            is_local: right_is_local,
+            opacity: right_opacity,
+            lang_item: right_lang_item,
+            diagnostic_item: right_diagnostic_item,
+        } = right;
+
+        self.visit(left_name, right_name)?;
+        self.visit(left_span, right_span)?;
+        self.visit(left_attr_info, right_attr_info)?;
+        self.visit(left_is_local, right_is_local)?;
+        self.visit(left_opacity, right_opacity)?;
+        self.visit(left_lang_item, right_lang_item)?;
+        self.visit(left_diagnostic_item, right_diagnostic_item)
+    }
+
+    fn visit_type_decl(&mut self, left: &TypeDecl, right: &TypeDecl) -> ControlFlow<Self::Break> {
+        let TypeDecl {
+            def_id: left_def_id,
+            item_meta: left_item_meta,
+            generics: left_generics,
+            src: left_src,
+            kind: left_kind,
+            // Layouts are allowed to differ per target.
+            layout: _,
+            ptr_metadata: left_ptr_metadata,
+        } = left;
+        let TypeDecl {
+            def_id: right_def_id,
+            item_meta: right_item_meta,
+            generics: right_generics,
+            src: right_src,
+            kind: right_kind,
+            layout: _,
+            ptr_metadata: right_ptr_metadata,
+        } = right;
+
+        self.visit(left_def_id, right_def_id)?;
+        self.visit(left_item_meta, right_item_meta)?;
+        self.visit(left_generics, right_generics)?;
+        self.visit(left_src, right_src)?;
+        self.visit(left_kind, right_kind)?;
+        self.visit(left_ptr_metadata, right_ptr_metadata)
+    }
+}
 
 impl TargetGroup {
     /// Deterministically chosen representative id.
@@ -247,15 +425,10 @@ impl TargetGroup {
         krate: &TranslatedCrate,
         remap: &HashMap<ItemId, ItemId>,
     ) -> MergeDecision {
-        let canonical_id = self.canonical_id();
-        let items: Vec<Option<ItemByVal>> = self
+        let items: Vec<Option<ItemRef<'_>>> = self
             .ids
             .values()
-            .map(|&id| {
-                krate
-                    .get_item(id)
-                    .map(|item| normalize_item(item.to_owned(), canonical_id, remap))
-            })
+            .map(|&id| krate.get_item(id))
             .collect_vec();
 
         // Items that don't exist in the crate can't be compared; if they're all missing we can
@@ -268,20 +441,19 @@ impl TargetGroup {
             None => return MergeDecision::Skip,
         };
 
-        let mut comparer = ItemComparer;
-        let mut is_eq = |left, right| ZipAst::visit(&mut comparer, left, right).is_continue();
+        let mut comparer = ItemComparer { remap };
         if items
             .iter()
             .tuple_windows()
-            .all(|(left, right)| is_eq(left, right))
+            .all(|(&left, &right)| comparer.compare_items(left, right).is_continue())
         {
             MergeDecision::Dedup
         } else if self.is_function_group()
             && items
                 .iter()
                 .map(|item| item.as_fun().unwrap())
-                .map(|d| (&d.item_meta.name, &d.generics, &d.signature))
-                .all_equal()
+                .tuple_windows()
+                .all(|(left, right)| comparer.compare_fun_interface(left, right).is_continue())
         {
             MergeDecision::Facade
         } else {
@@ -713,56 +885,6 @@ fn remove_unmentioned_methods(krate: &mut TranslatedCrate) {
 // =============================================================================================
 // Utilities
 // =============================================================================================
-
-/// Normalize an item for cross-target comparison.
-fn normalize_item(
-    mut item: ItemByVal,
-    canonical_id: ItemId,
-    remap: &HashMap<ItemId, ItemId>,
-) -> ItemByVal {
-    item.as_mut().drive_mut(&mut IdRefMapperVisitor::new(remap));
-    item.as_mut().set_id(canonical_id);
-    item.as_mut().dyn_visit_mut(|name: &mut Name| {
-        name.name
-            .retain(|elem| !matches!(elem, PathElem::Target(_)))
-    });
-
-    strip_unstable_attributes(&mut item);
-    // Ignore source text and spans: if the items are otherwise identical, it's ok to just pick one
-    // of the identical instances wrt spans/source.
-    item.as_mut()
-        .dyn_visit_mut(|span: &mut Span| *span = Span::dummy());
-    item.as_mut().item_meta().source_text = None;
-    if let ItemByVal::Type(ty_decl) = &mut item {
-        // Layouts are allowed to differ per-target.
-        ty_decl.layout.clear();
-    }
-    item
-}
-
-/// Strip attributes such as `rustc_diagnostic_item` whose arguments can vary across targets in a
-/// way that doesn't matter to us.
-fn strip_unstable_attributes(item: &mut ItemByVal) {
-    fn strip_in_vec(attr_info: &mut AttrInfo) {
-        attr_info.attributes.retain(
-            |attr| !matches!(attr, Attribute::Unknown(attr) if attr.path.starts_with("rustc_")),
-        );
-    }
-
-    strip_in_vec(&mut item.as_mut().item_meta().attr_info);
-
-    if let ItemByVal::TraitDecl(d) = item {
-        for method in &mut d.methods {
-            strip_in_vec(&mut method.skip_binder.item_meta.attr_info);
-        }
-        for cst in &mut d.consts {
-            strip_in_vec(&mut cst.attr_info);
-        }
-        for ty in &mut d.types {
-            strip_in_vec(&mut ty.skip_binder.attr_info);
-        }
-    }
-}
 
 /// Visitor that remaps references to the given items.
 #[derive(Visitor)]

--- a/charon/src/export/multi_target.rs
+++ b/charon/src/export/multi_target.rs
@@ -221,6 +221,15 @@ enum MergeDecision {
     Facade,
 }
 
+struct ItemComparer;
+
+impl Visitor for ItemComparer {
+    type Break = ();
+}
+
+// Use lockstep visitation for "equality modulo" comparison.
+impl ZipAst for ItemComparer {}
+
 impl TargetGroup {
     /// Deterministically chosen representative id.
     fn canonical_id(&self) -> ItemId {
@@ -259,7 +268,13 @@ impl TargetGroup {
             None => return MergeDecision::Skip,
         };
 
-        if items.iter().all_equal() {
+        let mut comparer = ItemComparer;
+        let mut is_eq = |left, right| ZipAst::visit(&mut comparer, left, right).is_continue();
+        if items
+            .iter()
+            .tuple_windows()
+            .all(|(left, right)| is_eq(left, right))
+        {
             MergeDecision::Dedup
         } else if self.is_function_group()
             && items

--- a/charon/src/export/multi_target.rs
+++ b/charon/src/export/multi_target.rs
@@ -463,7 +463,8 @@ impl TargetGroup {
 
     /// Yields `(non_canonical_id, canonical_id)` pairs for building an ID remap.
     fn remap_entries<'a>(&'a self) -> impl Iterator<Item = (ItemId, ItemId)> + 'a {
-        self.ids.values().map(|&id| (id, self.canonical_id()))
+        let canonical_id = self.canonical_id();
+        self.ids.values().map(move |&id| (id, canonical_id))
     }
     fn into_remap_entries(self) -> impl Iterator<Item = (ItemId, ItemId)> {
         let canonical_id = self.canonical_id();
@@ -471,7 +472,7 @@ impl TargetGroup {
     }
 
     /// Build a façade `FunDecl` for a group of functions with matching signatures but different
-    /// bodies. The `def_id` is set to a placeholder and must be fixed up on insertion.
+    /// bodies.
     fn build_facade_decl(&self, def_id: FunDeclId, krate: &TranslatedCrate) -> FunDecl {
         let canonical_fun_id = *self.canonical_id().as_fun().unwrap();
         let canonical = krate.fun_decls.get(canonical_fun_id).unwrap();
@@ -511,7 +512,7 @@ fn normalize_name_for_grouping(
     let (mut name, target) = name.strip_target_suffix()?;
     for elem in &mut name.name {
         if let PathElem::Impl(ImplElem::Trait(id)) = elem {
-            // Replace ipl block references with something that contains the implemented trait
+            // Replace impl block references with something that contains the implemented trait
             // predicate instead. That way, comparing names for equality compares trait predicates
             // instead.
             if let Some(timpl) = krate.trait_impls.get(*id) {
@@ -658,13 +659,13 @@ impl<'a> ItemDeduplicator<'a> {
         let mut remap = HashMap::new();
         let mut facade_decls: Vec<FunDecl> = Vec::new();
         for &(idx, decision) in &decisions {
-            let mut group = &self.groups[idx];
+            let group = &self.groups[idx];
             let target_id = match decision {
                 MergeDecision::Skip => unreachable!(),
                 MergeDecision::Dedup => {
-                    self.dedup_group(idx); // takes mutable borrow; invalidates `group`
-                    group = &self.groups[idx];
-                    group.canonical_id()
+                    let canonical_id = group.canonical_id();
+                    self.dedup_group(idx);
+                    canonical_id
                 }
                 MergeDecision::Facade => {
                     let facade_id = self.krate.fun_decls.reserve_slot();
@@ -686,6 +687,7 @@ impl<'a> ItemDeduplicator<'a> {
                     ItemId::Fun(facade_id)
                 }
             };
+            let group = &self.groups[idx];
             for &id in group.ids.values() {
                 if id != target_id {
                     remap.insert(id, target_id);


### PR DESCRIPTION
This avoids repeatedly cloning basically the whole crate when doing multi-target comparisons. Instead we use zipping visitors to compare items modulo id remapping and some other per-target details.