### PR TITLE
Rework the representation of switches

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.246"
+let supported_charon_version = "0.1.247"

--- a/charon-ml/src/GAstUtils.ml
+++ b/charon-ml/src/GAstUtils.ml
@@ -51,6 +51,58 @@ let locals_get_input_vars (locals : locals) : local list =
 let fun_body_get_input_vars (fbody : 'body gexpr_body) : local list =
   locals_get_input_vars fbody.locals
 
+(** If this is a switch over a boolean, return its [then] and [else] branches.
+*)
+let switch_as_if (data : switch_data) : (branch_id * branch_id) option =
+  match data.scrutinee with
+  | SwitchValue op ->
+      let ty =
+        match op with
+        | Expressions.Copy p | Expressions.Move p -> p.ty
+        | Expressions.Constant cv -> cv.ty
+      in
+      if ty <> TLiteral TBool then None
+      else
+        let branch_for value =
+          match
+            List.find_map
+              (fun ((case : constant_expr), branch_id) ->
+                match case.kind with
+                | CLiteral (Values.VBool case_value) when case_value = value ->
+                    Some branch_id
+                | _ -> None)
+              data.branches
+          with
+          | Some branch_id -> Some branch_id
+          | None -> data.fallback
+        in
+        Option.bind (branch_for true) (fun then_branch ->
+            Option.map
+              (fun else_branch -> (then_branch, else_branch))
+              (branch_for false))
+  | SwitchDiscriminant _ -> None
+
+(** Group the explicit switch values by the branch they select. *)
+let switch_group_by_branch (data : switch_data) : constant_expr list list =
+  let num_branches =
+    match data.fallback with
+    | None -> 0
+    | Some branch_id -> BranchId.to_int branch_id + 1
+  in
+  let num_branches =
+    List.fold_left
+      (fun num_branches (_, branch_id) ->
+        Int.max num_branches (BranchId.to_int branch_id + 1))
+      num_branches data.branches
+  in
+  let grouped = Array.make num_branches [] in
+  List.iter
+    (fun (value, branch_id) ->
+      let i = BranchId.to_int branch_id in
+      grouped.(i) <- value :: grouped.(i))
+    data.branches;
+  grouped |> Array.map List.rev |> Array.to_list
+
 (** Get the signature of this function as a bound value, i.e. including its
     generics parameters. *)
 let bound_fun_sig_of_decl (def : fun_decl) : bound_fun_sig =

--- a/charon-ml/src/Print.ml
+++ b/charon-ml/src/Print.ml
@@ -398,8 +398,9 @@ module Ullbc = struct
     PrintFmt.pp_to_string (fun fmt ->
         PrintFmt.Ullbc.pp_statement_kind env indent fmt st)
 
-  let switch_to_string indent tgt =
-    PrintFmt.pp_to_string (fun fmt -> PrintFmt.Ullbc.pp_switch indent fmt tgt)
+  let switch_to_string env indent data branches =
+    PrintFmt.pp_to_string (fun fmt ->
+        PrintFmt.Ullbc.pp_switch env indent fmt data branches)
 
   let terminator_to_string env indent st =
     PrintFmt.pp_to_string (fun fmt ->

--- a/charon-ml/src/PrintFmt.ml
+++ b/charon-ml/src/PrintFmt.ml
@@ -487,6 +487,10 @@ and pp_constant_expr (env : fmt_env) (fmt : Format.formatter)
     (cv : constant_expr) : unit =
   match cv.kind with
   | CLiteral lit -> pp_literal fmt lit
+  | CDiscriminant ({ id = type_id; _ }, variant_id) ->
+      Format.fprintf fmt "discriminant_of(%a)"
+        (pp_adt_variant env type_id)
+        variant_id
   | CVar var -> pp_string fmt (const_generic_db_var_to_string env var)
   | CTraitConst (trait_ref, const_id) ->
       let name =
@@ -536,6 +540,13 @@ and pp_constant_expr (env : fmt_env) (fmt : Format.formatter)
           Format.fprintf fmt " with_metadata(%a)" (pp_unsizing_metadata env)
             meta)
         meta
+
+and pp_match_pattern (env : fmt_env) (fmt : Format.formatter)
+    (cv : constant_expr) : unit =
+  match cv.kind with
+  | CDiscriminant ({ id = type_id; _ }, variant_id) ->
+      pp_adt_variant env type_id fmt variant_id
+  | _ -> pp_constant_expr env fmt cv
 
 and constant_expr_to_string env cv =
   pp_to_string (fun fmt -> pp_constant_expr env fmt cv)
@@ -1960,11 +1971,32 @@ let pp_global_decl (env : fmt_env) (indent : string) (indent_incr : string)
     (if clauses = "" then " " else "\n ")
     (pp_constant_expr env) def.value
 
+let switch_as_if (data : switch_data) : (branch_id * branch_id) option =
+  match data.scrutinee with
+  | SwitchValue op when operand_ty op = TLiteral TBool ->
+      let branch_for value =
+        match
+          List.find_map
+            (fun ((case : constant_expr), branch_id) ->
+              match case.kind with
+              | CLiteral (VBool case_value) when case_value = value ->
+                  Some branch_id
+              | _ -> None)
+            data.branches
+        with
+        | Some branch_id -> Some branch_id
+        | None -> data.fallback
+      in
+      Option.bind (branch_for true) (fun then_branch ->
+          Option.map
+            (fun else_branch -> (then_branch, else_branch))
+            (branch_for false))
+  | _ -> None
+
 module Llbc = struct
   (** Pretty-printing for LLBC AST (generic functions) *)
 
   let pp_print_call = pp_call
-  let pp_print_literal = pp_literal
   let pp_print_place = pp_place
   let pp_print_fn_ptr = pp_fn_ptr
   let pp_print_rvalue = pp_rvalue
@@ -2068,9 +2100,42 @@ module Llbc = struct
     | Break i -> Format.fprintf fmt "%sbreak %d" indent i
     | Continue i -> Format.fprintf fmt "%scontinue %d" indent i
     | Nop -> Format.fprintf fmt "%snop" indent
-    | Switch switch -> (
-        match switch with
-        | If (op, true_st, false_st) ->
+    | Switch (data, branches) -> (
+        let branch branch_id = List.nth branches (BranchId.to_int branch_id) in
+        let pp_multiway keyword scrutinee pp_case =
+          let indent1 = indent ^ indent_incr in
+          let indent2 = indent1 ^ indent_incr in
+          Format.fprintf fmt "%s%s %s {\n" indent keyword scrutinee;
+          let first = ref true in
+          List.iteri
+            (fun i be ->
+              let branch_id = BranchId.of_int i in
+              let cases =
+                List.filter_map
+                  (fun (case, id) -> if id = branch_id then Some case else None)
+                  data.branches
+              in
+              let cases =
+                if cases = [] then "_"
+                else
+                  let cases =
+                    pp_to_string (fun fmt ->
+                        pp_sep_list " | " (pp_case env) fmt cases)
+                  in
+                  if data.fallback = Some branch_id then cases ^ " | _"
+                  else cases
+              in
+              if !first then first := false else pp_string fmt "\n";
+              Format.fprintf fmt "%s%s => {\n%a%s}," indent1 cases
+                (pp_block env indent2 indent_incr)
+                be indent1)
+            branches;
+          Format.fprintf fmt "\n%s}" indent
+        in
+        match (data.scrutinee, switch_as_if data) with
+        | SwitchValue op, Some (then_branch, else_branch) ->
+            let true_st = branch then_branch in
+            let false_st = branch else_branch in
             let op = operand_to_string env op in
             let inner_indent = indent ^ indent_incr in
             Format.fprintf fmt "%sif %s {\n%a%s} else {\n%a%s}" indent op
@@ -2078,59 +2143,11 @@ module Llbc = struct
               true_st indent
               (pp_block env inner_indent indent_incr)
               false_st indent
-        | SwitchInt (op, _ty, branches, otherwise) ->
-            let op = operand_to_string env op in
-            let indent1 = indent ^ indent_incr in
-            let indent2 = indent1 ^ indent_incr in
-            Format.fprintf fmt "%sswitch %s {\n" indent op;
-            let first = ref true in
-            List.iter
-              (fun (svl, be) ->
-                if !first then first := false else pp_string fmt "\n";
-                Format.fprintf fmt "%s%a => {\n%a%s}," indent1
-                  (pp_sep_list " | " pp_print_literal)
-                  svl
-                  (pp_block env indent2 indent_incr)
-                  be indent1)
-              branches;
-            if not !first then pp_string fmt "\n";
-            Format.fprintf fmt "%s_ => {\n%a%s},\n%s}" indent1
-              (pp_block env indent2 indent_incr)
-              otherwise indent1 indent
-        | Match (place, branches, otherwise) ->
-            let p = place_to_string env place in
-            let discr_type =
-              match place.ty with
-              | TAdt tref -> Some tref.id
-              | _ -> None
-            in
-            let indent1 = indent ^ indent_incr in
-            let indent2 = indent1 ^ indent_incr in
-            Format.fprintf fmt "%smatch %s {\n" indent p;
-            let first = ref true in
-            let pp_variant_id fmt variant_id =
-              match discr_type with
-              | Some type_id -> pp_adt_variant env type_id fmt variant_id
-              | None -> pp_string fmt (variant_id_to_pretty_string variant_id)
-            in
-            List.iter
-              (fun (svl, be) ->
-                if !first then first := false else pp_string fmt "\n";
-                Format.fprintf fmt "%s%a => {\n%a%s}," indent1
-                  (pp_sep_list " | " pp_variant_id)
-                  svl
-                  (pp_block env indent2 indent_incr)
-                  be indent1)
-              branches;
-            Option.iter
-              (fun otherwise ->
-                if not !first then pp_string fmt "\n";
-                first := false;
-                Format.fprintf fmt "%s_ => {\n%a%s}," indent1
-                  (pp_block env indent2 indent_incr)
-                  otherwise indent1)
-              otherwise;
-            Format.fprintf fmt "\n%s}" indent)
+        | SwitchValue op, None ->
+            pp_multiway "switch" (operand_to_string env op) pp_constant_expr
+        | SwitchDiscriminant place, None ->
+            pp_multiway "match" (place_to_string env place) pp_match_pattern
+        | SwitchDiscriminant _, Some _ -> assert false)
     | Loop loop_blk ->
         Format.fprintf fmt "%sloop {\n%a%s}" indent
           (pp_block env (indent ^ indent_incr) indent_incr)
@@ -2153,7 +2170,6 @@ end
 
 module Ullbc = struct
   let pp_print_call = pp_call
-  let pp_print_literal = pp_literal
   let pp_print_place = pp_place
   let pp_print_rvalue = pp_rvalue
   let pp_print_assertion = pp_assertion
@@ -2196,22 +2212,41 @@ module Ullbc = struct
         Format.fprintf fmt "%s_ = %s" indent (place_to_string env place)
     | Nop -> Format.fprintf fmt "%snop" indent
 
-  let pp_switch (indent : string) (fmt : Format.formatter) (tgt : switch) : unit
-      =
-    match tgt with
-    | If (b0, b1) ->
-        Format.fprintf fmt "%strue -> %s else -> %s" indent
-          (block_id_to_string b0) (block_id_to_string b1)
-    | SwitchInt (_int_ty, branches, otherwise) ->
+  let pp_switch (env : fmt_env) (indent : string) (fmt : Format.formatter)
+      (data : switch_data) (branches : block_id list) : unit =
+    let branch branch_id = List.nth branches (BranchId.to_int branch_id) in
+    match (data.scrutinee, switch_as_if data) with
+    | SwitchValue op, Some (then_branch, else_branch) ->
+        let true_block = branch then_branch in
+        let false_block = branch else_branch in
+        Format.fprintf fmt "%sif %s -> %s else -> %s" indent
+          (operand_to_string env op)
+          (block_id_to_string true_block)
+          (block_id_to_string false_block)
+    | ((SwitchValue _ | SwitchDiscriminant _) as scrutinee), None ->
+        let keyword, scrutinee =
+          match scrutinee with
+          | SwitchValue op -> ("switch", operand_to_string env op)
+          | SwitchDiscriminant place -> ("match", place_to_string env place)
+        in
+        let fallback =
+          data.fallback
+          |> Option.map (fun branch_id ->
+                 "otherwise: " ^ block_id_to_string (branch branch_id))
+          |> Option.to_list
+        in
         let targets =
           List.map
-            (fun (sv, bid) ->
-              pp_to_string (fun fmt -> pp_print_literal fmt sv)
-              ^ ": " ^ block_id_to_string bid)
-            branches
-          @ [ "otherwise: " ^ block_id_to_string otherwise ]
+            (fun (case, branch_id) ->
+              pp_to_string (fun fmt -> pp_match_pattern env fmt case)
+              ^ ": "
+              ^ block_id_to_string (branch branch_id))
+            data.branches
+          @ fallback
         in
-        Format.fprintf fmt "%s%s" indent (String.concat ", " targets)
+        Format.fprintf fmt "%s%s %s -> %s" indent keyword scrutinee
+          (String.concat ", " targets)
+    | SwitchDiscriminant _, Some _ -> assert false
 
   let rec pp_terminator (env : fmt_env) (indent : string)
       (fmt : Format.formatter) (st : terminator) : unit =
@@ -2224,22 +2259,7 @@ module Ullbc = struct
       (fmt : Format.formatter) (st : terminator_kind) : unit =
     match st with
     | Goto bid -> Format.fprintf fmt "%sgoto %s" indent (block_id_to_string bid)
-    | Switch (op, If (true_block, false_block)) ->
-        Format.fprintf fmt "%sif %s -> %s else -> %s" indent
-          (operand_to_string env op)
-          (block_id_to_string true_block)
-          (block_id_to_string false_block)
-    | Switch (op, SwitchInt (_int_ty, branches, otherwise)) ->
-        let targets =
-          List.map
-            (fun (sv, bid) ->
-              pp_to_string (fun fmt -> pp_print_literal fmt sv)
-              ^ ": " ^ block_id_to_string bid)
-            branches
-          @ [ "otherwise: " ^ block_id_to_string otherwise ]
-        in
-        Format.fprintf fmt "%sswitch %s -> %s" indent (operand_to_string env op)
-          (String.concat ", " targets)
+    | Switch (data, branches) -> pp_switch env indent fmt data branches
     | Call (call, tgt, unwind) ->
         Format.fprintf fmt "%a -> %s (unwind: %s)" (pp_print_call env indent)
           call (block_id_to_string tgt)

--- a/charon-ml/src/PrintFmt.ml
+++ b/charon-ml/src/PrintFmt.ml
@@ -1971,28 +1971,6 @@ let pp_global_decl (env : fmt_env) (indent : string) (indent_incr : string)
     (if clauses = "" then " " else "\n ")
     (pp_constant_expr env) def.value
 
-let switch_as_if (data : switch_data) : (branch_id * branch_id) option =
-  match data.scrutinee with
-  | SwitchValue op when operand_ty op = TLiteral TBool ->
-      let branch_for value =
-        match
-          List.find_map
-            (fun ((case : constant_expr), branch_id) ->
-              match case.kind with
-              | CLiteral (VBool case_value) when case_value = value ->
-                  Some branch_id
-              | _ -> None)
-            data.branches
-        with
-        | Some branch_id -> Some branch_id
-        | None -> data.fallback
-      in
-      Option.bind (branch_for true) (fun then_branch ->
-          Option.map
-            (fun else_branch -> (then_branch, else_branch))
-            (branch_for false))
-  | _ -> None
-
 module Llbc = struct
   (** Pretty-printing for LLBC AST (generic functions) *)
 
@@ -2105,16 +2083,13 @@ module Llbc = struct
         let pp_multiway keyword scrutinee pp_case =
           let indent1 = indent ^ indent_incr in
           let indent2 = indent1 ^ indent_incr in
+          let cases_by_branch = switch_group_by_branch data in
           Format.fprintf fmt "%s%s %s {\n" indent keyword scrutinee;
           let first = ref true in
           List.iteri
             (fun i be ->
               let branch_id = BranchId.of_int i in
-              let cases =
-                List.filter_map
-                  (fun (case, id) -> if id = branch_id then Some case else None)
-                  data.branches
-              in
+              let cases = BranchId.nth cases_by_branch branch_id in
               let cases =
                 if cases = [] then "_"
                 else

--- a/charon-ml/src/generated/Generated_FullAst.ml
+++ b/charon-ml/src/generated/Generated_FullAst.ml
@@ -189,6 +189,10 @@ and cli_options = {
           information. *)
   reconstruct_asserts : bool;
       (** Replace [if x { panic() }] with [assert(x)]. *)
+  reconstruct_matches : bool;
+      (** Recombine a [read_discriminant(place)] followed by a [switch] into a
+          single operation that uses enum variants instead of their
+          discriminants. *)
   deallocate_all_locals : bool;
       (** Ensure all local deallocations are made explicit with [StorageDead]
           statements. If this flag is not passed, every non-return local is

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -10,11 +10,13 @@
 open Generated_Types
 open Generated_Meta
 open Generated_Expressions
+open Identifiers
 module FunDeclId = Expressions.FunDeclId
 module GlobalDeclId = Expressions.GlobalDeclId
 module TraitDeclId = Types.TraitDeclId
 module TraitImplId = Types.TraitImplId
 module TraitClauseId = Types.TraitClauseId
+module BranchId = IdGen ()
 
 (* Imports *)
 type builtin_fun_id = Types.builtin_fun_id [@@deriving show, ord]
@@ -75,6 +77,8 @@ and borrowck_statement =
       (** Require a trait predicate to hold. For example, the [Copy] bound in
           [let x: impl Copy = value] produces [PredicateHolds(typeof(x): Copy)].
       *)
+
+and branch_id = (BranchId.id[@visitors.opaque])
 
 (** The kind of a built-in assertion, which may panic and unwind. These are
     removed by [reconstruct_fallible_operations] because they're implicit in the
@@ -223,6 +227,27 @@ and locals = {
           - the [arg_count] input arguments
           - the remaining locals, used for the intermediate computations *)
 }
+
+(** A branching operation. *)
+and switch_data = {
+  scrutinee : switch_scrutinee;  (** The value to branch over. *)
+  branches : (constant_expr * branch_id) list;
+      (** Which branch to take for each value of the scrutinee. Several values
+          may point to the same branch, and not all values may be accounted for.
+
+          If the scrutinee is an operand, the constant expressions are literal
+          values. If the scrutinee is a discriminant read, the expressions are
+          of the form [ConstantExprKind::Discriminant]. *)
+  fallback : branch_id option;
+      (** Branch to use if the scrutinee didn't match any of the values above.
+          [None] if the set of branch values is known to be exhaustive. *)
+}
+
+(** The value inspected by a switch. Must be of integer, bool or char type. *)
+and switch_scrutinee =
+  | SwitchValue of operand  (** Inspect the value produced by an operand. *)
+  | SwitchDiscriminant of place
+      (** Inspect the discriminant of an enum place. *)
 [@@deriving
   show,
   eq,

--- a/charon-ml/src/generated/Generated_LlbcAst.ml
+++ b/charon-ml/src/generated/Generated_LlbcAst.ml
@@ -102,40 +102,12 @@ and statement_kind =
           to continue to: * 0: continue to first outer loop (the current loop) *
           1: continue to second outer loop * ... *)
   | Nop  (** No-op. *)
-  | Switch of switch
+  | Switch of switch_data * block list
+      (** Fields:
+          - [data]
+          - [branches] *)
   | Loop of block
   | Error of string
-
-and switch =
-  | If of operand * block * block
-      (** Gives the [if] block and the [else] block. The [Operand] is the
-          condition of the [if], e.g. [if (y == 0)] could become
-          {@rust[
-            v@3 := copy y; // Represented as [Assign(v@3, Use(Copy(y))]
-            v@2 := move v@3 == 0; // Represented as [Assign(v@2, BinOp(BinOp::Eq, Move(y), Const(0)))]
-            if (move v@2) { // Represented as [If(Move(v@2), <then branch>, <else branch>)]
-          ]} *)
-  | SwitchInt of operand * literal_type * (literal list * block) list * block
-      (** Gives the integer type, a map linking values to switch branches, and
-          the otherwise block. Note that matches over enumerations are performed
-          by switching over the discriminant, which is an integer. Also, we use
-          a [Vec] to make sure the order of the switch branches is preserved.
-
-          Rk.: we use a vector of values, because some of the branches may be
-          grouped together, like for the following code:
-          {@rust[
-            match e {
-              E::V1 | E::V2 => ..., // Grouped
-              E::V3 => ...
-            }
-          ]} *)
-  | Match of place * (variant_id list * block) list * block option
-      (** A match over an ADT.
-
-          The match statement is introduced in
-          [crate::transform::resugar::reconstruct_matches] (whenever we find a
-          discriminant read, we merge it with the subsequent switch into a
-          match). *)
 [@@deriving
   show,
   eq,

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -2205,6 +2205,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           ("unsized_strings", unsized_strings);
           ("reconstruct_fallible_operations", reconstruct_fallible_operations);
           ("reconstruct_asserts", reconstruct_asserts);
+          ("reconstruct_matches", reconstruct_matches);
           ("deallocate_all_locals", deallocate_all_locals);
           ("unbind_item_vars", unbind_item_vars);
           ("print_original_ullbc", print_original_ullbc);
@@ -2274,6 +2275,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
           bool_of_json ctx reconstruct_fallible_operations
         in
         let* reconstruct_asserts = bool_of_json ctx reconstruct_asserts in
+        let* reconstruct_matches = bool_of_json ctx reconstruct_matches in
         let* deallocate_all_locals = bool_of_json ctx deallocate_all_locals in
         let* unbind_item_vars = bool_of_json ctx unbind_item_vars in
         let* print_original_ullbc = bool_of_json ctx print_original_ullbc in
@@ -2332,6 +2334,7 @@ and cli_options_of_json (ctx : of_json_ctx) (js : json) :
              unsized_strings;
              reconstruct_fallible_operations;
              reconstruct_asserts;
+             reconstruct_matches;
              deallocate_all_locals;
              unbind_item_vars;
              print_original_ullbc;

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -268,6 +268,13 @@ and borrowck_statement_of_json (ctx : of_json_ctx) (js : json) :
         Ok (PredicateHolds _0)
     | _ -> Error "")
 
+and branch_id_of_json (ctx : of_json_ctx) (js : json) :
+    (branch_id, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | x -> BranchId.id_of_json ctx x
+    | _ -> Error "")
+
 and builtin_assert_kind_of_json (ctx : of_json_ctx) (js : json) :
     (builtin_assert_kind, string) result =
   combine_error_msgs js __FUNCTION__
@@ -499,6 +506,10 @@ and constant_expr_kind_of_json (ctx : of_json_ctx) (js : json) :
     | `Assoc [ ("VTableRef", _0) ] ->
         let* _0 = trait_ref_of_json ctx _0 in
         Ok (CVTableRef _0)
+    | `Assoc [ ("Discriminant", `List [ _0; _1 ]) ] ->
+        let* _0 = type_decl_ref_of_json ctx _0 in
+        let* _1 = variant_id_of_json ctx _1 in
+        Ok (CDiscriminant (_0, _1))
     | `Assoc [ ("Ref", `List [ _0; _1 ]) ] ->
         let* _0 = constant_expr_of_json ctx _0 in
         let* _1 = option_of_json unsizing_metadata_of_json ctx _1 in
@@ -1246,6 +1257,38 @@ and span_data_of_json (ctx : of_json_ctx) (js : json) :
         Ok ({ file; beg_loc; end_loc } : span_data)
     | _ -> Error "")
 
+and switch_data_of_json (ctx : of_json_ctx) (js : json) :
+    (switch_data, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc
+        [
+          ("scrutinee", scrutinee);
+          ("branches", branches);
+          ("fallback", fallback);
+        ] ->
+        let* scrutinee = switch_scrutinee_of_json ctx scrutinee in
+        let* branches =
+          list_of_json
+            (pair_of_json constant_expr_of_json branch_id_of_json)
+            ctx branches
+        in
+        let* fallback = option_of_json branch_id_of_json ctx fallback in
+        Ok ({ scrutinee; branches; fallback } : switch_data)
+    | _ -> Error "")
+
+and switch_scrutinee_of_json (ctx : of_json_ctx) (js : json) :
+    (switch_scrutinee, string) result =
+  combine_error_msgs js __FUNCTION__
+    (match js with
+    | `Assoc [ ("Value", _0) ] ->
+        let* _0 = operand_of_json ctx _0 in
+        Ok (SwitchValue _0)
+    | `Assoc [ ("Discriminant", _0) ] ->
+        let* _0 = place_of_json ctx _0 in
+        Ok (SwitchDiscriminant _0)
+    | _ -> Error "")
+
 and trait_assoc_ty_impl_of_json (ctx : of_json_ctx) (js : json) :
     (trait_assoc_ty_impl, string) result =
   combine_error_msgs js __FUNCTION__
@@ -1667,23 +1710,6 @@ module Ullbc = struct
       | `String "Nop" -> Ok Nop
       | _ -> Error "")
 
-  and switch_of_json (ctx : of_json_ctx) (js : json) :
-      (Generated_UllbcAst.switch, string) result =
-    combine_error_msgs js __FUNCTION__
-      (match js with
-      | `Assoc [ ("If", `List [ _0; _1 ]) ] ->
-          let* _0 = block_id_of_json ctx _0 in
-          let* _1 = block_id_of_json ctx _1 in
-          Ok (If (_0, _1))
-      | `Assoc [ ("SwitchInt", `List [ _0; _1; _2 ]) ] ->
-          let* _0 = literal_type_of_json ctx _0 in
-          let* _1 =
-            list_of_json (pair_of_json literal_of_json block_id_of_json) ctx _1
-          in
-          let* _2 = block_id_of_json ctx _2 in
-          Ok (SwitchInt (_0, _1, _2))
-      | _ -> Error "")
-
   and terminator_of_json (ctx : of_json_ctx) (js : json) :
       (terminator, string) result =
     combine_error_msgs js __FUNCTION__
@@ -1707,11 +1733,13 @@ module Ullbc = struct
       | `Assoc [ ("Goto", `Assoc [ ("target", target) ]) ] ->
           let* target = block_id_of_json ctx target in
           Ok (Goto target)
-      | `Assoc [ ("Switch", `Assoc [ ("discr", discr); ("targets", targets) ]) ]
+      | `Assoc [ ("Switch", `Assoc [ ("data", data); ("branches", branches) ]) ]
         ->
