### PR TITLE
Profiling work

### DIFF
--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -251,7 +251,6 @@ dependencies = [
  "env_logger",
  "extension-traits",
  "flate2",
- "fraction",
  "hashbrown",
  "hax-adt-into",
  "ignore",
@@ -725,16 +724,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fraction"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
-dependencies = [
- "lazy_static",
- "num",
 ]
 
 [[package]]
@@ -1472,35 +1461,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
  "num-traits",
 ]
 
@@ -1516,28 +1482,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -82,7 +82,6 @@ either = "1.15.0"
 env_logger = { version = "0.11", features = ["color"] }
 extension-traits = "1.0.1"
 flate2 = { version = "1.0.34", optional = true }
-fraction = "0.15.3"
 hashbrown = { version = "0.15.0", default-features = false }
 indexmap = { version = "2.7.1", features = ["serde"] }
 index_vec = { version = "0.1.3", features = ["serde"] }

--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -145,12 +145,38 @@ fn check_late_rustc_errors(tcx: TyCtxt<'_>) {
     }
 }
 
+/// Whether this sysroot provides libraries for the given target.
+fn sysroot_has_target(sysroot: &std::path::Path, target: &str) -> bool {
+    sysroot.join("lib").join("rustlib").join(target).is_dir()
+}
+
+/// Where we remember the sysroot that `cargo miri setup` computed. The sysroot depends on the
+/// toolchain, so we only cache when we know which toolchain we're running under; `rustup` tells us
+/// through `RUSTUP_TOOLCHAIN`.
+fn miri_sysroot_cache_file(target: &str) -> Option<PathBuf> {
+    let toolchain = env::var("RUSTUP_TOOLCHAIN").ok()?;
+    let cache_dir = match env::var_os("CHARON_CACHE_DIR") {
+        Some(dir) => PathBuf::from(dir),
+        None => env::home_dir()?.join(".cache").join("charon"),
+    };
+    Some(cache_dir.join(format!("miri-sysroot-{toolchain}-{target}")))
+}
+
 /// `cargo miri setup` sets up a sysroot containing a standard library built with
 /// `-Zalways-encode-mir`.
 fn setup_miri_sysroot(target: &str) -> Option<PathBuf> {
     if let Some(root) = env::var_os("CHARON_MIRI_SYSROOTS")
         && let sysroot = PathBuf::from(root)
-        && sysroot.join("lib").join("rustlib").join(target).is_dir()
+        && sysroot_has_target(&sysroot, target)
+    {
+        return Some(sysroot);
+    }
+
+    // Memoise where the sysroot is, to avoid a subprocess call for all tests.
+    if let Some(cache_file) = miri_sysroot_cache_file(target)
+        && let Ok(contents) = std::fs::read_to_string(&cache_file)
+        && let sysroot = PathBuf::from(contents.trim())
+        && sysroot_has_target(&sysroot, target)
     {
         return Some(sysroot);
     }
@@ -187,7 +213,15 @@ fn setup_miri_sysroot(target: &str) -> Option<PathBuf> {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let sysroot = stdout.lines().map(str::trim).find(|line| !line.is_empty());
     match sysroot {
-        Some(sysroot) => Some(PathBuf::from(sysroot)),
+        Some(sysroot) => {
+            if let Some(cache_file) = miri_sysroot_cache_file(target)
+                && let Some(cache_dir) = cache_file.parent()
+                && std::fs::create_dir_all(cache_dir).is_ok()
+            {
+                let _ = std::fs::write(&cache_file, sysroot);
+            }
+            Some(PathBuf::from(sysroot))
+        }
         None => {
             eprintln!(
                 "warning: `cargo miri setup --print-sysroot` printed no sysroot for target \

--- a/charon/src/bin/charon-driver/driver.rs
+++ b/charon/src/bin/charon-driver/driver.rs
@@ -301,7 +301,9 @@ pub fn run_rustc_driver() -> Result<Option<(TransformCtx, CliOpts)>, CharonFailu
             error_ctx: Some(error_ctx),
             transform_ctx: None,
         };
-        run_compiler_with_callbacks(compiler_args, &mut callback)?;
+        charon_lib::timing::time("rustc-driver", || {
+            run_compiler_with_callbacks(compiler_args, &mut callback)
+        })?;
         // If `transform_ctx` is not set here, there was a fatal error.
         let ctx = callback.transform_ctx.ok_or(CharonFailure::RustcError)?;
         Some((ctx, options))
@@ -343,23 +345,25 @@ impl<'a> Callbacks for CharonCallbacks<'a> {
         rustc_hir::def_id::DEF_ID_DEBUG
             .swap(&(def_id_debug as fn(_, &mut fmt::Formatter<'_>) -> _));
 
-        if precheck_rustc_errors(tcx) {
+        if charon_lib::timing::time("rustc-precheck-errors", || precheck_rustc_errors(tcx)) {
             return Compilation::Continue;
         }
 
-        self.transform_ctx = translate_crate::translate(
-            tcx,
-            self.options,
-            self.error_ctx.take().unwrap(),
-            compiler.sess.opts.sysroot.path().to_owned(),
-        )
+        self.transform_ctx = charon_lib::timing::time("translate-crate", || {
+            translate_crate::translate(
+                tcx,
+                self.options,
+                self.error_ctx.take().unwrap(),
+                compiler.sess.opts.sysroot.path().to_owned(),
+            )
+        })
         .ok();
 
         Compilation::Continue
     }
     fn after_analysis<'tcx>(&mut self, _compiler: &Compiler, tcx: TyCtxt<'tcx>) -> Compilation {
         if !self.emit_artifacts {
-            check_late_rustc_errors(tcx);
+            charon_lib::timing::time("rustc-late-checks", || check_late_rustc_errors(tcx));
         }
         Compilation::Continue
     }

--- a/charon/src/bin/charon-driver/main.rs
+++ b/charon/src/bin/charon-driver/main.rs
@@ -88,16 +88,21 @@ fn run_charon() -> Result<usize, CharonFailure> {
 
     // The bulk of the translation is done, we no longer need to interact with rustc internals. We
     // run several passes that simplify the items and cleanup the bodies.
-    run_transformation_passes(&options, &mut ctx);
+    charon_lib::timing::time("transformation-passes", || {
+        run_transformation_passes(&options, &mut ctx)
+    });
 
     let error_count = ctx.errors.borrow().error_count;
 
     // # Final step: generate the files.
     let targets = options.targets(&ctx.translated.crate_name);
     trace!("Targets: {:?}", targets);
-    export::CrateData::new(ctx)
-        .serialize_to_files(targets)
-        .map_err(|()| CharonFailure::Serialize)?;
+    let crate_name = ctx.translated.crate_name.clone();
+    charon_lib::timing::time("serialize", || {
+        export::CrateData::new(ctx).serialize_to_files(targets)
+    })
+    .map_err(|()| CharonFailure::Serialize)?;
+    charon_lib::timing::report(&crate_name);
 
     if options.error_on_warnings && error_count != 0 {
         return Err(CharonFailure::CharonError(error_count));

--- a/charon/src/bin/charon-driver/translate/get_mir.rs
+++ b/charon/src/bin/charon-driver/translate/get_mir.rs
@@ -18,6 +18,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         item_ref: &hax::ItemRef,
         span: Span,
     ) -> Result<Option<mir::Body<'tcx>>, Error> {
+        let _guard = charon_lib::timing::scope("get-mir");
         // Stopgap measure because there are still many panics in charon and hax.
         let mut this = panic::AssertUnwindSafe(&mut *self);
         let res = panic::catch_unwind(move || this.get_mir_inner(item_ref));

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -231,6 +231,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         body: mir::Body<'tcx>,
         source_text: &Option<String>,
     ) -> Body {
+        let _guard = charon_lib::timing::scope("translate-body");
         let drop_kind = match body.phase {
             mir::MirPhase::Built | mir::MirPhase::Analysis(..) => DropKind::Conditional,
             mir::MirPhase::Runtime(..) => DropKind::Precise,

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -1061,6 +1061,7 @@ pub fn translate<'tcx>(
         id_map: Default::default(),
         reverse_id_map: Default::default(),
         file_to_id: Default::default(),
+        cached_spans: Default::default(),
         items_to_translate: Default::default(),
         processed: Default::default(),
         translate_stack: Default::default(),

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -178,6 +178,7 @@ impl<'tcx> TranslateCtx<'tcx> {
             raise_error!(self, span, "Item is not monomorphic: {item:?}")
         }
         // Hax takes care of caching the translation.
+        let _guard = charon_lib::timing::scope("hax-full-def");
         let unwind_safe_s = std::panic::AssertUnwindSafe(&self.hax_state);
         std::panic::catch_unwind(move || match item {
             RustcItem::Poly(def_id) => def_id.full_def(*unwind_safe_s),

--- a/charon/src/bin/charon-driver/translate/translate_ctx.rs
+++ b/charon/src/bin/charon-driver/translate/translate_ctx.rs
@@ -56,6 +56,8 @@ pub struct TranslateCtx<'tcx> {
     pub assoc_item_id_map: HashMap<hax::DefId, AssocItemId>,
     /// The reverse filename map.
     pub file_to_id: HashMap<FileName, FileId>,
+    /// Cache of the translated span, as translating one is costly
+    pub cached_spans: HashMap<rustc_span::Span, meta::SpanData>,
 
     /// Context for tracking and reporting errors.
     pub errors: RefCell<ErrorCtx>,

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -14,6 +14,10 @@ use std::ops::ControlFlow;
 
 impl<'tcx> TranslateCtx<'tcx> {
     pub(crate) fn translate_item(&mut self, item_src: &TransItemSource) {
+        let _guard = charon_lib::timing::scope_lazy("translate-item", || {
+            let kind = format!("{:?}", item_src.kind);
+            kind.split('(').next().unwrap().to_owned()
+        });
         let trans_id = self.register_no_enqueue(&None, item_src);
         let def_id = item_src.def_id();
         if let Some(trans_id) = trans_id {

--- a/charon/src/bin/charon-driver/translate/translate_meta.rs
+++ b/charon/src/bin/charon-driver/translate/translate_meta.rs
@@ -56,6 +56,8 @@ impl<'tcx> TranslateCtx<'tcx> {
                         // Find the cargo home directory: according to cargo docs and having a
                         // look at the cargo source, it's either the `$CARGO_HOME` var or
                         // `$HOME/.cargo`
+                        static CURRENT_DIR: LazyLock<Option<PathBuf>> =
+                            LazyLock::new(|| std::env::current_dir().ok());
                         static CARGO_HOME: LazyLock<Option<PathBuf>> = LazyLock::new(|| {
                             std::env::var("CARGO_HOME")
                                 .map(PathBuf::from)
@@ -85,7 +87,7 @@ impl<'tcx> TranslateCtx<'tcx> {
                             let mut rewritten_path: PathBuf = "/cargo".into();
                             rewritten_path.extend(path);
                             rewritten_path
-                        } else if let Ok(current_dir) = std::env::current_dir()
+                        } else if let Some(current_dir) = &*CURRENT_DIR
                             && let Ok(path) = path.strip_prefix(current_dir)
                         {
                             path.to_path_buf()

--- a/charon/src/bin/charon-driver/translate/translate_meta.rs
+++ b/charon/src/bin/charon-driver/translate/translate_meta.rs
@@ -130,6 +130,15 @@ impl<'tcx> TranslateCtx<'tcx> {
     }
 
     pub fn translate_span_data(&mut self, span: rustc_span::Span) -> meta::SpanData {
+        if let Some(data) = self.cached_spans.get(&span) {
+            return *data;
+        }
+        let data = self.translate_span_data_uncached(span);
+        self.cached_spans.insert(span, data);
+        data
+    }
+
+    fn translate_span_data_uncached(&mut self, span: rustc_span::Span) -> meta::SpanData {
         let smap: &rustc_span::source_map::SourceMap = self.tcx.sess.psess.source_map();
         let filename = smap.span_to_filename(span);
         let filename = self.translate_filename(filename);

--- a/charon/src/export.rs
+++ b/charon/src/export.rs
@@ -117,7 +117,7 @@ impl CrateData {
             return Err(());
         };
         // Write to the file.
-        let mut writer = BufWriter::new(outfile);
+        let mut writer = BufWriter::with_capacity(4 * 1024 * 1024, outfile);
         match format {
             SerializationFormat::Json => {
                 if let Err(err) = serde_json::to_writer(&mut writer, self) {

--- a/charon/src/lib.rs
+++ b/charon/src/lib.rs
@@ -54,6 +54,7 @@ pub mod export;
 pub mod name_matcher;
 pub mod options;
 pub mod pretty;
+pub mod timing;
 pub mod transform;
 pub mod utils;
 

--- a/charon/src/timing.rs
+++ b/charon/src/timing.rs
@@ -1,0 +1,148 @@
+//! Lightweight, opt-in timing instrumentation.
+//!
+//! Enabled by setting the `CHARON_TIMINGS` environment variable. Set it to `1` to get a
+//! human-readable report on stderr at the end of the run; set it to a file path to additionally
+//! append the measurements as csv lines to that file.
+//!
+//! Scopes can be nested: we report both the total (wall) time spent in a scope and the "self"
+//! time, i.e. the time not spent inside a nested instrumented scope.
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::io::Write;
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
+/// Whether timing is enabled at all.
+static SETTING: LazyLock<Option<String>> = LazyLock::new(|| std::env::var("CHARON_TIMINGS").ok());
+
+pub fn enabled() -> bool {
+    SETTING.is_some()
+}
+
+#[derive(Default, Clone, Copy)]
+pub struct Measure {
+    pub total: Duration,
+    pub own: Duration,
+    pub count: u64,
+}
+
+/// Measurements are aggregated globally (translation is single-threaded but rustc may call us from
+/// several threads, hence the mutex).
+static MEASURES: LazyLock<Mutex<HashMap<String, Measure>>> = LazyLock::new(Default::default);
+
+thread_local! {
+    /// Time spent in nested scopes, for the currently-running scope.
+    static NESTED: RefCell<Vec<Duration>> = const { RefCell::new(Vec::new()) };
+}
+
+/// A running measurement; the timing is recorded when this is dropped.
+pub struct Guard {
+    name: &'static str,
+    /// Only used to give a more precise name than `name` when relevant.
+    suffix: Option<String>,
+    start: Instant,
+}
+
+/// Time the given scope, if timings are enabled.
+pub fn scope(name: &'static str) -> Option<Guard> {
+    scope_with(name, None)
+}
+
+/// Same as [`scope`] but allows refining the name dynamically.
+pub fn scope_with(name: &'static str, suffix: Option<String>) -> Option<Guard> {
+    if !enabled() {
+        return None;
+    }
+    NESTED.with_borrow_mut(|stack| stack.push(Duration::ZERO));
+    Some(Guard {
+        name,
+        suffix,
+        start: Instant::now(),
+    })
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let elapsed = self.start.elapsed();
+        let nested = NESTED.with_borrow_mut(|stack| {
+            let nested = stack.pop().unwrap_or_default();
+            if let Some(parent) = stack.last_mut() {
+                *parent += elapsed;
+            }
+            nested
+        });
+        let long_key = self
+            .suffix
+            .as_ref()
+            .map(|suffix| format!("{}/{suffix}", self.name));
+        let key: &str = long_key.as_deref().unwrap_or(self.name);
+        let mut measures = MEASURES.lock().unwrap();
+        // Avoid allocating a fresh `String` on each call.
+        if !measures.contains_key(key) {
+            measures.insert(key.to_owned(), Measure::default());
+        }
+        let entry = measures.get_mut(key).unwrap();
+        entry.total += elapsed;
+        entry.own += elapsed.saturating_sub(nested);
+        entry.count += 1;
+    }
+}
+
+/// Same as [`scope_with`] but only computes the suffix if timings are enabled.
+pub fn scope_lazy(name: &'static str, suffix: impl FnOnce() -> String) -> Option<Guard> {
+    if !enabled() {
+        return None;
+    }
+    scope_with(name, Some(suffix()))
+}
+
+/// Time the given closure.
+pub fn time<T>(name: &'static str, f: impl FnOnce() -> T) -> T {
+    let _guard = scope(name);
+    f()
+}
+
+/// Print the timing report on stderr, and append it to the file given in `CHARON_TIMINGS` if it
+/// isn't `1`.
+pub fn report(crate_name: &str) {
+    let Some(setting) = SETTING.as_ref() else {
+        return;
+    };
+    let measures = MEASURES.lock().unwrap();
+    let mut entries: Vec<(&String, &Measure)> = measures.iter().collect();
+    entries.sort_by_key(|(name, m)| (std::cmp::Reverse(m.own), (*name).clone()));
+
+    let mut out = String::new();
+    out += &format!("\n=== charon timings for crate `{crate_name}` ===\n");
+    out += &format!(
+        "{:<60} {:>12} {:>12} {:>10}\n",
+        "scope", "total (ms)", "self (ms)", "calls"
+    );
+    for (name, m) in &entries {
+        out += &format!(
+            "{:<60} {:>12.2} {:>12.2} {:>10}\n",
+            name,
+            m.total.as_secs_f64() * 1000.,
+            m.own.as_secs_f64() * 1000.,
+            m.count
+        );
+    }
+    eprint!("{out}");
+
+    if setting != "1"
+        && let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(setting)
+    {
+        for (name, m) in &entries {
+            let _ = writeln!(
+                file,
+                "{crate_name},{name},{:.3},{:.3},{}",
+                m.total.as_secs_f64() * 1000.,
+                m.own.as_secs_f64() * 1000.,
+                m.count
+            );
+        }
+    }
+}

--- a/charon/src/transform/add_missing_info/reorder_decls.rs
+++ b/charon/src/transform/add_missing_info/reorder_decls.rs
@@ -13,7 +13,7 @@ use crate::utils::*;
 use derive_generic_visitor::*;
 use itertools::Itertools;
 use petgraph::graphmap::DiGraphMap;
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::fmt::{Debug, Display, Error};
 use std::vec::Vec;
 

--- a/charon/src/transform/control_flow/ullbc_to_llbc.rs
+++ b/charon/src/transform/control_flow/ullbc_to_llbc.rs
@@ -89,9 +89,38 @@ where
     }
 }
 
-/// Arbitrary-precision numbers
-type BigUint = fraction::DynaInt<u64, fraction::BigUint>;
-type BigRational = fraction::Ratio<BigUint>;
+/// The amount of "flow" reaching a block.
+#[derive(Debug, Clone, Copy, Default)]
+struct Flow(f64);
+
+impl Ord for Flow {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.total_cmp(&other.0)
+    }
+}
+impl PartialOrd for Flow {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl PartialEq for Flow {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other).is_eq()
+    }
+}
+impl Eq for Flow {}
+impl std::ops::AddAssign<Flow> for Flow {
+    fn add_assign(&mut self, other: Flow) {
+        self.0 += other.0;
+    }
+}
+impl Flow {
+    const ZERO: Flow = Flow(0.);
+    const ONE: Flow = Flow(1.);
+    fn divided_by(self, n: usize) -> Flow {
+        Flow(self.0 / (n as f64))
+    }
+}
 
 /// Control-Flow Graph
 type Cfg = DiGraphMap<src::BlockId, ()>;
@@ -182,7 +211,7 @@ struct BlockData {
     /// This is exactly this problems:
     /// <https://stackoverflow.com/questions/78221666/algorithm-for-total-flow-through-weighted-directed-acyclic-graph>
     /// TODO: the way I compute this is not efficient.
-    pub flow: IndexVec<BlockId, BigRational>,
+    pub flow: IndexVec<BlockId, Flow>,
     /// Reconstructed information about loops and switches.
     pub exit_info: ExitInfo,
 }
@@ -207,7 +236,7 @@ impl CfgInfo {
         // previous one.
         let start_block = BlockId::ZERO;
 
-        let empty_flow = body.map_ref(|_| BigRational::new(0u64.into(), 1u64.into()));
+        let empty_flow = body.map_ref(|_| Flow::ZERO);
         let mut block_data: IndexVec<BlockId, _> = body.map_ref_indexed(|id, contents| {
             Box::new(BlockData {
                 id,
@@ -321,10 +350,9 @@ impl CfgInfo {
             }
 
             // Compute the flows between each pair of nodes.
-            let mut flow: IndexVec<src::BlockId, BigRational> =
-                mem::take(&mut block_data[block_id].flow);
+            let mut flow: IndexVec<src::BlockId, Flow> = mem::take(&mut block_data[block_id].flow);
             // The flow to self is 1.
-            flow[block_id] = BigRational::new(1u64.into(), 1u64.into());
+            flow[block_id] = Flow::ONE;
             // If a block has both regular and unwind targets, don't let the unwind path dilute
             // the normal-control-flow heuristic used to pick switch exits. Unwind-only subgraphs
             // still flow through their own targets.
@@ -339,11 +367,11 @@ impl CfgInfo {
             // Divide the flow from each child to a given target block by the number of children.
             // This is a sparse matrix multiplication and could be implemented using a linalg
             // library.
-            let num_children: BigUint = flow_targets.len().into();
+            let num_children = flow_targets.len();
             for child in flow_targets {
                 for grandchild in block_data[child].reachable_including_self() {
                     // Flow from `child` to `grandchild`
-                    flow[grandchild] += &block_data[child].flow[grandchild] / &num_children;
+                    flow[grandchild] += block_data[child].flow[grandchild].divided_by(num_children);
                 }
             }
             block_data[block_id].flow = flow;

--- a/charon/src/transform/control_flow/ullbc_to_llbc.rs
+++ b/charon/src/transform/control_flow/ullbc_to_llbc.rs
@@ -1342,6 +1342,13 @@ fn translate_body(ctx: &mut TransformCtx, body: &mut Body) {
         panic!("Called `ullbc_to_llbc` on an already restructured body")
     };
     trace!("About to translate to ullbc: {:?}", src_body.span);
+    // Report the time spent per body size, since this pass is superlinear in the number of blocks.
+    let _guard = crate::timing::scope_lazy("ullbc_to_llbc-body", || {
+        format!(
+            "{:05} blocks or less",
+            src_body.body.len().next_power_of_two()
+        )
+    });
 
     // Calculate info about the graph and heuristically determine loop and switch exit blocks.
     let start_block = BlockId::ZERO;

--- a/charon/src/transform/control_flow/ullbc_to_llbc.rs
+++ b/charon/src/transform/control_flow/ullbc_to_llbc.rs
@@ -18,9 +18,9 @@ use petgraph::graphmap::DiGraphMap;
 use petgraph::visit::{
     Dfs, DfsPostOrder, EdgeFiltered, EdgeRef, GraphRef, IntoNeighbors, VisitMap, Visitable, Walker,
 };
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::SmallVec;
 use std::cmp::Reverse;
-use std::collections::{HashMap, HashSet};
 use std::mem;
 
 use crate::ids::IndexVec;
@@ -123,7 +123,7 @@ impl Flow {
 }
 
 /// Control-Flow Graph
-type Cfg = DiGraphMap<src::BlockId, ()>;
+type Cfg = DiGraphMap<src::BlockId, (), rustc_hash::FxBuildHasher>;
 
 /// Information precomputed about a function's CFG.
 #[derive(Debug)]
@@ -286,8 +286,8 @@ impl CfgInfo {
 
         // Compute the forward graph (without backward edges).
         let mut fwd_cfg = Cfg::new();
-        let mut loop_entries = HashSet::new();
-        let mut switch_blocks = HashSet::new();
+        let mut loop_entries = HashSet::default();
+        let mut switch_blocks = HashSet::default();
         for block_id in Dfs::new(&cfg, start_block).iter(&cfg) {
             fwd_cfg.add_node(block_id);
 
@@ -783,7 +783,7 @@ impl ExitInfo {
     fn compute_switch_exits(cfg: &mut CfgInfo) {
         // We need to give precedence to the outer switches: we thus iterate
         // over the switch blocks in topological order.
-        let mut exits_set = HashSet::new();
+        let mut exits_set = HashSet::default();
         for bid in cfg
             .switch_blocks
             .iter()

--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -78,6 +78,13 @@ use ctx::{LlbcPass, TransformPass, UllbcPass};
 
 use crate::options::CliOpts;
 
+/// Shorten a pass name for display: `charon_lib::transform::foo::bar::Transform` -> `foo::bar`.
+fn short_pass_name(name: &str) -> String {
+    let name = name.strip_prefix("charon_lib::transform::").unwrap_or(name);
+    let name = name.strip_suffix("::Transform").unwrap_or(name);
+    name.to_owned()
+}
+
 /// Run transformation passes on the crate before outputting it.
 pub fn run_transformation_passes(options: &CliOpts, ctx: &mut TransformCtx) {
     // Passes that apply to the whole crate at once, typically those that change item signatures.
@@ -295,6 +302,8 @@ impl TransformCtx {
             Pass::NonBody(pass) => {
                 if pass.should_run(&self.options) {
                     trace!("# Starting pass {}", pass.name());
+                    let _guard =
+                        crate::timing::scope_lazy("transform", || short_pass_name(pass.name()));
                     pass.transform_ctx(self)
                 }
             }
@@ -312,6 +321,9 @@ impl TransformCtx {
                     for pass in passes.iter() {
                         if pass.should_run(&ctx.options) {
                             trace!("# Starting pass {}", pass.name());
+                            let _guard = crate::timing::scope_lazy("transform", || {
+                                short_pass_name(pass.name())
+                            });
                             pass.transform_item(ctx, item.reborrow());
                         }
                     }
@@ -325,6 +337,9 @@ impl TransformCtx {
                     for pass in passes.iter() {
                         if pass.should_run(&ctx.options) {
                             trace!("# Starting pass {}", pass.name());
+                            let _guard = crate::timing::scope_lazy("transform", || {
+                                short_pass_name(pass.name())
+                            });
                             pass.transform_function(ctx, decl);
                         }
                     }

--- a/charon/src/transform/normalize/expand_associated_types.rs
+++ b/charon/src/transform/normalize/expand_associated_types.rs
@@ -71,7 +71,7 @@
 //!   with an existing trait impl. See the `dictionary_passing_style_woes.rs` test file.
 use derive_generic_visitor::*;
 use itertools::Itertools;
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::{
     ast::*, formatter::IntoFormatter, ids::IndexMap, pretty::FmtWithCtx, register_error,
@@ -381,7 +381,7 @@ mod trait_ref_path {
 /// Efficient representation of a set of `<Type as Trait>::Type = T` constraints.
 use type_constraint_set::*;
 mod type_constraint_set {
-    use std::collections::HashMap;
+    use rustc_hash::FxHashMap as HashMap;
 
     use super::trait_ref_path::*;
     use crate::{ast::*, ids::IndexVec};
@@ -1420,7 +1420,7 @@ impl TransformPass for Transform {
         // types.
         let item_modifications: HashMap<GenericsSource, ItemModifications> = {
             let mut computer = ComputeItemModifications::new(ctx);
-            let mut item_modifications = HashMap::new();
+            let mut item_modifications = HashMap::default();
             for (id, item) in ctx.translated.all_items_with_ids() {
                 let modifications = computer.compute_item_modifications(item);
                 item_modifications.insert(GenericsSource::Item(id), modifications);

--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -41,6 +41,11 @@ struct TypeCheckVisitor<'a> {
     /// Remember the names of the types visited up to here.
     visit_stack: Vec<&'static str>,
     body_lt_unifier: Option<UnionFind<RegionId>>,
+    /// Whether `body_lt_unifier` merged anything, i.e. whether the body needs rewriting.
+    did_unify_lifetimes: bool,
+    /// The unifiers computed for each body we visited, in visit order. `None` for the bodies that
+    /// don't need rewriting.
+    body_lt_unifiers: Vec<Option<UnionFind<RegionId>>>,
     /// Copies of default methods may have contradictory premises like `Self::Item = bool` and
     /// `Self::Item = u32` which may equate entirely different types. We don't try to reason about
     /// this and instead accept this fact. It's fine because the original methods will be
@@ -84,7 +89,7 @@ impl TypeCheckVisitor<'_> {
         if let (Region::Body(a), Region::Body(b)) = (a, b)
             && let Some(unifier) = &mut self.body_lt_unifier
         {
-            unifier.union(*a, *b);
+            self.did_unify_lifetimes |= unifier.union(*a, *b);
         }
         Ok(())
     }
@@ -320,7 +325,7 @@ impl TypeCheckVisitor<'_> {
         &mut self,
         params_fmt: &FmtCtx<'_>,
         params: &GenericParams,
-        args: &mut GenericArgs,
+        args: &GenericArgs,
         target: &GenericsSource,
     ) -> ControlFlow<()> {
         self.zip_assert_match(
@@ -357,7 +362,7 @@ impl TypeCheckVisitor<'_> {
         ControlFlow::Continue(())
     }
 
-    fn assert_matches_item(&mut self, id: impl Into<ItemId>, args: &mut GenericArgs) {
+    fn assert_matches_item(&mut self, id: impl Into<ItemId>, args: &GenericArgs) {
         let id = id.into();
         let Some(item) = self.ctx.translated.get_item(id) else {
             return;
@@ -372,7 +377,7 @@ impl TypeCheckVisitor<'_> {
         &mut self,
         trait_ref: &TraitRef,
         method_id: TraitMethodId,
-        args: &mut GenericArgs,
+        args: &GenericArgs,
     ) {
         let trait_id = trait_ref.trait_decl_ref.skip_binder.id;
         let target = &GenericsSource::Method(trait_id, method_id);
@@ -394,7 +399,7 @@ impl TypeCheckVisitor<'_> {
         &mut self,
         trait_ref: &TraitRef,
         type_id: AssocTypeId,
-        args: &mut GenericArgs,
+        args: &GenericArgs,
     ) {
         let trait_id = trait_ref.trait_id();
         let target = &GenericsSource::TraitType(trait_id, type_id);
@@ -413,8 +418,8 @@ impl TypeCheckVisitor<'_> {
     }
 }
 
-impl VisitAstMut for TypeCheckVisitor<'_> {
-    fn visit<T: AstVisitable>(&mut self, x: &mut T) -> ControlFlow<Self::Break> {
+impl VisitAst for TypeCheckVisitor<'_> {
+    fn visit<T: AstVisitable>(&mut self, x: &T) -> ControlFlow<Self::Break> {
         self.visit_stack.push(x.name());
         VisitWithSpan::new(VisitWithBinderStack::new(self)).visit(x)?;
         self.visit_stack.pop();
@@ -422,14 +427,14 @@ impl VisitAstMut for TypeCheckVisitor<'_> {
     }
 
     // Check that generics are correctly bound.
-    fn enter_region(&mut self, x: &mut Region) {
+    fn enter_region(&mut self, x: &Region) {
         if let Region::Var(var) = x
             && self.binder_stack.get_var(*var).is_none()
         {
             self.error(format!("Found incorrect region var: {var}"));
         }
     }
-    fn enter_ty_kind(&mut self, x: &mut TyKind) {
+    fn enter_ty_kind(&mut self, x: &TyKind) {
         match x {
             TyKind::TypeVar(var) if self.binder_stack.get_var(*var).is_none() => {
                 self.error(format!("Found incorrect type var: {var}"));
@@ -440,14 +445,14 @@ impl VisitAstMut for TypeCheckVisitor<'_> {
             _ => {}
         }
     }
-    fn enter_constant_expr(&mut self, x: &mut ConstantExpr) {
+    fn enter_constant_expr(&mut self, x: &ConstantExpr) {
         if let ConstantExprKind::Var(var) = x.kind()
             && self.binder_stack.get_var(*var).is_none()
         {
             self.error(format!("Found incorrect const-generic var: {var}"));
         }
     }
-    fn enter_trait_ref(&mut self, x: &mut TraitRef) {
+    fn enter_trait_ref(&mut self, x: &TraitRef) {
         match &x.kind {
             TraitRefKind::Clause(var) if self.binder_stack.get_var(*var).is_none() => {
                 self.error(format!("Found incorrect clause var: {var}"));
@@ -504,34 +509,34 @@ impl VisitAstMut for TypeCheckVisitor<'_> {
     }
 
     // Check that generics match the parameters of the target item.
-    fn enter_type_decl_ref(&mut self, x: &mut TypeDeclRef) {
+    fn enter_type_decl_ref(&mut self, x: &TypeDeclRef) {
         // With `--no-gen-tuple-structs`, a tuple stores its field types in its generics while
         // pointing to the parameter-less opaque unit declaration, so the two don't match.
         if x.is_tuple() && self.ctx.options.no_gen_tuple_structs {
             return;
         }
-        self.assert_matches_item(x.id, &mut x.generics)
+        self.assert_matches_item(x.id, &x.generics)
     }
-    fn enter_fun_decl_ref(&mut self, x: &mut FunDeclRef) {
-        self.assert_matches_item(x.id, &mut x.generics);
+    fn enter_fun_decl_ref(&mut self, x: &FunDeclRef) {
+        self.assert_matches_item(x.id, &x.generics);
     }
-    fn enter_fn_ptr(&mut self, x: &mut FnPtr) {
+    fn enter_fn_ptr(&mut self, x: &FnPtr) {
         match x.kind.as_ref() {
-            FnPtrKind::Fun(FunId::Regular(id)) => self.assert_matches_item(*id, &mut x.generics),
+            FnPtrKind::Fun(FunId::Regular(id)) => self.assert_matches_item(*id, &x.generics),
             // TODO: check builtin generics.
             FnPtrKind::Fun(FunId::Builtin(_)) => {}
             FnPtrKind::Trait(trait_ref, method_id) => {
-                self.assert_matches_method(trait_ref, *method_id, &mut x.generics);
+                self.assert_matches_method(trait_ref, *method_id, &x.generics);
             }
         }
     }
-    fn visit_rvalue(&mut self, x: &mut Rvalue) -> ::std::ops::ControlFlow<Self::Break> {
+    fn visit_rvalue(&mut self, x: &Rvalue) -> ::std::ops::ControlFlow<Self::Break> {
         if let Rvalue::UnaryOp(UnOp::Cast(CastKind::Concretize(src, tar)), _) = x {
             self.check_concretization_ty_match(src, tar);
         }
         Continue(())
     }
-    fn visit_body(&mut self, body: &mut Body) -> ControlFlow<Self::Break> {
+    fn visit_body(&mut self, body: &Body) -> ControlFlow<Self::Break> {
         self.body_lt_unifier = match body {
             Body::Unstructured(GExprBody {
                 bound_body_regions, ..
@@ -544,26 +549,23 @@ impl VisitAstMut for TypeCheckVisitor<'_> {
 
         self.visit_inner(body)?;
 
-        if let Some(mut unifier) = self.body_lt_unifier.take() {
-            body.dyn_visit_mut(|r: &mut Region| {
-                if let Region::Body(body_id) = r {
-                    *body_id = unifier.find_mut(*body_id);
-                }
-            });
-        }
+        let unifier = self.body_lt_unifier.take();
+        self.body_lt_unifiers
+            .push(unifier.filter(|_| self.did_unify_lifetimes));
+        self.did_unify_lifetimes = false;
         Continue(())
     }
-    fn enter_global_decl_ref(&mut self, x: &mut GlobalDeclRef) {
-        self.assert_matches_item(x.id, &mut x.generics);
+    fn enter_global_decl_ref(&mut self, x: &GlobalDeclRef) {
+        self.assert_matches_item(x.id, &x.generics);
     }
-    fn enter_trait_decl_ref(&mut self, x: &mut TraitDeclRef) {
+    fn enter_trait_decl_ref(&mut self, x: &TraitDeclRef) {
         // TODO: don't we need to pass the trait_self for correctness here?
-        self.assert_matches_item(x.id, &mut x.generics);
+        self.assert_matches_item(x.id, &x.generics);
     }
-    fn enter_trait_impl_ref(&mut self, x: &mut TraitImplRef) {
-        self.assert_matches_item(x.id, &mut x.generics);
+    fn enter_trait_impl_ref(&mut self, x: &TraitImplRef) {
+        self.assert_matches_item(x.id, &x.generics);
     }
-    fn enter_trait_impl(&mut self, timpl: &mut TraitImpl) {
+    fn enter_trait_impl(&mut self, timpl: &TraitImpl) {
         let Some(tdecl) = self.ctx.translated.trait_decls.get(timpl.impl_trait.id) else {
             return;
         };
@@ -666,9 +668,25 @@ impl TransformPass for Check {
                 binder_stack: BindingStack::empty(),
                 visit_stack: Default::default(),
                 body_lt_unifier: None,
+                did_unify_lifetimes: false,
+                body_lt_unifiers: Default::default(),
                 accept_type_errors,
             };
-            let _ = item.drive_mut(&mut visitor);
+            // Check the item without touching it, to avoid useless re-internings.
+            let _ = item.as_ref().drive(&mut visitor);
+            // Apply the lifetime unifications we computed, if any.
+            if visitor.body_lt_unifiers.iter().any(|u| u.is_some()) {
+                let mut unifiers = visitor.body_lt_unifiers.into_iter();
+                item.dyn_visit_mut(|body: &mut Body| {
+                    if let Some(Some(mut unifier)) = unifiers.next() {
+                        body.dyn_visit_mut(|r: &mut Region| {
+                            if let Region::Body(body_id) = r {
+                                *body_id = unifier.find_mut(*body_id);
+                            }
+                        });
+                    }
+                });
+            }
         });
     }
 }

--- a/charon/src/utils/hash_cons.rs
+++ b/charon/src/utils/hash_cons.rs
@@ -111,41 +111,6 @@ mod intern_table {
         HashConsed(HashByAddr(arc))
     }
 
-    /// Mutate the contents in-place if possible.
-    pub fn mutate_in_place<T: HashConsable, R, F: FnOnce(&mut T) -> R>(
-        x: &mut HashConsed<T>,
-        f: F,
-    ) -> Result<R, F> {
-        let arc = &mut x.0.0;
-        // Every value has at least two pointers: the current value and the one stored in the
-        // global map. If there are exactly two, we may mutate directly by discarding the one in
-        // the global map temporarily.
-        if Arc::strong_count(arc) != 2 {
-            return Err(f);
-        }
-        {
-            // Take the write guard just long enough to drop the other `Arc` to this value.
-            let mut write_guard = INTERNED.write().unwrap();
-            if let Some((other_arc, _)) = write_guard.or_default::<T>().swap_remove_entry(&*arc) {
-                drop(other_arc);
-            } else {
-                // Nothing was removed, early return.
-                return Err(f);
-            }
-            // The Arc was removed from the map; `x` is invalid as interning the same value would
-            // result in a different pointer. NO MORE EARLY RETURN until we fix that.
-        }
-        // If we are still the sole owner, we can now mutate in-place.
-        let ret = match Arc::get_mut(arc) {
-            Some(val) => Ok(f(val)),
-            None => Err(f),
-        };
-        // Re-establish the interning invariant. If the same value was added to the map in the
-        // meantime, we'll get a pointer to that.
-        *x = HashConsed::from_arc(arc.clone());
-        ret
-    }
-
     /// Identify this value uniquely amongst values of its type. The id depends on insertion
     /// order into the interning table which makes them in principle deterministic.
     pub fn id<T: HashConsable>(x: &HashConsed<T>) -> HashConsId {
@@ -172,19 +137,16 @@ where
         intern_table::intern(inner)
     }
 
-    /// Clones if needed to get mutable access to the inner value.
+    /// Clones the value to give mutable access to it, and re-interns it if it changed.
     pub fn with_inner_mut<R>(&mut self, f: impl FnOnce(&mut T) -> R) -> R {
-        match intern_table::mutate_in_place(self, f) {
-            Ok(r) => r,
-            Err(f) => {
-                // The value is behind a shared `Arc`, we clone it in order to mutate it.
-                let mut value = self.inner().clone();
-                let ret = f(&mut value);
-                // Re-intern the new value.
-                *self = Self::new(value);
-                ret
-            }
+        let mut value = self.inner().clone();
+        let ret = f(&mut value);
+        // Most of the time nothing changed, in which case we can keep the `Arc`
+        // we have instead of interning again.
+        if &value != self.inner() {
+            *self = Self::new(value);
         }
+        ret
     }
 
     pub fn id(&self) -> HashConsId {


### PR DESCRIPTION
Added a way to do some profiling to Charon. Calling Charon with `CHARON_TIMINGS=1` prints out the timings of relevant parts of the code to stderr, and setting `CHARON_TIMINGS=<file>` appends the data as csv rows.

<details>
<summary>Example for a tiny test</summary>

```
=== charon timings for crate `test_crate` ===
scope                                                          total (ms)    self (ms)      calls
rustc-driver                                                        32.85        32.85          1
hax-full-def                                                         9.67         9.67        951
translate-crate                                                     21.35         4.42          1
transform/PrintCtxPass                                               3.99         3.99          3
serialize                                                            3.20         3.20          1
translate-body                                                       4.75         3.05         66
rustc-precheck-errors                                                2.49         2.49          1
transform/typecheck_and_unify::Check                                 1.92         1.92          2
transformation-passes                                               11.78         1.15          1
get-mir                                                              1.09         1.09         64
translate-item/Fun                                                   6.81         1.05         76
rustc-late-checks                                                    0.94         0.94          1
translate-item/Type                                                  0.96         0.91          5
translate-item/TraitImpl                                             1.14         0.73          7
transform/normalize::expand_associated_types                         0.50         0.50          1
transform/simplify_output::lift_associated_item_clauses              0.47         0.47          1
transform/add_missing_info::reorder_decls                            0.43         0.43          1
transform/simplify_output::duplicate_defaulted_methods               0.27         0.27          1
transform/simplify_output::remove_unit_locals                        0.26         0.26         97
ullbc_to_llbc-body/00008 blocks or less                              0.26         0.26         11
transform/normalize::skip_trait_refs_when_known                      0.23         0.23         97
ullbc_to_llbc-body/00001 blocks or less                              0.23         0.23         42
transform/simplify_output::hide_allocator_param                      0.23         0.23          1
transform/normalize::normalize_trait_refs                            0.23         0.23          1
transform/add_missing_info::compute_short_names                      0.21         0.21          1
translate-item/Module                                                4.80         0.20          1
translate-item/TraitDecl                                             3.10         0.20          6
transform/finish_translation::insert_storage_statements              0.19         0.19         98
transform/simplify_output::index_to_function_calls                   0.14         0.14         77
ullbc_to_llbc-body/00004 blocks or less                              0.10         0.10         12
transform/simplify_output::index_intermediate_assigns                0.09         0.09         97
transform/control_flow::prettify_cfg                                 0.09         0.09         77
transform/simplify_output::remove_unused_locals                      0.09         0.09         98
transform/simplify_output::simplify_constants                        0.06         0.06         97
transform/control_flow::duplicate_return                             0.06         0.06         97
transform/resugar::reconstruct_fallible_operations                   0.06         0.06         97
ullbc_to_llbc-body/00016 blocks or less                              0.05         0.05          1
transform/add_missing_info::add_implied_outlives                     0.05         0.05          1
transform/simplify_output::anon_const_to_call                        0.05         0.05         97
transform/resugar::reconstruct_box_derefs                            0.05         0.05         97
transform/finish_translation::insert_ptr_metadata                    0.04         0.04         97
transform/normalize::filter_unreachable_blocks                       0.04         0.04         97
transform/control_flow::merge_goto_chains                            0.03         0.03        194
transform/add_missing_info::add_missing_alias_clauses                0.03         0.03          1
transform/simplify_output::remove_nops                               0.03         0.03          1
translate-item/DropGlueMethod                                        0.11         0.03          2
transform/add_missing_info::recover_body_comments                    0.02         0.02          1
transform/resugar::reconstruct_matches                               0.02         0.02         77
transform/simplify_output::update_block_indices                      0.02         0.02         97
transform/control_flow::ullbc_to_llbc                                0.66         0.02          1
transform/simplify_output::inline_selected_functions                 0.02         0.02         97
transform/simplify_output::ops_to_function_calls                     0.01         0.01         77
translate-item/Global                                                0.01         0.01          2
transform/resugar::move_asserts_to_statements                        0.01         0.01         97
transform/resugar::reconstruct_asserts                               0.01         0.01         97
transform/finish_translation::insert_assign_return_unit              0.01         0.01         97
transform/normalize::transform_dyn_trait_calls                       0.00         0.00         97
transform/resugar::reconstruct_intrinsics                            0.00         0.00         97
transform/finish_translation::filter_invisible_trait_impls           0.00         0.00          1
transform/simplify_output::filter_trivial_drops                      0.00         0.00         97
transform/add_missing_info::link_specs                               0.00         0.00          1
transform/simplify_output::remove_adt_clauses                        0.00         0.00          1
transform/normalize::partial_monomorphization                        0.00         0.00          1
```

</details>

Next, implement a handful of tiny optimisations that improve performance by 3.30 for `serde` with `--preset fast`, and up to 2.6 for `regex-syntax` with `--preset aeneas`!

- Cache the current directory in span translation
- Cache spans
- Use floats rather than arbitrary precision numbers for ULBC-LLBC reconstruction (for flow)
- Cache the sysroot we use in `~/.cache/charon/miri-sysroot-<toolchain>-<target>`, which speeds up running `cargo test` by 2x (happy to change this to use a flag or something, maybe).
- For in-place mutation, just clone and update if the value changed, rather than going through the `Arc` which is expensive!
- Do unification in a separate step to type-checking, to avoid doing mutable traversal of the entire AST for nothing
- Use `FxHash{Map,Set}` instead of the regular ones when we hash on IDs which are small and dont need a full hash anyways
- Start the write buffer with a bigger size than the default (8KB)