-          let* discr = operand_of_json ctx discr in
-          let* targets = switch_of_json ctx targets in
-          Ok (Switch (discr, targets))
+          let* data = switch_data_of_json ctx data in
+          let* branches =
+            index_vec_of_json branch_id_of_json block_id_of_json ctx branches
+          in
+          Ok (Switch (data, branches))
       | `Assoc
           [
             ( "Call",
@@ -1908,45 +1936,19 @@ module Llbc = struct
           let* _0 = int_of_json ctx _0 in
           Ok (Continue _0)
       | `String "Nop" -> Ok Nop
-      | `Assoc [ ("Switch", _0) ] ->
-          let* _0 = switch_of_json ctx _0 in
-          Ok (Switch _0)
+      | `Assoc [ ("Switch", `Assoc [ ("data", data); ("branches", branches) ]) ]
+        ->
+          let* data = switch_data_of_json ctx data in
+          let* branches =
+            index_vec_of_json branch_id_of_json block_of_json ctx branches
+          in
+          Ok (Switch (data, branches))
       | `Assoc [ ("Loop", _0) ] ->
           let* _0 = block_of_json ctx _0 in
           Ok (Loop _0)
       | `Assoc [ ("Error", _0) ] ->
           let* _0 = string_of_json ctx _0 in
           Ok (Error _0)
-      | _ -> Error "")
-
-  and switch_of_json (ctx : of_json_ctx) (js : json) :
-      (Generated_LlbcAst.switch, string) result =
-    combine_error_msgs js __FUNCTION__
-      (match js with
-      | `Assoc [ ("If", `List [ _0; _1; _2 ]) ] ->
-          let* _0 = operand_of_json ctx _0 in
-          let* _1 = block_of_json ctx _1 in
-          let* _2 = block_of_json ctx _2 in
-          Ok (If (_0, _1, _2))
-      | `Assoc [ ("SwitchInt", `List [ _0; _1; _2; _3 ]) ] ->
-          let* _0 = operand_of_json ctx _0 in
-          let* _1 = literal_type_of_json ctx _1 in
-          let* _2 =
-            list_of_json
-              (pair_of_json (list_of_json literal_of_json) block_of_json)
-              ctx _2
-          in
-          let* _3 = block_of_json ctx _3 in
-          Ok (SwitchInt (_0, _1, _2, _3))
-      | `Assoc [ ("Match", `List [ _0; _1; _2 ]) ] ->
-          let* _0 = place_of_json ctx _0 in
-          let* _1 =
-            list_of_json
-              (pair_of_json (list_of_json variant_id_of_json) block_of_json)
-              ctx _1
-          in
-          let* _2 = option_of_json block_of_json ctx _2 in
-          Ok (Match (_0, _1, _2))
       | _ -> Error "")
 end
 

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -250,6 +250,10 @@ and borrowck_statement_of_postcard (ctx : of_postcard_ctx) (st : postcard_state)
          Ok (PredicateHolds _0)
      | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
 
+and branch_id_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
+    (branch_id, string) result =
+  combine_error_msgs st __FUNCTION__ (BranchId.id_of_postcard ctx st)
+
 and builtin_assert_kind_of_postcard (ctx : of_postcard_ctx)
     (st : postcard_state) : (builtin_assert_kind, string) result =
   combine_error_msgs st __FUNCTION__
@@ -468,45 +472,49 @@ and constant_expr_kind_of_postcard (ctx : of_postcard_ctx) (st : postcard_state)
          let* _0 = trait_ref_of_postcard ctx st in
          Ok (CVTableRef _0)
      | 6 ->
+         let* _0 = type_decl_ref_of_postcard ctx st in
+         let* _1 = variant_id_of_postcard ctx st in
+         Ok (CDiscriminant (_0, _1))
+     | 7 ->
          let* _0 = constant_expr_of_postcard ctx st in
          let* _1 = option_of_postcard unsizing_metadata_of_postcard ctx st in
          Ok (CRef (_0, _1))
-     | 7 ->
+     | 8 ->
          let* _0 = ref_kind_of_postcard ctx st in
          let* _1 = constant_expr_of_postcard ctx st in
          let* _2 = option_of_postcard unsizing_metadata_of_postcard ctx st in
          Ok (CPtr (_0, _1, _2))
-     | 8 ->
+     | 9 ->
          let* _0 =
            de_bruijn_var_of_postcard const_generic_var_id_of_postcard ctx st
          in
          Ok (CVar _0)
-     | 9 ->
+     | 10 ->
          let* _0 = fn_ptr_of_postcard ctx st in
          let* _1 = list_of_postcard constant_expr_of_postcard ctx st in
          Ok (CCall (_0, _1))
-     | 10 ->
-         let* _0 = fn_ptr_of_postcard ctx st in
-         Ok (CFnDef _0)
      | 11 ->
          let* _0 = fn_ptr_of_postcard ctx st in
-         Ok (CFnPtr _0)
+         Ok (CFnDef _0)
      | 12 ->
-         let* _0 = ty_of_postcard ctx st in
-         Ok (CSizeOf _0)
+         let* _0 = fn_ptr_of_postcard ctx st in
+         Ok (CFnPtr _0)
      | 13 ->
          let* _0 = ty_of_postcard ctx st in
-         Ok (CAlignOf _0)
+         Ok (CSizeOf _0)
      | 14 ->
          let* _0 = ty_of_postcard ctx st in
-         Ok (CTypeId _0)
+         Ok (CAlignOf _0)
      | 15 ->
+         let* _0 = ty_of_postcard ctx st in
+         Ok (CTypeId _0)
+     | 16 ->
          let* _0 = big_uint_of_postcard ctx st in
          Ok (CPtrNoProvenance _0)
-     | 16 ->
+     | 17 ->
          let* _0 = list_of_postcard byte_of_postcard ctx st in
          Ok (CRawMemory _0)
-     | 17 ->
+     | 18 ->
          let* _0 = string_of_postcard ctx st in
          Ok (COpaque _0)
      | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
@@ -1143,6 +1151,31 @@ and span_data_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
      let* end_loc = loc_of_postcard ctx st in
      Ok ({ file; beg_loc; end_loc } : span_data))
 
+and switch_data_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
+    (switch_data, string) result =
+  combine_error_msgs st __FUNCTION__
+    (let* scrutinee = switch_scrutinee_of_postcard ctx st in
+     let* branches =
+       list_of_postcard
+         (pair_of_postcard constant_expr_of_postcard branch_id_of_postcard)
+         ctx st
+     in
+     let* fallback = option_of_postcard branch_id_of_postcard ctx st in
+     Ok ({ scrutinee; branches; fallback } : switch_data))
+
+and switch_scrutinee_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
+    (switch_scrutinee, string) result =
+  combine_error_msgs st __FUNCTION__
+    (let* __tag = int_of_postcard ctx st in
+     match __tag with
+     | 0 ->
+         let* _0 = operand_of_postcard ctx st in
+         Ok (SwitchValue _0)
+     | 1 ->
+         let* _0 = place_of_postcard ctx st in
+         Ok (SwitchDiscriminant _0)
+     | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
+
 and trait_assoc_ty_impl_of_postcard (ctx : of_postcard_ctx)
     (st : postcard_state) : (trait_assoc_ty_impl, string) result =
   combine_error_msgs st __FUNCTION__
@@ -1491,26 +1524,6 @@ module Ullbc = struct
        | 7 -> Ok Nop
        | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
 
-  and switch_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
-      (Generated_UllbcAst.switch, string) result =
-    combine_error_msgs st __FUNCTION__
-      (let* __tag = int_of_postcard ctx st in
-       match __tag with
-       | 0 ->
-           let* _0 = block_id_of_postcard ctx st in
-           let* _1 = block_id_of_postcard ctx st in
-           Ok (If (_0, _1))
-       | 1 ->
-           let* _0 = literal_type_of_postcard ctx st in
-           let* _1 =
-             list_of_postcard
-               (pair_of_postcard literal_of_postcard block_id_of_postcard)
-               ctx st
-           in
-           let* _2 = block_id_of_postcard ctx st in
-           Ok (SwitchInt (_0, _1, _2))
-       | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
-
   and terminator_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
       (terminator, string) result =
     combine_error_msgs st __FUNCTION__
@@ -1528,9 +1541,12 @@ module Ullbc = struct
            let* target = block_id_of_postcard ctx st in
            Ok (Goto target)
        | 1 ->
-           let* discr = operand_of_postcard ctx st in
-           let* targets = switch_of_postcard ctx st in
-           Ok (Switch (discr, targets))
+           let* data = switch_data_of_postcard ctx st in
+           let* branches =
+             index_vec_of_postcard branch_id_of_postcard block_id_of_postcard
+               ctx st
+           in
+           Ok (Switch (data, branches))
        | 2 ->
            let* call = call_of_postcard ctx st in
            let* target = block_id_of_postcard ctx st in
@@ -1651,49 +1667,18 @@ module Llbc = struct
            Ok (Continue _0)
        | 15 -> Ok Nop
        | 16 ->
-           let* _0 = switch_of_postcard ctx st in
-           Ok (Switch _0)
+           let* data = switch_data_of_postcard ctx st in
+           let* branches =
+             index_vec_of_postcard branch_id_of_postcard block_of_postcard ctx
+               st
+           in
+           Ok (Switch (data, branches))
        | 17 ->
            let* _0 = block_of_postcard ctx st in
            Ok (Loop _0)
        | 18 ->
            let* _0 = string_of_postcard ctx st in
            Ok (Error _0)
-       | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
-
-  and switch_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
-      (Generated_LlbcAst.switch, string) result =
-    combine_error_msgs st __FUNCTION__
-      (let* __tag = int_of_postcard ctx st in
-       match __tag with
-       | 0 ->
-           let* _0 = operand_of_postcard ctx st in
-           let* _1 = block_of_postcard ctx st in
-           let* _2 = block_of_postcard ctx st in
-           Ok (If (_0, _1, _2))
-       | 1 ->
-           let* _0 = operand_of_postcard ctx st in
-           let* _1 = literal_type_of_postcard ctx st in
-           let* _2 =
-             list_of_postcard
-               (pair_of_postcard
-                  (list_of_postcard literal_of_postcard)
-                  block_of_postcard)
-               ctx st
-           in
-           let* _3 = block_of_postcard ctx st in
-           Ok (SwitchInt (_0, _1, _2, _3))
-       | 2 ->
-           let* _0 = place_of_postcard ctx st in
-           let* _1 =
-             list_of_postcard
-               (pair_of_postcard
-                  (list_of_postcard variant_id_of_postcard)
-                  block_of_postcard)
-               ctx st
-           in
-           let* _2 = option_of_postcard block_of_postcard ctx st in
-           Ok (Match (_0, _1, _2))
        | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
 end
 

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -1912,6 +1912,7 @@ and cli_options_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
      let* unsized_strings = bool_of_postcard ctx st in
      let* reconstruct_fallible_operations = bool_of_postcard ctx st in
      let* reconstruct_asserts = bool_of_postcard ctx st in
+     let* reconstruct_matches = bool_of_postcard ctx st in
      let* deallocate_all_locals = bool_of_postcard ctx st in
      let* unbind_item_vars = bool_of_postcard ctx st in
      let* print_original_ullbc = bool_of_postcard ctx st in
@@ -1968,6 +1969,7 @@ and cli_options_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
           unsized_strings;
           reconstruct_fallible_operations;
           reconstruct_asserts;
+          reconstruct_matches;
           deallocate_all_locals;
           unbind_item_vars;
           print_original_ullbc;

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -370,6 +370,8 @@ and constant_expr_kind =
       (** A reference to the vtable [static] item for this trait ref. This can
           be normalized for cases where we do emit a vtable item. That's not
           always the case for builtin traits, e.g. for [MetaSized]. *)
+  | CDiscriminant of type_decl_ref * variant_id
+      (** The integer discriminant value corresponding to this enum variant. *)
   | CRef of constant_expr * unsizing_metadata option
       (** A shared reference to a constant value.
 

--- a/charon-ml/src/generated/Generated_UllbcAst.ml
+++ b/charon-ml/src/generated/Generated_UllbcAst.ml
@@ -58,13 +58,6 @@ and statement_kind =
           - [on_failure] *)
   | Nop  (** Does nothing. Useful for passes. *)
 
-and switch =
-  | If of block_id * block_id  (** Gives the [if] block and the [else] block *)
-  | SwitchInt of literal_type * (literal * block_id) list * block_id
-      (** Gives the integer type, a map linking values to switch branches, and
-          the otherwise block. Note that matches over enumerations are performed
-          by switching over the discriminant, which is an integer. *)
-
 (** A terminator: instruction to execute at the end of a block, which may jump
     to other blocks. *)
 and terminator = {
@@ -77,10 +70,10 @@ and terminator_kind =
   | Goto of block_id
       (** Fields:
           - [target] *)
-  | Switch of operand * switch
+  | Switch of switch_data * block_id list
       (** Fields:
-          - [discr]
-          - [targets] *)
+          - [data]
+          - [branches] *)
   | Call of call * block_id * block_id
       (** Fields:
           - [call]

--- a/charon-ml/tests/Test_NameMatcher.ml
+++ b/charon-ml/tests/Test_NameMatcher.ml
@@ -146,8 +146,14 @@ module PatternTest = struct
           let rec list_stmt_calls (statement : statement) : call list =
             match statement.kind with
             | Call (call, _) -> [ call ]
-            | Switch (If (_, st1, st2)) ->
-                list_block_calls st1 @ list_block_calls st2
+            | Switch
+                ({ scrutinee = SwitchValue _; branches = cases; _ }, branches)
+              when List.exists
+                     (fun ((case : Charon.Types.constant_expr), _) ->
+                       match case.kind with
+                       | CLiteral (VBool _) -> true
+                       | _ -> false)
+                     cases -> List.concat_map list_block_calls branches
             | Switch _ ->
                 failwith
                   "Only `if then else` are supported in name matcher tests, \

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "charon"
-version = "0.1.246"
+version = "0.1.247"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -26,7 +26,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.246"
+version = "0.1.247"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/src/ast/bodies.rs
+++ b/charon/src/ast/bodies.rs
@@ -119,6 +119,39 @@ pub struct GExprBody<T> {
     pub comments: Vec<(usize, Vec<String>)>,
 }
 
+generate_index_type!(BranchId, "Branch");
+
+/// The value inspected by a switch. Must be of integer, bool or char type.
+#[derive(
+    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
+)]
+#[cfg_attr(feature = "charon_on_charon", charon::variants_prefix("Switch"))]
+pub enum SwitchScrutinee {
+    /// Inspect the value produced by an operand.
+    Value(Operand),
+    /// Inspect the discriminant of an enum place.
+    Discriminant(Place),
+}
+
+/// A branching operation.
+#[derive(
+    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
+)]
+pub struct SwitchData {
+    /// The value to branch over.
+    pub scrutinee: SwitchScrutinee,
+    /// Which branch to take for each value of the scrutinee. Several values may point to the same
+    /// branch, and not all values may be accounted for.
+    ///
+    /// If the scrutinee is an operand, the constant expressions are literal values. If the
+    /// scrutinee is a discriminant read, the expressions are of the form
+    /// `ConstantExprKind::Discriminant`.
+    pub branches: Vec<(ConstantExpr, BranchId)>,
+    /// Branch to use if the scrutinee didn't match any of the values above. `None` if the set of
+    /// branch values is known to be exhaustive.
+    pub fallback: Option<BranchId>,
+}
+
 /// A function operand is used in function calls.
 /// It either designates a top-level function, or a place in case
 /// we are using function pointers stored in local variables.
@@ -318,6 +351,47 @@ impl Locals {
     /// Locals that aren't arguments or return values.
     pub fn non_argument_locals(&self) -> impl Iterator<Item = (LocalId, &Local)> {
         self.locals.iter_enumerated().skip(1 + self.arg_count)
+    }
+}
+
+impl SwitchData {
+    /// If this is a switch over a boolean, return its `then` and `else` branches.
+    pub fn as_if(&self) -> Option<(BranchId, BranchId)> {
+        let SwitchScrutinee::Value(scrutinee) = &self.scrutinee else {
+            return None;
+        };
+        if !matches!(scrutinee.ty().kind(), TyKind::Literal(LiteralTy::Bool)) {
+            return None;
+        }
+
+        let branch_for = |value| {
+            self.branches
+                .iter()
+                .find_map(|(case, branch_id)| match case.kind() {
+                    ConstantExprKind::Literal(Literal::Bool(case_value))
+                        if *case_value == value =>
+                    {
+                        Some(*branch_id)
+                    }
+                    _ => None,
+                })
+                .or(self.fallback)
+        };
+        Some((branch_for(true)?, branch_for(false)?))
+    }
+
+    /// Group the explicit switch values by the branch they select.
+    pub fn group_by_branch(&self) -> IndexVec<BranchId, Vec<ConstantExpr>> {
+        let mut grouped = IndexVec::new();
+        if let Some(branch_id) = self.fallback {
+            grouped.get_or_extend_and_insert(branch_id, Vec::new);
+        }
+        for (value, branch_id) in &self.branches {
+            grouped
+                .get_or_extend_and_insert(*branch_id, Vec::new)
+                .push(value.clone());
+        }
+        grouped
     }
 }
 

--- a/charon/src/ast/bodies/structured.rs
+++ b/charon/src/ast/bodies/structured.rs
@@ -3,7 +3,7 @@
 //!
 //! We reconstruct this structure from the unstructured ast in an optional translation pass.
 use derive_generic_visitor::*;
-use macros::{EnumAsGetters, EnumIsA, EnumToGetters, VariantIndexArity, VariantName};
+use macros::{EnumAsGetters, EnumIsA, EnumToGetters};
 use serde_state::{DeserializeState, SerializeState};
 use std::mem;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -126,56 +126,12 @@ pub enum StatementKind {
     Continue(usize),
     /// No-op.
     Nop,
-    Switch(Switch),
+    Switch {
+        data: SwitchData,
+        branches: IndexVec<BranchId, Block>,
+    },
     Loop(Block),
     Error(String),
-}
-
-#[derive(
-    Debug,
-    PartialEq,
-    Eq,
-    Clone,
-    EnumIsA,
-    EnumToGetters,
-    EnumAsGetters,
-    SerializeState,
-    DeserializeState,
-    Drive,
-    DriveMut,
-    DriveTwo,
-    VariantName,
-    VariantIndexArity,
-)]
-pub enum Switch {
-    /// Gives the `if` block and the `else` block. The `Operand` is the condition of the `if`, e.g. `if (y == 0)` could become
-    /// ```text
-    /// v@3 := copy y; // Represented as `Assign(v@3, Use(Copy(y))`
-    /// v@2 := move v@3 == 0; // Represented as `Assign(v@2, BinOp(BinOp::Eq, Move(y), Const(0)))`
-    /// if (move v@2) { // Represented as `If(Move(v@2), <then branch>, <else branch>)`
-    /// ```
-    If(Operand, Block, Block),
-    /// Gives the integer type, a map linking values to switch branches, and the
-    /// otherwise block. Note that matches over enumerations are performed by
-    /// switching over the discriminant, which is an integer.
-    /// Also, we use a `Vec` to make sure the order of the switch
-    /// branches is preserved.
-    ///
-    /// Rk.: we use a vector of values, because some of the branches may
-    /// be grouped together, like for the following code:
-    /// ```text
-    /// match e {
-    ///   E::V1 | E::V2 => ..., // Grouped
-    ///   E::V3 => ...
-    /// }
-    /// ```
-    SwitchInt(Operand, LiteralTy, Vec<(Vec<Literal>, Block)>, Block),
-    /// A match over an ADT.
-    ///
-    /// The match statement is introduced in [crate::transform::resugar::reconstruct_matches]
-    /// (whenever we find a discriminant read, we merge it with the subsequent
-    /// switch into a match).
-    Match(Place, Vec<(Vec<VariantId>, Block)>, Option<Block>),
 }
 
 /// Ignores statement ids.
@@ -351,57 +307,5 @@ impl StatementId {
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let id = COUNTER.fetch_add(1, Ordering::Relaxed);
         StatementId::new(id)
-    }
-}
-
-impl Switch {
-    pub fn iter_targets(&self) -> impl Iterator<Item = &Block> {
-        use itertools::Either;
-        match self {
-            Switch::If(_, exp1, exp2) => Either::Left([exp1, exp2].into_iter()),
-            Switch::SwitchInt(_, _, targets, otherwise) => Either::Right(Either::Left(
-                targets.iter().map(|(_, tgt)| tgt).chain([otherwise]),
-            )),
-            Switch::Match(_, targets, otherwise) => Either::Right(Either::Right(
-                targets.iter().map(|(_, tgt)| tgt).chain(otherwise.as_ref()),
-            )),
-        }
-    }
-
-    pub fn iter_targets_mut(&mut self) -> impl Iterator<Item = &mut Block> {
-        use itertools::Either;
-        match self {
-            Switch::If(_, exp1, exp2) => Either::Left([exp1, exp2].into_iter()),
-            Switch::SwitchInt(_, _, targets, otherwise) => Either::Right(Either::Left(
-                targets.iter_mut().map(|(_, tgt)| tgt).chain([otherwise]),
-            )),
-            Switch::Match(_, targets, otherwise) => Either::Right(Either::Right(
-                targets
-                    .iter_mut()
-                    .map(|(_, tgt)| tgt)
-                    .chain(otherwise.as_mut()),
-            )),
-        }
-    }
-
-    /// Combine the span information from a [Switch]
-    pub fn combine_targets_span(&self) -> Span {
-        match self {
-            Switch::If(_, st1, st2) => meta::combine_span(&st1.span, &st2.span),
-            Switch::SwitchInt(_, _, branches, otherwise) => {
-                let branches = branches.iter().map(|b| &b.1.span);
-                let mbranches = meta::combine_span_iter(branches);
-                meta::combine_span(&mbranches, &otherwise.span)
-            }
-            Switch::Match(_, branches, otherwise) => {
-                let branches = branches.iter().map(|b| &b.1.span);
-                let mbranches = meta::combine_span_iter(branches);
-                if let Some(otherwise) = otherwise {
-                    meta::combine_span(&mbranches, &otherwise.span)
-                } else {
-                    mbranches
-                }
-            }
-        }
     }
 }

--- a/charon/src/ast/bodies/unstructured.rs
+++ b/charon/src/ast/bodies/unstructured.rs
@@ -2,7 +2,7 @@
 //!
 //! In effect, this is a cleaned up version of MIR.
 use derive_generic_visitor::{Drive, DriveMut, DriveTwo};
-use macros::{EnumAsGetters, EnumIsA, VariantIndexArity, VariantName};
+use macros::{EnumAsGetters, EnumIsA, VariantName};
 use serde_state::{DeserializeState, SerializeState};
 use smallvec::{SmallVec, smallvec};
 use std::collections::HashMap;
@@ -99,31 +99,6 @@ pub enum StatementKind {
     Clone,
     EnumIsA,
     EnumAsGetters,
-    VariantName,
-    VariantIndexArity,
-    SerializeState,
-    DeserializeState,
-    Drive,
-    DriveMut,
-    DriveTwo,
-)]
-#[cfg_attr(feature = "charon_on_charon", charon::rename("Switch"))]
-pub enum SwitchTargets {
-    /// Gives the `if` block and the `else` block
-    If(BlockId, BlockId),
-    /// Gives the integer type, a map linking values to switch branches, and the
-    /// otherwise block. Note that matches over enumerations are performed by
-    /// switching over the discriminant, which is an integer.
-    SwitchInt(LiteralTy, Vec<(Literal, BlockId)>, BlockId),
-}
-
-#[derive(
-    Debug,
-    PartialEq,
-    Eq,
-    Clone,
-    EnumIsA,
-    EnumAsGetters,
     SerializeState,
     DeserializeState,
     Drive,
@@ -135,8 +110,8 @@ pub enum TerminatorKind {
         target: BlockId,
     },
     Switch {
-        discr: Operand,
-        targets: SwitchTargets,
+        data: SwitchData,
+        branches: IndexVec<BranchId, BlockId>,
     },
     Call {
         call: Call,
@@ -413,7 +388,7 @@ impl Terminator {
             TerminatorKind::Goto { target } => {
                 smallvec![*target]
             }
-            TerminatorKind::Switch { targets, .. } => targets.targets(),
+            TerminatorKind::Switch { branches, .. } => branches.iter().copied().collect(),
             TerminatorKind::InlineAsm {
                 targets, on_unwind, ..
             } => targets.iter().copied().chain([*on_unwind]).collect(),
@@ -436,7 +411,7 @@ impl Terminator {
             TerminatorKind::Goto { target } => {
                 smallvec![target]
             }
-            TerminatorKind::Switch { targets, .. } => targets.targets_mut(),
+            TerminatorKind::Switch { branches, .. } => branches.iter_mut().collect(),
             TerminatorKind::InlineAsm {
                 targets, on_unwind, ..
             } => targets.iter_mut().chain([on_unwind]).collect(),
@@ -460,7 +435,7 @@ impl Terminator {
             TerminatorKind::Goto { target } => {
                 smallvec![*target]
             }
-            TerminatorKind::Switch { targets, .. } => targets.targets(),
+            TerminatorKind::Switch { branches, .. } => branches.iter().copied().collect(),
             TerminatorKind::InlineAsm { targets, .. } => targets.iter().copied().collect(),
             TerminatorKind::Call { target, .. }
             | TerminatorKind::Drop { target, .. }
@@ -470,34 +445,6 @@ impl Terminator {
             TerminatorKind::Abort(..) | TerminatorKind::Return | TerminatorKind::UnwindResume => {
                 smallvec![]
             }
-        }
-    }
-}
-
-impl SwitchTargets {
-    pub fn targets(&self) -> SmallVec<[BlockId; 2]> {
-        match self {
-            SwitchTargets::If(then_tgt, else_tgt) => {
-                smallvec![*then_tgt, *else_tgt]
-            }
-            SwitchTargets::SwitchInt(_, targets, otherwise) => targets
-                .iter()
-                .map(|(_, t)| t)
-                .chain([otherwise])
-                .copied()
-                .collect(),
-        }
-    }
-    pub fn targets_mut(&mut self) -> SmallVec<[&mut BlockId; 2]> {
-        match self {
-            SwitchTargets::If(then_tgt, else_tgt) => {
-                smallvec![then_tgt, else_tgt]
-            }
-            SwitchTargets::SwitchInt(_, targets, otherwise) => targets
-                .iter_mut()
-                .map(|(_, t)| t)
-                .chain([otherwise])
-                .collect(),
         }
     }
 }

--- a/charon/src/ast/bodies/values.rs
+++ b/charon/src/ast/bodies/values.rs
@@ -88,6 +88,8 @@ pub enum ConstantExprKind {
     /// cases where we do emit a vtable item. That's not always the case for builtin traits, e.g.
     /// for `MetaSized`.
     VTableRef(TraitRef),
+    /// The integer discriminant value corresponding to this enum variant.
+    Discriminant(TypeDeclRef, VariantId),
     /// A shared reference to a constant value.
     ///
     /// We eliminate this case in a micro-pass.
@@ -327,8 +329,13 @@ impl Literal {
                 IntegerTy::Unsigned(uint_ty),
                 bits,
             ))),
+            LiteralTy::Bool => match bits {
+                0 => Some(Literal::Bool(false)),
+                1 => Some(Literal::Bool(true)),
+                _ => None,
+            },
             LiteralTy::Char => Some(Literal::char_from_le_bytes(bits)),
-            _ => None,
+            LiteralTy::Float(_) => None,
         }
     }
 }

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -53,7 +53,7 @@ use derive_generic_visitor::*;
         GlobalKind, ItemOpacity, LangItem, LifetimeMutability, OptimizeAttr, OverflowMode,
         ReprOptions, Variance,
         std::ops::RangeInclusive<ScalarValue>,
-        WithRetag, BuiltinPathElem
+        WithRetag, BuiltinPathElem, BranchId,
     ),
     // Types that are completely skipped, even by `ZipAst`.
     skip(
@@ -67,12 +67,12 @@ use derive_generic_visitor::*;
         Deprecation, Disambiguator, DynPredicate, Field, FieldId, File, FloatTy, FloatValue,
         FnOperand, FunId, FnPtrKind, FunSig, InlineAttr, IntegerTy, IntTy, UIntTy, Literal, LiteralTy,
         Ident, from_rustc::InlineAttr,
-        llbc_ast::ExprBody, llbc_ast::StatementKind, llbc_ast::Switch,
+        llbc_ast::ExprBody, llbc_ast::StatementKind,
         Loc, Locals, NullOp, Operand, PathElem, PlaceKind,
         RawAttribute, RefKind, RegionId, RegionParam, ScalarValue, TraitItemName, TraitMethodId, AssocTypeId, AssocConstId, AssocItemId, MaybeAssocItemId,
         TranslatedCrate, TypeDeclKind, TypeParam, TypePattern, TypeVarId,
         ullbc_ast::BlockData, ullbc_ast::BlockId, ullbc_ast::ExprBody, ullbc_ast::StatementKind,
-        ullbc_ast::TerminatorKind, ullbc_ast::SwitchTargets,
+        ullbc_ast::TerminatorKind, SwitchData, SwitchScrutinee,
         UnOp, UnsizingMetadata, Local, Variant, VariantId, LocalId, Layout, VariantLayout,
         Discriminator,
         SizeExpr, OffsetExpr, SizeGuarantee, OffsetGuarantee,
@@ -196,7 +196,7 @@ impl<K: BodyVisitable + Hash + Eq, T: BodyVisitable> BodyVisitable for SeqHashMa
     visitor(drive_body_mut(&mut VisitBodyMut)),
     // Types that are ignored when encountered.
     skip(
-        AbortKind, BinOp, BorrowKind, BuiltinAssertKind, ConstantExpr, FieldId,
+        AbortKind, BinOp, BorrowKind, BranchId, BuiltinAssertKind, ConstantExpr, FieldId,
         TypeDeclRef, FunDeclId, FunDeclRef, FnPtrKind, GenericArgs, GlobalDeclRef, IntegerTy, IntTy, UIntTy,
         NullOp, RefKind, ScalarValue, Span, Ty, TypeDeclId,  UnOp, VariantId,
         TraitRef, LiteralTy, Literal, Region, RegionId, (), String, PathBuf, bool, usize,
@@ -206,9 +206,9 @@ impl<K: BodyVisitable + Hash + Eq, T: BodyVisitable> BodyVisitable for SeqHashMa
     // Types that we unconditionally explore.
     drive(
         Assert, BorrowckStatement, PlaceKind,
-        llbc_ast::ExprBody, llbc_ast::StatementKind, llbc_ast::Switch,
+        llbc_ast::ExprBody, llbc_ast::StatementKind,
         ullbc_ast::BlockData, ullbc_ast::ExprBody, ullbc_ast::StatementKind,
-        ullbc_ast::TerminatorKind, ullbc_ast::SwitchTargets,
+        ullbc_ast::TerminatorKind, SwitchData, SwitchScrutinee,
         Body, Local,
         for<T: BodyVisitable> Box<T>,
         for<T: BodyVisitable> Option<T>,

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -1542,8 +1542,8 @@ impl<'tcx> BlockTransCtx<'tcx, '_, '_, '_> {
             }
             TerminatorKind::SwitchInt { discr, targets, .. } => {
                 let discr = self.translate_operand(span, discr)?;
-                let targets = self.translate_switch_targets(span, discr.ty(), targets)?;
-                ullbc_ast::TerminatorKind::Switch { discr, targets }
+                let (data, branches) = self.translate_switch_targets(span, discr, targets)?;
+                ullbc_ast::TerminatorKind::Switch { data, branches }
             }
             TerminatorKind::UnwindResume => ullbc_ast::TerminatorKind::UnwindResume,
             TerminatorKind::UnwindTerminate { .. } => {
@@ -1642,77 +1642,49 @@ impl<'tcx> BlockTransCtx<'tcx, '_, '_, '_> {
     fn translate_switch_targets(
         &mut self,
         span: Span,
-        switch_ty: &Ty,
+        discr: Operand,
         targets: &mir::SwitchTargets,
-    ) -> Result<SwitchTargets, Error> {
+    ) -> Result<(SwitchData, IndexVec<BranchId, BlockId>), Error> {
         // Convert all the test values to the proper values.
         let otherwise = targets.otherwise();
-        let targets = targets.iter().collect_vec();
-        let switch_ty = *switch_ty.kind().as_literal().unwrap();
-        match switch_ty {
-            LiteralTy::Bool => {
-                assert_eq!(targets.len(), 1);
-                let (val, target) = targets.first().unwrap();
-                // It seems the block targets are inverted
-                assert_eq!(*val, 0);
-                let if_block = self.translate_basic_block_id(otherwise);
-                let then_block = self.translate_basic_block_id(*target);
-                Ok(SwitchTargets::If(if_block, then_block))
-            }
-            LiteralTy::Char => {
-                let targets: Vec<(Literal, BlockId)> = targets
-                    .iter()
-                    .copied()
-                    .map(|(v, tgt)| {
-                        let v = Literal::char_from_le_bytes(v);
-                        let tgt = self.translate_basic_block_id(tgt);
-                        (v, tgt)
-                    })
-                    .collect();
-                let otherwise = self.translate_basic_block_id(otherwise);
-                Ok(SwitchTargets::SwitchInt(
-                    LiteralTy::Char,
-                    targets,
-                    otherwise,
-                ))
-            }
-            LiteralTy::Int(int_ty) => {
-                let targets: Vec<(Literal, BlockId)> = targets
-                    .iter()
-                    .copied()
-                    .map(|(v, tgt)| {
-                        let v = Literal::Scalar(ScalarValue::from_le_bytes(
-                            IntegerTy::Signed(int_ty),
-                            v.to_le_bytes(),
-                        ));
-                        let tgt = self.translate_basic_block_id(tgt);
-                        (v, tgt)
-                    })
-                    .collect();
-                let otherwise = self.translate_basic_block_id(otherwise);
-                Ok(SwitchTargets::SwitchInt(switch_ty, targets, otherwise))
-            }
-            LiteralTy::UInt(uint_ty) => {
-                let targets: Vec<(Literal, BlockId)> = targets
-                    .iter()
-                    .map(|(v, tgt)| {
-                        let v = Literal::Scalar(ScalarValue::from_le_bytes(
-                            IntegerTy::Unsigned(uint_ty),
-                            v.to_le_bytes(),
-                        ));
-                        let tgt = self.translate_basic_block_id(*tgt);
-                        (v, tgt)
-                    })
-                    .collect();
-                let otherwise = self.translate_basic_block_id(otherwise);
-                Ok(SwitchTargets::SwitchInt(
-                    LiteralTy::UInt(uint_ty),
-                    targets,
-                    otherwise,
-                ))
-            }
-            _ => raise_error!(self, span, "Can't match on type {switch_ty}"),
+        let switch_ty = discr.ty();
+        let switch_literal_ty = *switch_ty.as_literal().unwrap();
+        let mut branch_targets: IndexVec<BranchId, BlockId> = IndexVec::new();
+        let mut target_to_branch: SeqHashMap<BlockId, BranchId> = SeqHashMap::new();
+        let mut switch_branches = Vec::with_capacity(targets.iter().count());
+
+        // Keep the historical true-then-false traversal order for boolean switches.
+        let bool_fallback = (switch_literal_ty == LiteralTy::Bool).then(|| {
+            let target = self.translate_basic_block_id(otherwise);
+            *target_to_branch
+                .entry(target)
+                .or_insert_with(|| branch_targets.push(target))
+        });
+
+        for (bits, target) in targets.iter() {
+            let Some(literal) = Literal::from_bits(&switch_literal_ty, bits) else {
+                raise_error!(self, span, "Can't match on type {switch_literal_ty}")
+            };
+            let target = self.translate_basic_block_id(target);
+            let branch_id = *target_to_branch
+                .entry(target)
+                .or_insert_with(|| branch_targets.push(target));
+            let value = ConstantExpr::new(ConstantExprKind::Literal(literal), switch_ty.clone());
+            switch_branches.push((value, branch_id));
         }
+
+        let fallback = bool_fallback.unwrap_or_else(|| {
+            let target = self.translate_basic_block_id(otherwise);
+            *target_to_branch
+                .entry(target)
+                .or_insert_with(|| branch_targets.push(target))
+        });
+        let data = SwitchData {
+            scrutinee: SwitchScrutinee::Value(discr),
+            branches: switch_branches,
+            fallback: Some(fallback),
+        };
+        Ok((data, branch_targets))
     }
 
     /// Translate a function call statement.

--- a/charon/src/bin/generate-asts/generate_ml.rs
+++ b/charon/src/bin/generate-asts/generate_ml.rs
@@ -142,12 +142,10 @@ pub(crate) fn generate(
     let ambiguous_types = &[
         ("charon_lib::ast::bodies::unstructured::Statement", ("Generated_UllbcAst", "Ullbc")),
         ("charon_lib::ast::bodies::unstructured::StatementKind", ("Generated_UllbcAst", "Ullbc")),
-        ("charon_lib::ast::bodies::unstructured::SwitchTargets", ("Generated_UllbcAst", "Ullbc")),
         ("charon_lib::ast::bodies::unstructured::BlockData", ("Generated_UllbcAst", "Ullbc")),
         ("charon_lib::ast::bodies::unstructured::BlockId", ("Generated_UllbcAst", "Ullbc")),
         ("charon_lib::ast::bodies::structured::Statement", ("Generated_LlbcAst", "Llbc")),
         ("charon_lib::ast::bodies::structured::StatementKind", ("Generated_LlbcAst", "Llbc")),
-        ("charon_lib::ast::bodies::structured::Switch", ("Generated_LlbcAst", "Llbc")),
         ("charon_lib::ast::bodies::structured::Block", ("Generated_LlbcAst", "Llbc")),
         ("charon_lib::ast::bodies::structured::BlockId", ("Generated_LlbcAst", "Llbc")),
     ];
@@ -310,6 +308,7 @@ pub(crate) fn generate(
                     "FunSource",
                     "GlobalSource",
                     "Locals",
+                    "SwitchData",
                     "FunSig",
                     "Error",
                     "AbortKind",

--- a/charon/src/bin/generate-asts/generate_ml/templates/GAst.ml
+++ b/charon/src/bin/generate-asts/generate_ml/templates/GAst.ml
@@ -11,12 +11,14 @@
 open Generated_Types
 open Generated_Meta
 open Generated_Expressions
+open Identifiers
 
 module FunDeclId = Expressions.FunDeclId
 module GlobalDeclId = Expressions.GlobalDeclId
 module TraitDeclId = Types.TraitDeclId
 module TraitImplId = Types.TraitImplId
 module TraitClauseId = Types.TraitClauseId
+module BranchId = IdGen ()
 
 (* Imports *)
 type builtin_fun_id = Types.builtin_fun_id [@@deriving show, ord]

--- a/charon/src/options.rs
+++ b/charon/src/options.rs
@@ -250,6 +250,11 @@ pub struct CliOpts {
     #[clap(long)]
     #[serde(default)]
     pub reconstruct_asserts: bool,
+    /// Recombine a `read_discriminant(place)` followed by a `switch` into a single operation that
+    /// uses enum variants instead of their discriminants.
+    #[clap(long)]
+    #[serde(default)]
+    pub reconstruct_matches: bool,
     /// Ensure all local deallocations are made explicit with `StorageDead` statements. If this flag is not passed,
     /// every non-return local is implicitly deallocated on function return.
     /// Note this can add a lot of statements (quadratically-many, because of unwind paths).
@@ -457,6 +462,7 @@ impl CliOpts {
                     self.index_to_function_calls = true;
                     self.reconstruct_fallible_operations = true;
                     self.reconstruct_asserts = true;
+                    self.reconstruct_matches = true;
                     self.unbind_item_vars = true;
                     self.duplicate_defaulted_methods = true;
                 }
@@ -480,6 +486,7 @@ impl CliOpts {
                     self.index_to_function_calls = true;
                     self.reconstruct_fallible_operations = true;
                     self.reconstruct_asserts = true;
+                    self.reconstruct_matches = true;
                     self.hide_marker_traits = true;
                     self.hide_allocator = true;
                     self.remove_unused_self_clauses = true;
@@ -495,6 +502,7 @@ impl CliOpts {
                     self.index_to_function_calls = true;
                     self.reconstruct_fallible_operations = true;
                     self.reconstruct_asserts = true;
+                    self.reconstruct_matches = true;
                     self.lift_associated_types.push("*".to_owned());
                     self.unbind_item_vars = true;
                     self.duplicate_defaulted_methods = true;
@@ -518,6 +526,7 @@ impl CliOpts {
                     self.hide_allocator = true;
                     self.reconstruct_fallible_operations = true;
                     self.reconstruct_asserts = true;
+                    self.reconstruct_matches = true;
                     self.ops_to_function_calls = true;
                     self.index_to_function_calls = true;
                     self.duplicate_defaulted_methods = true;
@@ -690,6 +699,8 @@ pub struct TranslateOptions {
     pub reconstruct_fallible_operations: bool,
     /// Replace `if x { panic() }` with `assert(x)`.
     pub reconstruct_asserts: bool,
+    /// Reconstruct matches on enum variants.
+    pub reconstruct_matches: bool,
     /// Insert the `StorageDead`s that MIR omits for some locals.
     pub deallocate_all_locals: bool,
     // Use `DeBruijnVar::Free` for the variables bound in item signatures.
@@ -849,6 +860,7 @@ impl TranslateOptions {
             unsized_strings: options.unsized_strings,
             reconstruct_fallible_operations: options.reconstruct_fallible_operations,
             reconstruct_asserts: options.reconstruct_asserts,
+            reconstruct_matches: options.reconstruct_matches,
             deallocate_all_locals: options.deallocate_all_locals,
             lift_associated_types,
             unbind_item_vars: options.unbind_item_vars,

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -1588,6 +1588,20 @@ impl<C: AstFormatter> FmtWithCtx<C> for Byte {
     }
 }
 
+impl ConstantExpr {
+    fn format_as_match_pattern<'a, C: AstFormatter + 'a>(
+        &'a self,
+        ctx: &'a C,
+    ) -> impl Display + 'a {
+        std::fmt::from_fn(move |f| match self.kind() {
+            ConstantExprKind::Discriminant(type_ref, variant_id) => {
+                ctx.format_enum_variant(f, type_ref.id, *variant_id)
+            }
+            _ => self.fmt_with_ctx(ctx, f),
+        })
+    }
+}
+
 impl_display_via_ctx!(ConstantExpr);
 impl<C: AstFormatter> FmtWithCtx<C> for ConstantExpr {
     fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1629,6 +1643,11 @@ impl<C: AstFormatter> FmtWithCtx<C> for ConstantExpr {
             }
             ConstantExprKind::VTableRef(trait_ref) => {
                 write!(f, "&vtable_of({})", trait_ref.with_ctx(ctx),)
+            }
+            ConstantExprKind::Discriminant(type_ref, variant_id) => {
+                write!(f, "discriminant_of(")?;
+                ctx.format_enum_variant(f, type_ref.id, *variant_id)?;
+                write!(f, ")")
             }
             ConstantExprKind::Ref(cv, meta) => {
                 if let Some(meta) = meta {
@@ -2082,8 +2101,12 @@ impl<C: AstFormatter> FmtWithCtx<C> for llbc::Statement {
             StatementKind::UnwindResume => write!(f, "unwind_continue"),
             StatementKind::Break(index) => write!(f, "break {index}"),
             StatementKind::Continue(index) => write!(f, "continue {index}"),
-            StatementKind::Switch(switch) => match switch {
-                Switch::If(discr, true_st, false_st) => {
+            StatementKind::Switch { data, branches } => match &data.scrutinee {
+                SwitchScrutinee::Value(discr)
+                    if let Some((then_branch, else_branch)) = data.as_if() =>
+                {
+                    let true_st = &branches[then_branch];
+                    let false_st = &branches[else_branch];
                     let ctx = &ctx.increase_indent();
                     write!(
                         f,
@@ -2093,51 +2116,55 @@ impl<C: AstFormatter> FmtWithCtx<C> for llbc::Statement {
                         false_st.with_ctx(ctx),
                     )
                 }
-                Switch::SwitchInt(discr, _ty, maps, otherwise) => {
+                SwitchScrutinee::Value(discr) => {
                     writeln!(f, "switch {} {{", discr.with_ctx(ctx))?;
                     let ctx1 = &ctx.increase_indent();
                     let inner_tab1 = ctx1.indent();
                     let ctx2 = &ctx1.increase_indent();
-                    for (pvl, st) in maps {
-                        // Note that there may be several pattern values
-                        let pvl = pvl.iter().format(" | ");
+                    let cases_by_branch = data.group_by_branch();
+                    for (branch_id, st) in branches.iter_enumerated() {
+                        let cases = &cases_by_branch[branch_id];
+                        let cases = if cases.is_empty() && data.fallback != Some(branch_id) {
+                            "_".to_owned()
+                        } else {
+                            cases
+                                .iter()
+                                .map(|value| value.to_string_with_ctx(ctx))
+                                .chain((data.fallback == Some(branch_id)).then_some("_".to_owned()))
+                                .format(" | ")
+                                .to_string()
+                        };
                         writeln!(
                             f,
                             "{inner_tab1}{} => {{\n{}{inner_tab1}}},",
-                            pvl,
+                            cases,
                             st.with_ctx(ctx2),
                         )?;
                     }
-                    writeln!(
-                        f,
-                        "{inner_tab1}_ => {{\n{}{inner_tab1}}},",
-                        otherwise.with_ctx(ctx2),
-                    )?;
                     write!(f, "{tab}}}")
                 }
-                Switch::Match(discr, maps, otherwise) => {
+                SwitchScrutinee::Discriminant(discr) => {
                     writeln!(f, "match {} {{", discr.with_ctx(ctx))?;
                     let ctx1 = &ctx.increase_indent();
                     let inner_tab1 = ctx1.indent();
                     let ctx2 = &ctx1.increase_indent();
-                    let discr_type = discr.ty.as_adt_id();
-                    for (cases, st) in maps {
-                        write!(f, "{inner_tab1}",)?;
-                        // Note that there may be several pattern values
-                        for (bar, v) in repeat_except_first(" | ").zip(cases.iter()) {
-                            write!(f, "{}", bar.unwrap_or_default())?;
-                            match discr_type {
-                                Some(type_id) => ctx.format_enum_variant(f, type_id, *v)?,
-                                None => write!(f, "{}", v.to_pretty_string())?,
-                            }
-                        }
-                        writeln!(f, " => {{\n{}{inner_tab1}}},", st.with_ctx(ctx2),)?;
-                    }
-                    if let Some(otherwise) = otherwise {
+                    let cases_by_branch = data.group_by_branch();
+                    for (branch_id, st) in branches.iter_enumerated() {
+                        let cases = &cases_by_branch[branch_id];
+                        let cases = if cases.is_empty() && data.fallback != Some(branch_id) {
+                            "_".to_owned()
+                        } else {
+                            cases
+                                .iter()
+                                .map(|value| value.format_as_match_pattern(ctx).to_string())
+                                .chain((data.fallback == Some(branch_id)).then_some("_".to_owned()))
+                                .format(" | ")
+                                .to_string()
+                        };
                         writeln!(
                             f,
-                            "{inner_tab1}_ => {{\n{}{inner_tab1}}},",
-                            otherwise.with_ctx(ctx2),
+                            "{inner_tab1}{cases} => {{\n{}{inner_tab1}}},",
+                            st.with_ctx(ctx2),
                         )?;
                     }
                     write!(f, "{tab}}}")
@@ -2153,6 +2180,15 @@ impl<C: AstFormatter> FmtWithCtx<C> for llbc::Statement {
     }
 }
 
+impl<C: AstFormatter> FmtWithCtx<C> for SwitchScrutinee {
+    fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SwitchScrutinee::Value(operand) => operand.fmt_with_ctx(ctx, f),
+            SwitchScrutinee::Discriminant(place) => place.fmt_with_ctx(ctx, f),
+        }
+    }
+}
+
 impl<C: AstFormatter> FmtWithCtx<C> for Terminator {
     fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let tab = ctx.indent();
@@ -2162,23 +2198,43 @@ impl<C: AstFormatter> FmtWithCtx<C> for Terminator {
         write!(f, "{tab}")?;
         match &self.kind {
             TerminatorKind::Goto { target } => write!(f, "goto bb{target}"),
-            TerminatorKind::Switch { discr, targets } => match targets {
-                SwitchTargets::If(true_block, false_block) => write!(
-                    f,
-                    "if {} -> bb{} else -> bb{}",
-                    discr.with_ctx(ctx),
-                    true_block,
-                    false_block
-                ),
-                SwitchTargets::SwitchInt(_ty, maps, otherwise) => {
-                    let maps = maps
+            TerminatorKind::Switch { data, branches } => {
+                if let Some((then_branch, else_branch)) = data.as_if() {
+                    let true_block = branches[then_branch];
+                    let false_block = branches[else_branch];
+                    write!(
+                        f,
+                        "if {} -> bb{} else -> bb{}",
+                        data.scrutinee.with_ctx(ctx),
+                        true_block,
+                        false_block
+                    )
+                } else {
+                    let maps = data
+                        .branches
                         .iter()
-                        .map(|(v, bid)| format!("{}: bb{}", v, bid))
-                        .chain([format!("otherwise: bb{otherwise}")])
+                        .map(|(value, branch_id)| {
+                            format!(
+                                "{}: bb{}",
+                                value.format_as_match_pattern(ctx),
+                                branches[*branch_id]
+                            )
+                        })
+                        .chain(
+                            data.fallback
+                                .map(|branch_id| format!("otherwise: bb{}", branches[branch_id])),
+                        )
                         .format(", ");
-                    write!(f, "switch {} -> {}", discr.with_ctx(ctx), maps)
+                    match &data.scrutinee {
+                        SwitchScrutinee::Value(discr) => {
+                            write!(f, "switch {} -> {}", discr.with_ctx(ctx), maps)
+                        }
+                        SwitchScrutinee::Discriminant(place) => {
+                            write!(f, "match {} -> {}", place.with_ctx(ctx), maps)
+                        }
+                    }
                 }
-            },
+            }
             TerminatorKind::Call {
                 call,
                 target,

--- a/charon/src/transform/control_flow/ullbc_to_llbc.rs
+++ b/charon/src/transform/control_flow/ullbc_to_llbc.rs
@@ -1083,10 +1083,20 @@ impl<'a> ReconstructCtx<'a> {
             }
             src::TerminatorKind::Goto { target } => self.translate_jump(terminator.span, *target),
             src::TerminatorKind::Switch { data, branches } => {
-                let branches = branches
-                    .iter()
-                    .map(|target| self.translate_jump(terminator.span, *target))
-                    .collect::<IndexVec<BranchId, _>>();
+                let mut branches =
+                    branches.map_ref(|target| self.translate_jump(terminator.span, *target));
+                // If we considered the match to be exhaustive, the fallback block is still in
+                // the list of branches and can be removed.
+                if data.fallback.is_none()
+                    && let Some(last_branch_id) = branches.indices().next_back()
+                    && !data
+                        .branches
+                        .iter()
+                        .map(|(_, branch_id)| *branch_id)
+                        .contains(&last_branch_id)
+                {
+                    branches.pop();
+                }
 
                 // Return
                 let span = combine_span_iter(branches.iter().map(|branch| &branch.span));

--- a/charon/src/transform/control_flow/ullbc_to_llbc.rs
+++ b/charon/src/transform/control_flow/ullbc_to_llbc.rs
@@ -850,8 +850,8 @@ fn iter_tail_statements(block: &mut tgt::Block, f: &mut impl FnMut(&mut tgt::Sta
     else {
         return;
     };
-    if let tgt::StatementKind::Switch(switch) = &mut st.kind {
-        for block in switch.iter_targets_mut() {
+    if let tgt::StatementKind::Switch { branches, .. } = &mut st.kind {
+        for block in branches {
             iter_tail_statements(block, f);
         }
     } else {
@@ -1082,73 +1082,19 @@ impl<'a> ReconstructCtx<'a> {
                 tgt::Statement::new(src_span, st).into_block()
             }
             src::TerminatorKind::Goto { target } => self.translate_jump(terminator.span, *target),
-            src::TerminatorKind::Switch { discr, targets } => {
-                // Translate the target expressions
-                let switch = match &targets {
-                    src::SwitchTargets::If(then_tgt, else_tgt) => {
-                        let then_block = self.translate_jump(terminator.span, *then_tgt);
-                        let else_block = self.translate_jump(terminator.span, *else_tgt);
-                        tgt::Switch::If(discr.clone(), then_block, else_block)
-                    }
-                    src::SwitchTargets::SwitchInt(int_ty, targets, otherwise) => {
-                        // Note that some branches can be grouped together, like
-                        // here:
-                        // ```
-                        // match e {
-                        //   E::V1 | E::V2 => ..., // Grouped
-                        //   E::V3 => ...
-                        // }
-                        // ```
-                        // We detect this by checking if a block has already been
-                        // translated as one of the branches of the switch.
-                        //
-                        // Rk.: note there may be intermediate gotos depending
-                        // on the MIR we use. Typically, we manage to detect the
-                        // grouped branches with Optimized MIR, but not with Promoted
-                        // MIR. See the comment in "tests/src/matches.rs".
-
-                        // We link block ids to:
-                        // - vector of matched integer values
-                        // - translated blocks
-                        let mut branches: SeqHashMap<src::BlockId, (Vec<Literal>, tgt::Block)> =
-                            SeqHashMap::new();
-
-                        // Translate the children expressions
-                        for (v, bid) in targets.iter() {
-                            // Check if the block has already been translated:
-                            // if yes, it means we need to group branches
-                            if branches.contains_key(bid) {
-                                // Already translated: add the matched value to
-                                // the list of values
-                                let branch = branches.get_mut(bid).unwrap();
-                                branch.0.push(v.clone());
-                            } else {
-                                // Not translated: translate it
-                                let block = self.translate_jump(terminator.span, *bid);
-                                // We use the terminator span information in case then
-                                // then statement is `None`
-                                branches.insert(*bid, (vec![v.clone()], block));
-                            }
-                        }
-                        let targets_blocks: Vec<(Vec<Literal>, tgt::Block)> =
-                            branches.into_iter().map(|(_, x)| x).collect();
-
-                        let otherwise_block = self.translate_jump(terminator.span, *otherwise);
-
-                        // Translate
-                        tgt::Switch::SwitchInt(
-                            discr.clone(),
-                            *int_ty,
-                            targets_blocks,
-                            otherwise_block,
-                        )
-                    }
-                };
+            src::TerminatorKind::Switch { data, branches } => {
+                let branches = branches
+                    .iter()
+                    .map(|target| self.translate_jump(terminator.span, *target))
+                    .collect::<IndexVec<BranchId, _>>();
 
                 // Return
-                let span = switch.combine_targets_span();
+                let span = combine_span_iter(branches.iter().map(|branch| &branch.span));
                 let span = combine_span(&src_span, &span);
-                let st = tgt::StatementKind::Switch(switch);
+                let st = tgt::StatementKind::Switch {
+                    data: data.clone(),
+                    branches,
+                };
                 tgt::Statement::new(span, st).into_block()
             }
         }

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -177,6 +177,8 @@ pub fn run_transformation_passes(options: &CliOpts, ctx: &mut TransformCtx) {
         CowBox::Borrowed(&simplify_output::remove_unit_locals::Transform),
         // Duplicate the return blocks
         CowBox::Borrowed(&control_flow::duplicate_return::Transform),
+        // Reconstruct matches on enum variants.
+        resugar::reconstruct_matches::Transform::new(ctx),
         // Remove the locals which are never used.
         CowBox::Borrowed(&simplify_output::remove_unused_locals::Transform),
         // Another round.
@@ -202,8 +204,6 @@ pub fn run_transformation_passes(options: &CliOpts, ctx: &mut TransformCtx) {
         ctx.run_pass(mixed_body(&control_flow::ullbc_to_llbc::Transform));
         // Body cleanup passes after control flow reconstruction.
         let pass = Pass::FusedStructuredBody(Box::new([
-            // Reconstruct matches on enum variants.
-            resugar::reconstruct_matches::Transform::new(ctx),
             // Cleanup the cfg.
             CowBox::Borrowed(&control_flow::prettify_cfg::Transform),
             // Replace some unops/binops and the array aggregates with

--- a/charon/src/transform/resugar/reconstruct_asserts.rs
+++ b/charon/src/transform/resugar/reconstruct_asserts.rs
@@ -21,29 +21,28 @@ impl UllbcPass for Transform {
         let panics = b.as_abort_map();
 
         for block in b.body.iter_mut() {
-            if let TerminatorKind::Switch {
-                discr: _,
-                targets: SwitchTargets::If(bid0, bid1),
-            } = &block.terminator.kind
+            if let TerminatorKind::Switch { data, branches } = &block.terminator.kind
+                && let Some((true_id, false_id)) = data.as_if()
+                && let SwitchScrutinee::Value(discr) = data.scrutinee.clone()
             {
-                let (nbid, expected, abort) = if let Some(abort) = panics.get(bid0) {
-                    (*bid1, false, abort)
-                } else if let Some(abort) = panics.get(bid1) {
-                    (*bid0, true, abort)
+                let (true_bid, false_bid) = (branches[true_id], branches[false_id]);
+                let (nbid, expected, abort) = if let Some(abort) = panics.get(&true_bid) {
+                    (false_bid, false, abort)
+                } else if let Some(abort) = panics.get(&false_bid) {
+                    (true_bid, true, abort)
                 } else {
                     continue;
                 };
 
-                let kind = std::mem::replace(
+                let _ = std::mem::replace(
                     &mut block.terminator.kind,
                     TerminatorKind::Goto { target: nbid },
                 );
-                let (discr, _) = kind.as_switch().unwrap();
                 block.statements.push(Statement::new(
                     block.terminator.span,
                     StatementKind::Assert {
                         assert: Assert {
-                            cond: discr.clone(),
+                            cond: discr,
                             expected,
                             check_kind: None,
                         },

--- a/charon/src/transform/resugar/reconstruct_matches.rs
+++ b/charon/src/transform/resugar/reconstruct_matches.rs
@@ -1,16 +1,16 @@
 //! The way to match on enums in MIR is in two steps: first read the discriminant, then switch on
-//! the resulting integer. This pass merges the two into a `SwitchKind::Match` that directly
-//! mentions enum variants.
+//! the resulting integer. This pass records the enum place as the switch scrutinee and replaces
+//! the integer cases with symbolic enum discriminants.
+use itertools::Itertools;
+use std::collections::{HashMap, HashSet};
+
 use crate::formatter::IntoFormatter;
 use crate::llbc_ast::*;
 use crate::name_matcher::NamePattern;
 use crate::pretty::FmtWithCtx;
 use crate::transform::TransformCtx;
-use crate::{errors::register_error, transform::CowBox};
-use itertools::Itertools;
-use std::collections::{HashMap, HashSet};
-
 use crate::transform::ctx::LlbcPass;
+use crate::{errors::register_error, transform::CowBox};
 
 pub struct Transform {
     discriminant_intrinsics: HashSet<FunDeclId>,
@@ -67,18 +67,20 @@ impl Transform {
                         return;
                     };
 
-                    // We look for a `SwitchInt` just after the discriminant read.
+                    // We look for a switch on the temporary just after the discriminant read.
                     match rest {
                         [
                             Statement {
-                                kind:
-                                    StatementKind::Switch(
-                                        switch @ Switch::SwitchInt(Operand::Move(_), ..),
-                                    ),
+                                kind: StatementKind::Switch { data, branches },
                                 ..
                             },
                             ..,
-                        ] => {
+                        ] if let SwitchScrutinee::Value(Operand::Move(op_p)) = &data.scrutinee
+                            && op_p.is_local()
+                            && op_p.local_id() == dest.local_id() =>
+                        {
+                            data.scrutinee = SwitchScrutinee::Discriminant(p.clone());
+
                             // Convert between discriminants and variant indices. Remark: the discriminant can
                             // be of any *signed* integer type (`isize`, `i8`, etc.).
                             let discr_to_id: HashMap<Literal, VariantId> = variants
@@ -86,52 +88,53 @@ impl Transform {
                                 .map(|(id, variant)| (variant.discriminant.clone(), id))
                                 .collect();
 
-                            take_mut::take(switch, |switch| {
-                                let (Operand::Move(op_p), _, targets, otherwise) =
-                                    switch.to_switch_int().unwrap()
-                                else {
-                                    unreachable!()
-                                };
-                                assert!(op_p.is_local() && op_p.local_id() == dest.local_id());
+                            let mut covered_discriminants: HashSet<Literal> = HashSet::default();
+                            for (value, _) in &mut data.branches {
+                                if let ConstantExprKind::Literal(discr) = value.kind()
+                                    && let Some(variant_id) = discr_to_id.get(discr).copied()
+                                {
+                                    covered_discriminants.insert(discr.clone());
+                                    *value = ConstantExpr::new(
+                                        ConstantExprKind::Discriminant(
+                                            tdecl_ref.clone(),
+                                            variant_id,
+                                        ),
+                                        value.ty().clone(),
+                                    );
+                                } else {
+                                    register_error!(
+                                        ctx,
+                                        block.span,
+                                        "Found incorrect discriminant {value} for enum {}",
+                                        tdecl_ref.id
+                                    );
+                                }
+                            }
 
-                                let mut covered_discriminants: HashSet<Literal> =
-                                    HashSet::default();
-                                let targets = targets
-                                    .into_iter()
-                                    .map(|(v, e)| {
-                                        let targets = v
-                                            .into_iter()
-                                            .filter_map(|discr| {
-                                                covered_discriminants.insert(discr.clone());
-                                                discr_to_id.get(&discr).or_else(|| {
-                                                    register_error!(
-                                                        ctx,
-                                                        block.span,
-                                                        "Found incorrect discriminant \
-                                                        {discr} for enum {}",
-                                                        tdecl_ref.id
-                                                    );
-                                                    None
-                                                })
-                                            })
-                                            .copied()
-                                            .collect_vec();
-                                        (targets, e)
-                                    })
-                                    .collect_vec();
-                                // Filter the otherwise branch if it is not necessary.
-                                let covers_all = covered_discriminants.len() == discr_to_id.len();
-                                let otherwise = if covers_all { None } else { Some(otherwise) };
-
-                                // Replace the old switch with a match.
-                                Switch::Match(p.clone(), targets, otherwise)
-                            });
+                            // The fallback is unnecessary if the explicit cases cover every
+                            // variant.
+                            if covered_discriminants.len() == discr_to_id.len() {
+                                let fallback_id = data
+                                    .fallback
+                                    .take()
+                                    .expect("MIR switches always have a fallback branch");
+                                // Remove the fallback branch if nothing else points to it.
+                                if !data
+                                    .branches
+                                    .iter()
+                                    .map(|(_, branch_id)| *branch_id)
+                                    .contains(&fallback_id)
+                                {
+                                    assert_eq!(fallback_id.index(), branches.len() - 1);
+                                    branches.pop();
+                                }
+                            }
                             // `Nop` the discriminant read.
                             block.statements[i].kind = StatementKind::Nop;
                         }
                         _ => {
-                            // The discriminant read is not followed by a `SwitchInt`. This can happen
-                            // in optimized MIR.
+                            // The discriminant read is not followed by a switch on its result. This
+                            // can happen in optimized MIR.
                             continue;
                         }
                     }

--- a/charon/src/transform/resugar/reconstruct_matches.rs
+++ b/charon/src/transform/resugar/reconstruct_matches.rs
@@ -186,6 +186,10 @@ impl Transform {
 }
 
 impl LlbcPass for Transform {
+    fn should_run(&self, options: &crate::options::TranslateOptions) -> bool {
+        options.reconstruct_matches
+    }
+
     fn transform_body(&self, ctx: &mut TransformCtx, body: &mut llbc_ast::ExprBody) {
         body.body.visit_blocks_bwd(|block: &mut Block| {
             self.update_block(ctx, block);

--- a/charon/src/transform/resugar/reconstruct_matches.rs
+++ b/charon/src/transform/resugar/reconstruct_matches.rs
@@ -1,15 +1,17 @@
 //! The way to match on enums in MIR is in two steps: first read the discriminant, then switch on
 //! the resulting integer. This pass records the enum place as the switch scrutinee and replaces
 //! the integer cases with symbolic enum discriminants.
-use itertools::Itertools;
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    mem,
+};
 
 use crate::formatter::IntoFormatter;
-use crate::llbc_ast::*;
 use crate::name_matcher::NamePattern;
 use crate::pretty::FmtWithCtx;
 use crate::transform::TransformCtx;
-use crate::transform::ctx::LlbcPass;
+use crate::transform::ctx::UllbcPass;
+use crate::ullbc_ast::*;
 use crate::{errors::register_error, transform::CowBox};
 
 pub struct Transform {
@@ -17,150 +19,112 @@ pub struct Transform {
 }
 
 impl Transform {
-    fn update_block(&self, ctx: &mut TransformCtx, block: &mut Block) {
-        // Iterate through the statements.
-        for i in 0..block.statements.len() {
-            let suffix = &mut block.statements[i..];
-            match suffix {
-                [
-                    Statement {
-                        kind: StatementKind::Assign(dest, Rvalue::Discriminant(p)),
-                        ..
-                    },
-                    rest @ ..,
-                ] => {
-                    // The destination should be a variable
-                    assert!(dest.is_local());
-                    let TyKind::Adt(tdecl_ref) = p.ty().kind() else {
-                        continue;
-                    };
+    fn replace_mem_discriminant_call(&self, block: &mut BlockData) {
+        if let TerminatorKind::Call { call, target, .. } = &block.terminator.kind
+            && let FnOperand::Regular(fn_ptr) = &call.func
+            && let FnPtrKind::Fun(FunId::Regular(fun_id)) = fn_ptr.kind.as_ref()
+            && self.discriminant_intrinsics.contains(fun_id)
+            && let [Operand::Move(p)] = call.args.as_slice()
+            && let TyKind::Ref(_, sub_ty, _) = p.ty().kind()
+        {
+            let dest = call.dest.clone();
+            let p = p.clone().project(ProjectionElem::Deref, sub_ty.clone());
+            let target = *target;
+            let mut statement = Statement::new(
+                block.terminator.span,
+                StatementKind::Assign(dest, Rvalue::Discriminant(p)),
+            );
+            statement.comments_before = mem::take(&mut block.terminator.comments_before);
+            block.statements.push(statement);
+            block.terminator.kind = TerminatorKind::Goto { target };
+        }
+    }
 
-                    // Lookup the type of the scrutinee
-                    let tkind = ctx.translated.type_decls.get(tdecl_ref.id).map(|x| &x.kind);
-                    let Some(TypeDeclKind::Enum(variants)) = tkind else {
-                        match tkind {
-                            // This can happen if the type was declared as invisible or opaque.
-                            None | Some(TypeDeclKind::Opaque) => {
-                                let name = ctx.translated.item_name(tdecl_ref.id);
-                                register_error!(
-                                    ctx,
-                                    block.span,
-                                    "reading the discriminant of an opaque enum. \
-                                    Add `--include {}` to the `charon` arguments \
-                                    to translate this enum.",
-                                    name.with_ctx(&ctx.into_fmt())
-                                );
-                            }
-                            // Don't double-error
-                            Some(TypeDeclKind::Error(..)) => {}
-                            Some(_) => {
-                                register_error!(
-                                    ctx,
-                                    block.span,
-                                    "reading the discriminant of a non-enum type"
-                                );
-                            }
-                        }
-                        block.statements[i].kind = StatementKind::Error(
-                            "error reading the discriminant of this type".to_owned(),
-                        );
-                        return;
-                    };
+    fn reconstruct_match(&self, ctx: &mut TransformCtx, block: &mut BlockData) {
+        let span = block.terminator.span;
+        let TerminatorKind::Switch { data, .. } = &mut block.terminator.kind else {
+            return;
+        };
+        let SwitchScrutinee::Value(Operand::Move(op_p)) = &data.scrutinee else {
+            return;
+        };
+        // If the last statement is a discriminant read.
+        let Some(last_st) = block.statements.last_mut() else {
+            return;
+        };
+        let StatementKind::Assign(dest, Rvalue::Discriminant(p)) = &last_st.kind else {
+            return;
+        };
+        assert!(dest.is_local()); // The destination should be a variable.
+        if op_p != dest {
+            return;
+        }
+        let scrut_ty = p.ty().clone();
 
-                    // We look for a switch on the temporary just after the discriminant read.
-                    match rest {
-                        [
-                            Statement {
-                                kind: StatementKind::Switch { data, branches },
-                                ..
-                            },
-                            ..,
-                        ] if let SwitchScrutinee::Value(Operand::Move(op_p)) = &data.scrutinee
-                            && op_p.is_local()
-                            && op_p.local_id() == dest.local_id() =>
-                        {
-                            data.scrutinee = SwitchScrutinee::Discriminant(p.clone());
+        // Merge the two statements.
+        data.scrutinee = SwitchScrutinee::Discriminant(p.clone());
+        last_st.kind = StatementKind::Nop;
 
-                            // Convert between discriminants and variant indices. Remark: the discriminant can
-                            // be of any *signed* integer type (`isize`, `i8`, etc.).
-                            let discr_to_id: HashMap<Literal, VariantId> = variants
-                                .iter_enumerated()
-                                .map(|(id, variant)| (variant.discriminant.clone(), id))
-                                .collect();
-
-                            let mut covered_discriminants: HashSet<Literal> = HashSet::default();
-                            for (value, _) in &mut data.branches {
-                                if let ConstantExprKind::Literal(discr) = value.kind()
-                                    && let Some(variant_id) = discr_to_id.get(discr).copied()
-                                {
-                                    covered_discriminants.insert(discr.clone());
-                                    *value = ConstantExpr::new(
-                                        ConstantExprKind::Discriminant(
-                                            tdecl_ref.clone(),
-                                            variant_id,
-                                        ),
-                                        value.ty().clone(),
-                                    );
-                                } else {
-                                    register_error!(
-                                        ctx,
-                                        block.span,
-                                        "Found incorrect discriminant {value} for enum {}",
-                                        tdecl_ref.id
-                                    );
-                                }
-                            }
-
-                            // The fallback is unnecessary if the explicit cases cover every
-                            // variant.
-                            if covered_discriminants.len() == discr_to_id.len() {
-                                let fallback_id = data
-                                    .fallback
-                                    .take()
-                                    .expect("MIR switches always have a fallback branch");
-                                // Remove the fallback branch if nothing else points to it.
-                                if !data
-                                    .branches
-                                    .iter()
-                                    .map(|(_, branch_id)| *branch_id)
-                                    .contains(&fallback_id)
-                                {
-                                    assert_eq!(fallback_id.index(), branches.len() - 1);
-                                    branches.pop();
-                                }
-                            }
-                            // `Nop` the discriminant read.
-                            block.statements[i].kind = StatementKind::Nop;
-                        }
-                        _ => {
-                            // The discriminant read is not followed by a switch on its result. This
-                            // can happen in optimized MIR.
-                            continue;
-                        }
-                    }
+        // Lookup the type of the scrutinee.
+        let TyKind::Adt(tdecl_ref) = scrut_ty.kind() else {
+            return;
+        };
+        let tdecl_ref = tdecl_ref.clone();
+        let adt_id = tdecl_ref.id;
+        let tkind = ctx.translated.type_decls.get(adt_id).map(|x| &x.kind);
+        let Some(TypeDeclKind::Enum(variants)) = tkind else {
+            match tkind {
+                // This can happen if the type was declared as invisible or opaque.
+                None | Some(TypeDeclKind::Opaque) => {
+                    let name = ctx.translated.item_name(adt_id);
+                    register_error!(
+                        ctx,
+                        span,
+                        "reading the discriminant of an opaque enum. \
+                        Add `--include {}` to the `charon` arguments \
+                        to translate this enum.",
+                        name.with_ctx(&ctx.into_fmt())
+                    );
                 }
-                // Replace calls of `core::intrinsics::discriminant_value` on a known enum with the
-                // appropriate MIR.
-                [
-                    Statement {
-                        kind: StatementKind::Call { call, .. },
-                        ..
-                    },
-                    ..,
-                ] if let FnOperand::Regular(fn_ptr) = &call.func
-                        && let FnPtrKind::Fun(FunId::Regular(fun_id)) = fn_ptr.kind.as_ref()
-                        // Detect a call to the intrinsic...
-                        && self.discriminant_intrinsics.contains(fun_id)
-                        // passing it a reference.
-                        && let Operand::Move(p) = &call.args[0]
-                        && let TyKind::Ref(_, sub_ty, _) = p.ty().kind() =>
-                {
-                    let p = p.clone().project(ProjectionElem::Deref, sub_ty.clone());
-                    block.statements[i].kind =
-                        StatementKind::Assign(call.dest.clone(), Rvalue::Discriminant(p.clone()))
+                // Don't double-error.
+                Some(TypeDeclKind::Error(..)) => {}
+                Some(_) => {
+                    register_error!(ctx, span, "reading the discriminant of a non-enum type");
                 }
-                _ => {}
             }
+            return;
+        };
+
+        // Map from discriminants to variant indices. Remark: the discriminant can be of any
+        // *signed* integer type (`isize`, `i8`, etc.).
+        let discr_to_id: HashMap<Literal, VariantId> = variants
+            .iter_enumerated()
+            .map(|(id, variant)| (variant.discriminant.clone(), id))
+            .collect();
+
+        // Replace the branch values with discriminant constants.
+        let mut covered_discriminants: HashSet<Literal> = HashSet::default();
+        for (value, _) in &mut data.branches {
+            if let ConstantExprKind::Literal(discr) = value.kind()
+                && let Some(variant_id) = discr_to_id.get(discr).copied()
+            {
+                covered_discriminants.insert(discr.clone());
+                *value = ConstantExpr::new(
+                    ConstantExprKind::Discriminant(tdecl_ref.clone(), variant_id),
+                    value.ty().clone(),
+                );
+            } else {
+                register_error!(
+                    ctx,
+                    block.terminator.span,
+                    "Found incorrect discriminant {value} for enum {adt_id}"
+                );
+            }
+        }
+
+        // Remove the fallback if the explicit cases cover every variant.
+        if covered_discriminants.len() == discr_to_id.len() {
+            data.fallback.take();
         }
     }
 }
@@ -168,7 +132,7 @@ impl Transform {
 const DISCRIMINANT_INTRINSIC: &str = "core::intrinsics::discriminant_value";
 
 impl Transform {
-    pub fn new(ctx: &mut TransformCtx) -> CowBox<dyn LlbcPass> {
+    pub fn new(ctx: &mut TransformCtx) -> CowBox<dyn UllbcPass> {
         let pat = NamePattern::parse(DISCRIMINANT_INTRINSIC).unwrap();
         // There can be many if we're in mono mode.
         let discriminant_intrinsics = ctx
@@ -185,14 +149,15 @@ impl Transform {
     }
 }
 
-impl LlbcPass for Transform {
+impl UllbcPass for Transform {
     fn should_run(&self, options: &crate::options::TranslateOptions) -> bool {
         options.reconstruct_matches
     }
 
-    fn transform_body(&self, ctx: &mut TransformCtx, body: &mut llbc_ast::ExprBody) {
-        body.body.visit_blocks_bwd(|block: &mut Block| {
-            self.update_block(ctx, block);
-        })
+    fn transform_body(&self, ctx: &mut TransformCtx, body: &mut ExprBody) {
+        for block in &mut body.body {
+            self.reconstruct_match(ctx, block);
+            self.replace_mem_discriminant_call(block);
+        }
     }
 }

--- a/charon/src/transform/simplify_output/index_to_function_calls.rs
+++ b/charon/src/transform/simplify_output/index_to_function_calls.rs
@@ -275,7 +275,7 @@ impl LlbcPass for Transform {
                 Assign(..) | SetDiscriminant(..) | Drop { .. } | Call { .. } => {
                     let _ = visitor.visit_inner_with_mutability(st, true);
                 }
-                Switch(..) | PlaceMention(..) | Borrowck(..) => {
+                Switch { .. } | PlaceMention(..) | Borrowck(..) => {
                     let _ = visitor.visit_inner_with_mutability(st, false);
                 }
                 Nop

--- a/charon/tests/cargo/toml.out
+++ b/charon/tests/cargo/toml.out
@@ -33,11 +33,14 @@ where
 {
     let _0: bool; // return
     let self: &'1 Option<T>[TraitClause0]; // arg #1
+    let _2: isize; // anonymous local
 
     storage_live(_0)
+    storage_live(_2)
     _ = (*self)
-    match (*self) {
-        Option::Some => {
+    _2 = @discriminant((*self))
+    switch move _2 {
+        1isize => {
         },
         _ => {
             _0 = const false

--- a/charon/tests/help-output.txt
+++ b/charon/tests/help-output.txt
@@ -145,6 +145,9 @@ Options:
       --reconstruct-asserts
           Replace `if x { panic() }` with `assert(x)`
 
+      --reconstruct-matches
+          Recombine a `read_discriminant(place)` followed by a `switch` into a single operation that uses enum variants instead of their discriminants
+
       --deallocate-all-locals
           Ensure all local deallocations are made explicit with `StorageDead` statements. If this flag is not passed, every non-return local is implicitly deallocated on function return. Note this can add a lot of statements (quadratically-many, because of unwind paths)
 

--- a/charon/tests/ui/control-flow/ullbc-control-flow.out
+++ b/charon/tests/ui/control-flow/ullbc-control-flow.out
@@ -284,35 +284,29 @@ pub fn nested_loops_enum(step_out: usize, step_in: usize) -> usize
     let _7: Option<i32>[{built_in impl Sized for i32}]; // anonymous local
     let _8: &'1 mut Range<i32>[{built_in impl Sized for i32}]; // anonymous local
     let _9: &'2 mut Range<i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _10: isize; // anonymous local
-    let _11: usize; // anonymous local
+    let _10: usize; // anonymous local
+    let _11: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _12: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
-    let _13: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
-    let _14: usize; // anonymous local
-    let iter_15: Range<usize>[{built_in impl Sized for usize}]; // local
-    let _16: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
-    let _17: &'4 mut Range<usize>[{built_in impl Sized for usize}]; // anonymous local
-    let _18: &'5 mut Range<usize>[{built_in impl Sized for usize}]; // anonymous local
-    let _19: isize; // anonymous local
-    let _20: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
-    let _21: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
-    let _22: usize; // anonymous local
-    let iter_23: Range<usize>[{built_in impl Sized for usize}]; // local
-    let _24: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
-    let _25: &'6 mut Range<usize>[{built_in impl Sized for usize}]; // anonymous local
-    let _26: &'7 mut Range<usize>[{built_in impl Sized for usize}]; // anonymous local
-    let _27: isize; // anonymous local
-    let _28: usize; // anonymous local
-    let _29: bool; // anonymous local
-    let _30: usize; // anonymous local
+    let _13: usize; // anonymous local
+    let iter_14: Range<usize>[{built_in impl Sized for usize}]; // local
+    let _15: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _16: &'4 mut Range<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _17: &'5 mut Range<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _18: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _19: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _20: usize; // anonymous local
+    let iter_21: Range<usize>[{built_in impl Sized for usize}]; // local
+    let _22: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _23: &'6 mut Range<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _24: &'7 mut Range<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _25: usize; // anonymous local
+    let _26: bool; // anonymous local
+    let _27: usize; // anonymous local
 
     bb0: {
         storage_live(_0);
         storage_live(_10);
-        storage_live(_11);
-        storage_live(_19);
-        storage_live(_27);
-        storage_live(_28);
+        storage_live(_25);
         storage_live(s);
         s = const 0usize;
         fake_read(s);
@@ -323,10 +317,7 @@ pub fn nested_loops_enum(step_out: usize, step_in: usize) -> usize
     }
 
     bb1: {
-        storage_dead(_28);
-        storage_dead(_27);
-        storage_dead(_19);
-        storage_dead(_11);
+        storage_dead(_25);
         storage_dead(_10);
         storage_dead(step_in);
         storage_dead(step_out);
@@ -351,8 +342,7 @@ pub fn nested_loops_enum(step_out: usize, step_in: usize) -> usize
 
     bb4: {
         storage_dead(_8);
-        _10 = @discriminant(_7);
-        switch move _10 -> 0isize: bb5, 1isize: bb6, otherwise: bb7;
+        match _7 -> Option::None: bb5, Option::Some: bb6;
     }
 
     bb5: {
@@ -360,18 +350,18 @@ pub fn nested_loops_enum(step_out: usize, step_in: usize) -> usize
         storage_dead(_7);
         storage_dead(iter_6);
         storage_dead(_4);
+        storage_live(_11);
         storage_live(_12);
         storage_live(_13);
-        storage_live(_14);
-        _14 = copy step_out;
-        _13 = Range { start: const 0usize, end: move _14 };
-        storage_dead(_14);
-        _12 = into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, impl_Iterator_for_Range<usize>[{built_in impl Sized for usize}, impl_Step_for_usize]](move _13) -> bb8 (unwind: bb1);
+        _13 = copy step_out;
+        _12 = Range { start: const 0usize, end: move _13 };
+        storage_dead(_13);
+        _11 = into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, impl_Iterator_for_Range<usize>[{built_in impl Sized for usize}, impl_Step_for_usize]](move _12) -> bb8 (unwind: bb1);
     }
 
     bb6: {
-        _11 = copy s panic.+ const 1usize;
-        s = move _11;
+        _10 = copy s panic.+ const 1usize;
+        s = move _10;
         storage_dead(_9);
         storage_dead(_7);
         goto bb3;
@@ -383,39 +373,35 @@ pub fn nested_loops_enum(step_out: usize, step_in: usize) -> usize
     }
 
     bb8: {
-        storage_dead(_13);
-        storage_live(iter_15);
-        iter_15 = move _12;
+        storage_dead(_12);
+        storage_live(iter_14);
+        iter_14 = move _11;
         goto bb9;
     }
 
     bb9: {
+        storage_live(_15);
         storage_live(_16);
         storage_live(_17);
-        storage_live(_18);
-        _18 = &mut iter_15;
-        _17 = &two-phase-mut (*_18);
-        _16 = next<'11, usize>[{built_in impl Sized for usize}, impl_Step_for_usize](move _17) -> bb10 (unwind: bb1);
+        _17 = &mut iter_14;
+        _16 = &two-phase-mut (*_17);
+        _15 = next<'11, usize>[{built_in impl Sized for usize}, impl_Step_for_usize](move _16) -> bb10 (unwind: bb1);
     }
 
     bb10: {
-        storage_dead(_17);
-        _19 = @discriminant(_16);
-        switch move _19 -> 0isize: bb11, 1isize: bb12, otherwise: bb13;
+        storage_dead(_16);
+        match _15 -> Option::None: bb11, Option::Some: bb12;
     }
 
     bb11: {
         // Test comment
-        storage_dead(_18);
-        storage_dead(_16);
-        storage_dead(iter_15);
-        storage_dead(_12);
+        storage_dead(_17);
+        storage_dead(_15);
+        storage_dead(iter_14);
+        storage_dead(_11);
         _0 = copy s;
         storage_dead(s);
-        storage_dead(_28);
-        storage_dead(_27);
-        storage_dead(_19);
-        storage_dead(_11);
+        storage_dead(_25);
         storage_dead(_10);
         storage_dead(step_in);
         storage_dead(step_out);
@@ -423,69 +409,68 @@ pub fn nested_loops_enum(step_out: usize, step_in: usize) -> usize
     }
 
     bb12: {
+        storage_live(_18);
+        storage_live(_19);
         storage_live(_20);
-        storage_live(_21);
-        storage_live(_22);
-        _22 = copy step_in;
-        _21 = Range { start: const 0usize, end: move _22 };
-        storage_dead(_22);
-        _20 = into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, impl_Iterator_for_Range<usize>[{built_in impl Sized for usize}, impl_Step_for_usize]](move _21) -> bb14 (unwind: bb1);
+        _20 = copy step_in;
+        _19 = Range { start: const 0usize, end: move _20 };
+        storage_dead(_20);
+        _18 = into_iter<Range<usize>[{built_in impl Sized for usize}]>[{built_in impl Sized for Range<usize>[{built_in impl Sized for usize}]}, impl_Iterator_for_Range<usize>[{built_in impl Sized for usize}, impl_Step_for_usize]](move _19) -> bb14 (unwind: bb1);
     }
 
     bb13: {
-        fake_read(_16);
+        fake_read(_15);
         undefined_behavior;
     }
 
     bb14: {
-        storage_dead(_21);
-        storage_live(iter_23);
-        iter_23 = move _20;
+        storage_dead(_19);
+        storage_live(iter_21);
+        iter_21 = move _18;
         goto bb15;
     }
 
     bb15: {
+        storage_live(_22);
+        storage_live(_23);
         storage_live(_24);
-        storage_live(_25);
-        storage_live(_26);
-        _26 = &mut iter_23;
-        _25 = &two-phase-mut (*_26);
-        _24 = next<'13, usize>[{built_in impl Sized for usize}, impl_Step_for_usize](move _25) -> bb16 (unwind: bb1);
+        _24 = &mut iter_21;
+        _23 = &two-phase-mut (*_24);
+        _22 = next<'13, usize>[{built_in impl Sized for usize}, impl_Step_for_usize](move _23) -> bb16 (unwind: bb1);
     }
 
     bb16: {
-        storage_dead(_25);
-        _27 = @discriminant(_24);
-        switch move _27 -> 0isize: bb17, 1isize: bb18, otherwise: bb19;
+        storage_dead(_23);
+        match _22 -> Option::None: bb17, Option::Some: bb18;
     }
 
     bb17: {
-        storage_dead(_26);
         storage_dead(_24);
-        storage_dead(iter_23);
-        storage_dead(_20);
+        storage_dead(_22);
+        storage_dead(iter_21);
         storage_dead(_18);
-        storage_dead(_16);
+        storage_dead(_17);
+        storage_dead(_15);
         goto bb9;
     }
 
     bb18: {
-        _28 = copy s panic.+ const 1usize;
-        s = move _28;
-        storage_live(_29);
-        storage_live(_30);
-        _30 = copy s;
-        _29 = move _30 >= const 1usize;
-        assert(move _29 == true) else panic(core::panicking::panic);
-        storage_dead(_30);
-        storage_dead(_29);
+        _25 = copy s panic.+ const 1usize;
+        s = move _25;
+        storage_live(_26);
+        storage_live(_27);
+        _27 = copy s;
+        _26 = move _27 >= const 1usize;
+        assert(move _26 == true) else panic(core::panicking::panic);
+        storage_dead(_27);
         storage_dead(_26);
         storage_dead(_24);
+        storage_dead(_22);
         goto bb15;
     }
 
     bb19: {
-        fake_read(_24);
+        fake_read(_22);
         undefined_behavior;
     }
 }

--- a/charon/tests/ui/dyn/box-dyn-fnonce-raw.out
+++ b/charon/tests/ui/dyn/box-dyn-fnonce-raw.out
@@ -412,51 +412,57 @@ fn box_new_uninit(layout: Layout) -> *mut u8
     let _2: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
     let _3: &'1 Global; // anonymous local
     let _4: Layout; // anonymous local
+    let _5: isize; // anonymous local
     let ptr: NonNull<[u8]>; // local
-    let _6: NonNull<[u8]>; // anonymous local
-    let _7: !; // anonymous local
-    let _8: Layout; // anonymous local
-    let _9: &'2 Global; // anonymous local
-    let _10: &'3 Global; // anonymous local
-    let _11: &'6 Global; // anonymous local
-    let _12: Global; // anonymous local
+    let _7: NonNull<[u8]>; // anonymous local
+    let _8: !; // anonymous local
+    let _9: Layout; // anonymous local
+    let _10: &'2 Global; // anonymous local
+    let _11: &'3 Global; // anonymous local
+    let _12: &'6 Global; // anonymous local
+    let _13: Global; // anonymous local
 
-    storage_live(_10)
     storage_live(_11)
     storage_live(_12)
-    _12 = Global {  }
-    _11 = &_12
-    _10 = move _11
+    storage_live(_13)
+    _13 = Global {  }
+    _12 = &_13
+    _11 = move _12
     storage_live(_0)
-    storage_live(_9)
+    storage_live(_5)
+    storage_live(_10)
     storage_live(_2)
     storage_live(_3)
-    _9 = move _10
-    _3 = &(*_9)
+    _10 = move _11
+    _3 = &(*_10)
     storage_live(_4)
     _4 = copy layout
     _2 = allocate<'5>(move _3, move _4)
     ↳⚡ unwind_continue
     storage_dead(_4)
     storage_dead(_3)
-    match _2 {
-        Result::Ok => {
+    _5 = @discriminant(_2)
+    switch move _5 {
+        0isize => {
         },
-        Result::Err => {
-            storage_live(_7)
+        1isize => {
             storage_live(_8)
-            _8 = copy layout
-            _7 = handle_alloc_error(move _8)
+            storage_live(_9)
+            _9 = copy layout
+            _8 = handle_alloc_error(move _9)
             ↳⚡ unwind_continue
+        },
+        _ => {
+            undefined_behavior
         },
     }
     storage_live(ptr)
     ptr = copy (_2 as variant Result::Ok)._0
-    storage_live(_6)
-    _6 = copy ptr
-    _0 = as_mut_ptr<u8>[{built_in impl Sized for u8}](move _6)
+    storage_live(_7)
+    _7 = copy ptr
+    _0 = as_mut_ptr<u8>[{built_in impl Sized for u8}](move _7)
     ↳⚡ unwind_continue
-    storage_dead(_6)
+    storage_dead(_7)
     storage_dead(ptr)
     storage_dead(_2)
     return

--- a/charon/tests/ui/filtering/match_on_opaque_enum.out
+++ b/charon/tests/ui/filtering/match_on_opaque_enum.out
@@ -1,11 +1,7 @@
 error: reading the discriminant of an opaque enum. Add `--include test_crate::Enum` to the `charon` arguments to translate this enum.
-  --> tests/ui/filtering/match_on_opaque_enum.rs:9:5
-   |
- 9 | /     match x {
-10 | |         Enum::A => true,
-11 | |         Enum::B => false,
-12 | |     }
-13 | | }
-   | |_^
+ --> tests/ui/filtering/match_on_opaque_enum.rs:9:5
+  |
+9 |     match x {
+  |     ^^^^^^^
 
 ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/raw-boxes.out
+++ b/charon/tests/ui/raw-boxes.out
@@ -734,18 +734,20 @@ where
     let _5: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
     let _6: &'2 Self; // anonymous local
     let _7: Layout; // anonymous local
+    let _8: isize; // anonymous local
     let residual: Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]; // local
-    let _9: Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]; // anonymous local
+    let _10: Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]; // anonymous local
     let val: NonNull<[u8]>; // local
-    let _11: (); // anonymous local
-    let _12: *mut u8; // anonymous local
-    let _13: NonNull<u8>; // anonymous local
-    let _14: NonNull<[u8]>; // anonymous local
-    let _15: usize; // anonymous local
-    let _16: NonNull<[u8]>; // anonymous local
+    let _12: (); // anonymous local
+    let _13: *mut u8; // anonymous local
+    let _14: NonNull<u8>; // anonymous local
+    let _15: NonNull<[u8]>; // anonymous local
+    let _16: usize; // anonymous local
     let _17: NonNull<[u8]>; // anonymous local
+    let _18: NonNull<[u8]>; // anonymous local
 
     storage_live(_0)
+    storage_live(_8)
     storage_live(ptr)
     storage_live(_4)
     storage_live(_5)
@@ -760,21 +762,25 @@ where
     _4 = branch<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}](move _5)
     ↳⚡ unwind_continue
     storage_dead(_5)
-    match _4 {
-        ControlFlow::Continue => {
+    _8 = @discriminant(_4)
+    switch move _8 {
+        0isize => {
         },
-        ControlFlow::Break => {
+        1isize => {
             storage_live(residual)
             residual = copy (_4 as variant ControlFlow::Break)._0
-            storage_live(_9)
-            _9 = copy residual
-            _0 = from_residual<NonNull<[u8]>, AllocError, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}, {built_in impl Sized for AllocError}, {impl#6}<AllocError>[{built_in impl Sized for AllocError}]](move _9)
+            storage_live(_10)
+            _10 = copy residual
+            _0 = from_residual<NonNull<[u8]>, AllocError, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}, {built_in impl Sized for AllocError}, {impl#6}<AllocError>[{built_in impl Sized for AllocError}]](move _10)
             ↳⚡ unwind_continue
-            storage_dead(_9)
+            storage_dead(_10)
             storage_dead(residual)
             storage_dead(_4)
             storage_dead(ptr)
             return
+        },
+        _ => {
+            undefined_behavior
         },
     }
     storage_live(val)
@@ -782,32 +788,32 @@ where
     ptr = copy val
     storage_dead(val)
     storage_dead(_4)
-    storage_live(_11)
     storage_live(_12)
     storage_live(_13)
     storage_live(_14)
-    _14 = copy ptr
-    _13 = core::ptr::non_null::{NonNull<[T]>}::as_non_null_ptr<u8>[{built_in impl Sized for u8}](move _14)
-    ↳⚡ unwind_continue
-    storage_dead(_14)
-    _12 = core::ptr::non_null::{NonNull<T>}::as_ptr<u8>(move _13)
-    ↳⚡ unwind_continue
-    storage_dead(_13)
     storage_live(_15)
-    storage_live(_16)
-    _16 = copy ptr
-    _15 = core::ptr::non_null::{NonNull<[T]>}::len<u8>[{built_in impl Sized for u8}](move _16)
-    ↳⚡ unwind_continue
-    storage_dead(_16)
-    _11 = core::ptr::mut_ptr::{*mut T}::write_bytes<u8>[{built_in impl Sized for u8}](move _12, const 0u8, move _15)
+    _15 = copy ptr
+    _14 = core::ptr::non_null::{NonNull<[T]>}::as_non_null_ptr<u8>[{built_in impl Sized for u8}](move _15)
     ↳⚡ unwind_continue
     storage_dead(_15)
-    storage_dead(_12)
-    storage_dead(_11)
+    _13 = core::ptr::non_null::{NonNull<T>}::as_ptr<u8>(move _14)
+    ↳⚡ unwind_continue
+    storage_dead(_14)
+    storage_live(_16)
     storage_live(_17)
     _17 = copy ptr
-    _0 = Result::Ok { _0: move _17 }
+    _16 = core::ptr::non_null::{NonNull<[T]>}::len<u8>[{built_in impl Sized for u8}](move _17)
+    ↳⚡ unwind_continue
     storage_dead(_17)
+    _12 = core::ptr::mut_ptr::{*mut T}::write_bytes<u8>[{built_in impl Sized for u8}](move _13, const 0u8, move _16)
+    ↳⚡ unwind_continue
+    storage_dead(_16)
+    storage_dead(_13)
+    storage_dead(_12)
+    storage_live(_18)
+    _18 = copy ptr
+    _0 = Result::Ok { _0: move _18 }
+    storage_dead(_18)
     storage_dead(ptr)
     return
 }
@@ -1077,24 +1083,26 @@ where
     let _14: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
     let _15: &'7 Self; // anonymous local
     let _16: Layout; // anonymous local
+    let _17: isize; // anonymous local
     let residual: Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]; // local
-    let _18: Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]; // anonymous local
+    let _19: Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]; // anonymous local
     let val: NonNull<[u8]>; // local
-    let _20: (); // anonymous local
-    let _21: *const u8; // anonymous local
-    let _22: *mut u8; // anonymous local
-    let _23: NonNull<u8>; // anonymous local
-    let _24: *mut u8; // anonymous local
-    let _25: NonNull<[u8]>; // anonymous local
-    let _26: usize; // anonymous local
-    let _27: &'8 Layout; // anonymous local
-    let _28: (); // anonymous local
-    let _29: &'9 Self; // anonymous local
-    let _30: NonNull<u8>; // anonymous local
-    let _31: Layout; // anonymous local
-    let _32: NonNull<[u8]>; // anonymous local
+    let _21: (); // anonymous local
+    let _22: *const u8; // anonymous local
+    let _23: *mut u8; // anonymous local
+    let _24: NonNull<u8>; // anonymous local
+    let _25: *mut u8; // anonymous local
+    let _26: NonNull<[u8]>; // anonymous local
+    let _27: usize; // anonymous local
+    let _28: &'8 Layout; // anonymous local
+    let _29: (); // anonymous local
+    let _30: &'9 Self; // anonymous local
+    let _31: NonNull<u8>; // anonymous local
+    let _32: Layout; // anonymous local
+    let _33: NonNull<[u8]>; // anonymous local
 
     storage_live(_0)
+    storage_live(_17)
     storage_live(_5)
     _5 = const false
     if move _5 {
@@ -1141,21 +1149,25 @@ where
     _13 = branch<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}](move _14)
     ↳⚡ unwind_continue
     storage_dead(_14)
-    match _13 {
-        ControlFlow::Continue => {
+    _17 = @discriminant(_13)
+    switch move _17 {
+        0isize => {
         },
-        ControlFlow::Break => {
+        1isize => {
             storage_live(residual)
             residual = copy (_13 as variant ControlFlow::Break)._0
-            storage_live(_18)
-            _18 = copy residual
-            _0 = from_residual<NonNull<[u8]>, AllocError, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}, {built_in impl Sized for AllocError}, {impl#6}<AllocError>[{built_in impl Sized for AllocError}]](move _18)
+            storage_live(_19)
+            _19 = copy residual
+            _0 = from_residual<NonNull<[u8]>, AllocError, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}, {built_in impl Sized for AllocError}, {impl#6}<AllocError>[{built_in impl Sized for AllocError}]](move _19)
             ↳⚡ unwind_continue
-            storage_dead(_18)
+            storage_dead(_19)
             storage_dead(residual)
             storage_dead(_13)
             storage_dead(new_ptr)
             return
+        },
+        _ => {
+            undefined_behavior
         },
     }
     storage_live(val)
@@ -1163,51 +1175,51 @@ where
     new_ptr = copy val
     storage_dead(val)
     storage_dead(_13)
-    storage_live(_20)
     storage_live(_21)
     storage_live(_22)
     storage_live(_23)
-    _23 = copy ptr
-    _22 = core::ptr::non_null::{NonNull<T>}::as_ptr<u8>(move _23)
-    ↳⚡ unwind_continue
-    _21 = cast<*mut u8, *const u8>(move _22)
-    storage_dead(_23)
-    storage_dead(_22)
     storage_live(_24)
+    _24 = copy ptr
+    _23 = core::ptr::non_null::{NonNull<T>}::as_ptr<u8>(move _24)
+    ↳⚡ unwind_continue
+    _22 = cast<*mut u8, *const u8>(move _23)
+    storage_dead(_24)
+    storage_dead(_23)
     storage_live(_25)
-    _25 = copy new_ptr
-    _24 = as_mut_ptr<u8>[{built_in impl Sized for u8}](move _25)
-    ↳⚡ unwind_continue
-    storage_dead(_25)
     storage_live(_26)
-    storage_live(_27)
-    _27 = &old_layout
-    _26 = size<'19>(move _27)
-    ↳⚡ unwind_continue
-    storage_dead(_27)
-    _20 = core::ptr::copy_nonoverlapping<u8>[{built_in impl Sized for u8}](move _21, move _24, move _26)
+    _26 = copy new_ptr
+    _25 = as_mut_ptr<u8>[{built_in impl Sized for u8}](move _26)
     ↳⚡ unwind_continue
     storage_dead(_26)
-    storage_dead(_24)
-    storage_dead(_21)
-    storage_dead(_20)
+    storage_live(_27)
     storage_live(_28)
-    storage_live(_29)
-    _29 = &(*self) with_metadata(copy self.metadata)
-    storage_live(_30)
-    _30 = copy ptr
-    storage_live(_31)
-    _31 = copy old_layout
-    _28 = TraitClause0::deallocate<'20>(move _29, move _30, move _31)
+    _28 = &old_layout
+    _27 = size<'19>(move _28)
     ↳⚡ unwind_continue
+    storage_dead(_28)
+    _21 = core::ptr::copy_nonoverlapping<u8>[{built_in impl Sized for u8}](move _22, move _25, move _27)
+    ↳⚡ unwind_continue
+    storage_dead(_27)
+    storage_dead(_25)
+    storage_dead(_22)
+    storage_dead(_21)
+    storage_live(_29)
+    storage_live(_30)
+    _30 = &(*self) with_metadata(copy self.metadata)
+    storage_live(_31)
+    _31 = copy ptr
+    storage_live(_32)
+    _32 = copy old_layout
+    _29 = TraitClause0::deallocate<'20>(move _30, move _31, move _32)
+    ↳⚡ unwind_continue
+    storage_dead(_32)
     storage_dead(_31)
     storage_dead(_30)
     storage_dead(_29)
-    storage_dead(_28)
-    storage_live(_32)
-    _32 = copy new_ptr
-    _0 = Result::Ok { _0: move _32 }
-    storage_dead(_32)
+    storage_live(_33)
+    _33 = copy new_ptr
+    _0 = Result::Ok { _0: move _33 }
+    storage_dead(_33)
     storage_dead(new_ptr)
     return
 }
@@ -1235,24 +1247,26 @@ where
     let _14: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
     let _15: &'7 Self; // anonymous local
     let _16: Layout; // anonymous local
+    let _17: isize; // anonymous local
     let residual: Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]; // local
-    let _18: Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]; // anonymous local
+    let _19: Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]; // anonymous local
     let val: NonNull<[u8]>; // local
-    let _20: (); // anonymous local
-    let _21: *const u8; // anonymous local
-    let _22: *mut u8; // anonymous local
-    let _23: NonNull<u8>; // anonymous local
-    let _24: *mut u8; // anonymous local
-    let _25: NonNull<[u8]>; // anonymous local
-    let _26: usize; // anonymous local
-    let _27: &'8 Layout; // anonymous local
-    let _28: (); // anonymous local
-    let _29: &'9 Self; // anonymous local
-    let _30: NonNull<u8>; // anonymous local
-    let _31: Layout; // anonymous local
-    let _32: NonNull<[u8]>; // anonymous local
+    let _21: (); // anonymous local
+    let _22: *const u8; // anonymous local
+    let _23: *mut u8; // anonymous local
+    let _24: NonNull<u8>; // anonymous local
+    let _25: *mut u8; // anonymous local
+    let _26: NonNull<[u8]>; // anonymous local
+    let _27: usize; // anonymous local
+    let _28: &'8 Layout; // anonymous local
+    let _29: (); // anonymous local
+    let _30: &'9 Self; // anonymous local
+    let _31: NonNull<u8>; // anonymous local
+    let _32: Layout; // anonymous local
+    let _33: NonNull<[u8]>; // anonymous local
 
     storage_live(_0)
+    storage_live(_17)
     storage_live(_5)
     _5 = const false
     if move _5 {
@@ -1299,21 +1313,25 @@ where
     _13 = branch<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}](move _14)
     ↳⚡ unwind_continue
     storage_dead(_14)
-    match _13 {
-        ControlFlow::Continue => {
+    _17 = @discriminant(_13)
+    switch move _17 {
+        0isize => {
         },
-        ControlFlow::Break => {
+        1isize => {
             storage_live(residual)
             residual = copy (_13 as variant ControlFlow::Break)._0
-            storage_live(_18)
-            _18 = copy residual
-            _0 = from_residual<NonNull<[u8]>, AllocError, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}, {built_in impl Sized for AllocError}, {impl#6}<AllocError>[{built_in impl Sized for AllocError}]](move _18)
+            storage_live(_19)
+            _19 = copy residual
+            _0 = from_residual<NonNull<[u8]>, AllocError, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}, {built_in impl Sized for AllocError}, {impl#6}<AllocError>[{built_in impl Sized for AllocError}]](move _19)
             ↳⚡ unwind_continue
-            storage_dead(_18)
+            storage_dead(_19)
             storage_dead(residual)
             storage_dead(_13)
             storage_dead(new_ptr)
             return
+        },
+        _ => {
+            undefined_behavior
         },
     }
     storage_live(val)
@@ -1321,51 +1339,51 @@ where
     new_ptr = copy val
     storage_dead(val)
     storage_dead(_13)
-    storage_live(_20)
     storage_live(_21)
     storage_live(_22)
     storage_live(_23)
-    _23 = copy ptr
-    _22 = core::ptr::non_null::{NonNull<T>}::as_ptr<u8>(move _23)
-    ↳⚡ unwind_continue
-    _21 = cast<*mut u8, *const u8>(move _22)
-    storage_dead(_23)
-    storage_dead(_22)
     storage_live(_24)
+    _24 = copy ptr
+    _23 = core::ptr::non_null::{NonNull<T>}::as_ptr<u8>(move _24)
+    ↳⚡ unwind_continue
+    _22 = cast<*mut u8, *const u8>(move _23)
+    storage_dead(_24)
+    storage_dead(_23)
     storage_live(_25)
-    _25 = copy new_ptr
-    _24 = as_mut_ptr<u8>[{built_in impl Sized for u8}](move _25)
-    ↳⚡ unwind_continue
-    storage_dead(_25)
     storage_live(_26)
-    storage_live(_27)
-    _27 = &old_layout
-    _26 = size<'19>(move _27)
-    ↳⚡ unwind_continue
-    storage_dead(_27)
-    _20 = core::ptr::copy_nonoverlapping<u8>[{built_in impl Sized for u8}](move _21, move _24, move _26)
+    _26 = copy new_ptr
+    _25 = as_mut_ptr<u8>[{built_in impl Sized for u8}](move _26)
     ↳⚡ unwind_continue
     storage_dead(_26)
-    storage_dead(_24)
-    storage_dead(_21)
-    storage_dead(_20)
+    storage_live(_27)
     storage_live(_28)
-    storage_live(_29)
-    _29 = &(*self) with_metadata(copy self.metadata)
-    storage_live(_30)
-    _30 = copy ptr
-    storage_live(_31)
-    _31 = copy old_layout
-    _28 = TraitClause0::deallocate<'20>(move _29, move _30, move _31)
+    _28 = &old_layout
+    _27 = size<'19>(move _28)
     ↳⚡ unwind_continue
+    storage_dead(_28)
+    _21 = core::ptr::copy_nonoverlapping<u8>[{built_in impl Sized for u8}](move _22, move _25, move _27)
+    ↳⚡ unwind_continue
+    storage_dead(_27)
+    storage_dead(_25)
+    storage_dead(_22)
+    storage_dead(_21)
+    storage_live(_29)
+    storage_live(_30)
+    _30 = &(*self) with_metadata(copy self.metadata)
+    storage_live(_31)
+    _31 = copy ptr
+    storage_live(_32)
+    _32 = copy old_layout
+    _29 = TraitClause0::deallocate<'20>(move _30, move _31, move _32)
+    ↳⚡ unwind_continue
+    storage_dead(_32)
     storage_dead(_31)
     storage_dead(_30)
     storage_dead(_29)
-    storage_dead(_28)
-    storage_live(_32)
-    _32 = copy new_ptr
-    _0 = Result::Ok { _0: move _32 }
-    storage_dead(_32)
+    storage_live(_33)
+    _33 = copy new_ptr
+    _0 = Result::Ok { _0: move _33 }
+    storage_dead(_33)
     storage_dead(new_ptr)
     return
 }
@@ -1393,24 +1411,26 @@ where
     let _14: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
     let _15: &'7 Self; // anonymous local
     let _16: Layout; // anonymous local
+    let _17: isize; // anonymous local
     let residual: Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]; // local
-    let _18: Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]; // anonymous local
+    let _19: Result<Infallible, AllocError>[{built_in impl Sized for Infallible}, {built_in impl Sized for AllocError}]; // anonymous local
     let val: NonNull<[u8]>; // local
-    let _20: (); // anonymous local
-    let _21: *const u8; // anonymous local
-    let _22: *mut u8; // anonymous local
-    let _23: NonNull<u8>; // anonymous local
-    let _24: *mut u8; // anonymous local
-    let _25: NonNull<[u8]>; // anonymous local
-    let _26: usize; // anonymous local
-    let _27: &'8 Layout; // anonymous local
-    let _28: (); // anonymous local
-    let _29: &'9 Self; // anonymous local
-    let _30: NonNull<u8>; // anonymous local
-    let _31: Layout; // anonymous local
-    let _32: NonNull<[u8]>; // anonymous local
+    let _21: (); // anonymous local
+    let _22: *const u8; // anonymous local
+    let _23: *mut u8; // anonymous local
+    let _24: NonNull<u8>; // anonymous local
+    let _25: *mut u8; // anonymous local
+    let _26: NonNull<[u8]>; // anonymous local
+    let _27: usize; // anonymous local
+    let _28: &'8 Layout; // anonymous local
+    let _29: (); // anonymous local
+    let _30: &'9 Self; // anonymous local
+    let _31: NonNull<u8>; // anonymous local
+    let _32: Layout; // anonymous local
+    let _33: NonNull<[u8]>; // anonymous local
 
     storage_live(_0)
+    storage_live(_17)
     storage_live(_5)
     _5 = const false
     if move _5 {
@@ -1457,21 +1477,25 @@ where
     _13 = branch<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}](move _14)
     ↳⚡ unwind_continue
     storage_dead(_14)
-    match _13 {
-        ControlFlow::Continue => {
+    _17 = @discriminant(_13)
+    switch move _17 {
+        0isize => {
         },
-        ControlFlow::Break => {
+        1isize => {
             storage_live(residual)
             residual = copy (_13 as variant ControlFlow::Break)._0
-            storage_live(_18)
-            _18 = copy residual
-            _0 = from_residual<NonNull<[u8]>, AllocError, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}, {built_in impl Sized for AllocError}, {impl#6}<AllocError>[{built_in impl Sized for AllocError}]](move _18)
+            storage_live(_19)
+            _19 = copy residual
+            _0 = from_residual<NonNull<[u8]>, AllocError, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}, {built_in impl Sized for AllocError}, {impl#6}<AllocError>[{built_in impl Sized for AllocError}]](move _19)
             ↳⚡ unwind_continue
-            storage_dead(_18)
+            storage_dead(_19)
             storage_dead(residual)
             storage_dead(_13)
             storage_dead(new_ptr)
             return
+        },
+        _ => {
+            undefined_behavior
         },
     }
     storage_live(val)
@@ -1479,51 +1503,51 @@ where
     new_ptr = copy val
     storage_dead(val)
     storage_dead(_13)
-    storage_live(_20)
     storage_live(_21)
     storage_live(_22)
     storage_live(_23)
-    _23 = copy ptr
-    _22 = core::ptr::non_null::{NonNull<T>}::as_ptr<u8>(move _23)
-    ↳⚡ unwind_continue
-    _21 = cast<*mut u8, *const u8>(move _22)
-    storage_dead(_23)
-    storage_dead(_22)
     storage_live(_24)
+    _24 = copy ptr
+    _23 = core::ptr::non_null::{NonNull<T>}::as_ptr<u8>(move _24)
+    ↳⚡ unwind_continue
+    _22 = cast<*mut u8, *const u8>(move _23)
+    storage_dead(_24)
+    storage_dead(_23)
     storage_live(_25)
-    _25 = copy new_ptr
-    _24 = as_mut_ptr<u8>[{built_in impl Sized for u8}](move _25)
-    ↳⚡ unwind_continue
-    storage_dead(_25)
     storage_live(_26)
-    storage_live(_27)
-    _27 = &new_layout
-    _26 = size<'19>(move _27)
-    ↳⚡ unwind_continue
-    storage_dead(_27)
-    _20 = core::ptr::copy_nonoverlapping<u8>[{built_in impl Sized for u8}](move _21, move _24, move _26)
+    _26 = copy new_ptr
+    _25 = as_mut_ptr<u8>[{built_in impl Sized for u8}](move _26)
     ↳⚡ unwind_continue
     storage_dead(_26)
-    storage_dead(_24)
-    storage_dead(_21)
-    storage_dead(_20)
+    storage_live(_27)
     storage_live(_28)
-    storage_live(_29)
-    _29 = &(*self) with_metadata(copy self.metadata)
-    storage_live(_30)
-    _30 = copy ptr
-    storage_live(_31)
-    _31 = copy old_layout
-    _28 = TraitClause0::deallocate<'20>(move _29, move _30, move _31)
+    _28 = &new_layout
+    _27 = size<'19>(move _28)
     ↳⚡ unwind_continue
+    storage_dead(_28)
+    _21 = core::ptr::copy_nonoverlapping<u8>[{built_in impl Sized for u8}](move _22, move _25, move _27)
+    ↳⚡ unwind_continue
+    storage_dead(_27)
+    storage_dead(_25)
+    storage_dead(_22)
+    storage_dead(_21)
+    storage_live(_29)
+    storage_live(_30)
+    _30 = &(*self) with_metadata(copy self.metadata)
+    storage_live(_31)
+    _31 = copy ptr
+    storage_live(_32)
+    _32 = copy old_layout
+    _29 = TraitClause0::deallocate<'20>(move _30, move _31, move _32)
+    ↳⚡ unwind_continue
+    storage_dead(_32)
     storage_dead(_31)
     storage_dead(_30)
     storage_dead(_29)
-    storage_dead(_28)
-    storage_live(_32)
-    _32 = copy new_ptr
-    _0 = Result::Ok { _0: move _32 }
-    storage_dead(_32)
+    storage_live(_33)
+    _33 = copy new_ptr
+    _0 = Result::Ok { _0: move _33 }
+    storage_dead(_33)
     storage_dead(new_ptr)
     return
 }
@@ -2187,51 +2211,57 @@ fn box_new_uninit(layout: Layout) -> *mut u8
     let _2: Result<NonNull<[u8]>, AllocError>[{built_in impl Sized for NonNull<[u8]>}, {built_in impl Sized for AllocError}]; // anonymous local
     let _3: &'1 Global; // anonymous local
     let _4: Layout; // anonymous local
+    let _5: isize; // anonymous local
     let ptr: NonNull<[u8]>; // local
-    let _6: NonNull<[u8]>; // anonymous local
-    let _7: !; // anonymous local
-    let _8: Layout; // anonymous local
-    let _9: &'2 Global; // anonymous local
-    let _10: &'3 Global; // anonymous local
-    let _11: &'6 Global; // anonymous local
-    let _12: Global; // anonymous local
+    let _7: NonNull<[u8]>; // anonymous local
+    let _8: !; // anonymous local
+    let _9: Layout; // anonymous local
+    let _10: &'2 Global; // anonymous local
+    let _11: &'3 Global; // anonymous local
+    let _12: &'6 Global; // anonymous local
+    let _13: Global; // anonymous local
 
-    storage_live(_10)
     storage_live(_11)
     storage_live(_12)
-    _12 = Global {  }
-    _11 = &_12
-    _10 = move _11
+    storage_live(_13)
+    _13 = Global {  }
+    _12 = &_13
+    _11 = move _12
     storage_live(_0)
-    storage_live(_9)
+    storage_live(_5)
+    storage_live(_10)
     storage_live(_2)
     storage_live(_3)
-    _9 = move _10
-    _3 = &(*_9) with_metadata(copy _9.metadata)
+    _10 = move _11
+    _3 = &(*_10) with_metadata(copy _10.metadata)
     storage_live(_4)
     _4 = copy layout
     _2 = allocate<'5>(move _3, move _4)
     ↳⚡ unwind_continue
     storage_dead(_4)
     storage_dead(_3)
-    match _2 {
-        Result::Ok => {
+    _5 = @discriminant(_2)
+    switch move _5 {
+        0isize => {
         },
-        Result::Err => {
-            storage_live(_7)
+        1isize => {
             storage_live(_8)
-            _8 = copy layout
-            _7 = handle_alloc_error(move _8)
+            storage_live(_9)
+            _9 = copy layout
+            _8 = handle_alloc_error(move _9)
             ↳⚡ unwind_continue
+        },
+        _ => {
+            undefined_behavior
         },
     }
     storage_live(ptr)
     ptr = copy (_2 as variant Result::Ok)._0
-    storage_live(_6)
-    _6 = copy ptr
-    _0 = as_mut_ptr<u8>[{built_in impl Sized for u8}](move _6)
+    storage_live(_7)
+    _7 = copy ptr
+    _0 = as_mut_ptr<u8>[{built_in impl Sized for u8}](move _7)
     ↳⚡ unwind_continue
-    storage_dead(_6)
+    storage_dead(_7)
     storage_dead(ptr)
     storage_dead(_2)
     return


### PR DESCRIPTION
Fixes https://github.com/AeneasVerif/charon/issues/1377. The new representation looks like:
```rust
/// The value inspected by a switch. Must be of integer, bool or char type.
#[derive(
    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
)]
#[cfg_attr(feature = "charon_on_charon", charon::variants_prefix("Switch"))]
pub enum SwitchScrutinee {
    /// Inspect the value produced by an operand.
    Value(Operand),
    /// Inspect the discriminant of an enum place.
    Discriminant(Place),
}

/// A branching operation.
#[derive(
    Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
)]
pub struct SwitchData {
    /// The value to branch over.
    pub scrutinee: SwitchScrutinee,
    /// Which branch to take for each value of the scrutinee. Several values may point to the same
    /// branch, and not all values may be accounted for.
    ///
    /// If the scrutinee is an operand, the constant expressions are literal values. If the
    /// scrutinee is a discriminant read, the expressions are of the form
    /// `ConstantExprKind::Discriminant`.
    pub branches: Vec<(ConstantExpr, BranchId)>,
    /// Branch to use if the scrutinee didn't match any of the values above. `None` if the set of
    /// branch values is known to be exhaustive.
    pub fallback: Option<BranchId>,
}

pub enum StatementKind {
    ...
    Switch {
        data: SwitchData,
        branches: IndexVec<BranchId, Block>,
    },
}
```

ci: use https://github.com/AeneasVerif/aeneas/pull/1311

ci: use https://github.com/AeneasVerif/eurydice/pull/442