### PR TITLE
Translate `Fn*` calls in monomorphic code

### DIFF
--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -582,6 +582,54 @@ fn gen_vtable_sig<'tcx>(
     Some(normalized_sig.sinto(s))
 }
 
+/// The signatures the methods of this trait ref must have to be stored in a vtable, i.e. with
+/// `Self` replaced by the corresponding `dyn Trait` type; `None` for the methods that aren't
+/// vtable-safe. Same as `vtable_sig` in `AssocFn`, but for the virtual impls we generate ourselves,
+/// whose methods have no `AssocFn` of their own.
+///
+/// The order matches `VirtualTraitImpl::methods`. Only call this for a trait ref that holds and is
+/// used as a `dyn Trait`: computing the `dyn Trait` type requires resolving the associated types of
+/// the trait ref.
+/// The `dyn Trait<..>` type for this trait ref, i.e. its `Self` type made existential. Same as the
+/// `dyn_self` field of a `TraitImpl`, for the virtual impls we generate ourselves.
+pub fn trait_ref_dyn_self<'tcx, S: UnderOwnerState<'tcx>>(
+    s: &S,
+    trait_ref: &TraitRef,
+) -> Option<Ty> {
+    let tcx = s.base().tcx;
+    let trait_def_id = trait_ref.def_id.as_real_def_id()?;
+    let trait_ref = ty::TraitRef::new_from_args(tcx, trait_def_id, trait_ref.rustc_args(s));
+    Some(rustc_utils::dyn_self_ty(tcx, s.typing_env(), trait_ref)?.sinto(s))
+}
+
+pub fn virtual_impl_vtable_sigs<'tcx, S: UnderOwnerState<'tcx>>(
+    s: &S,
+    trait_ref: &TraitRef,
+) -> Vec<Option<PolyFnSig>> {
+    let tcx = s.base().tcx;
+    let Some(trait_def_id) = trait_ref.def_id.as_real_def_id() else {
+        return vec![];
+    };
+    let trait_ref = ty::TraitRef::new_from_args(tcx, trait_def_id, trait_ref.rustc_args(s));
+    tcx.associated_items(trait_def_id)
+        .in_definition_order()
+        .filter(|assoc| matches!(assoc.kind, ty::AssocKind::Fn { .. }))
+        .map(|assoc| {
+            if !rustc_trait_selection::traits::is_vtable_safe_method(tcx, trait_def_id, *assoc) {
+                return None;
+            }
+            let dyn_self = rustc_utils::dyn_self_ty(tcx, s.typing_env(), trait_ref)?;
+            // `trait_ref.args[0]` is `Self`, which we replace with `dyn Trait`.
+            let mut full_args = vec![ty::GenericArg::from(dyn_self)];
+            full_args.extend(trait_ref.args[1..].iter());
+            let sig = tcx
+                .fn_sig(assoc.def_id)
+                .instantiate(tcx, tcx.mk_args(&full_args));
+            Some(normalize(tcx, s.typing_env(), sig).sinto(s))
+        })
+        .collect()
+}
+
 fn gen_closure_sig<'tcx>(
     // The state that owns the method DefId
     s: &impl UnderOwnerState<'tcx>,

--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -57,6 +57,40 @@ pub fn translate_closure_kind(kind: &hax::ClosureKind) -> ClosureKind {
     }
 }
 
+/// If this trait proof is the built-in impl of a `Fn*` trait for a closure or function item,
+/// return the callable item and the kind of the implemented trait.
+pub fn recognize_callable_impl_proof(
+    trait_proof: &hax::TraitProof,
+) -> Option<(&hax::ItemRef, ClosureKind)> {
+    let hax::TraitProofKind::Builtin {
+        trait_data: hax::BuiltinTraitData::Other(lang_item),
+        ..
+    } = &trait_proof.kind
+    else {
+        return None;
+    };
+    let target_kind = match lang_item {
+        hax::SolverTraitLangItem::FnOnce => ClosureKind::FnOnce,
+        hax::SolverTraitLangItem::FnMut => ClosureKind::FnMut,
+        hax::SolverTraitLangItem::Fn => ClosureKind::Fn,
+        _ => return None,
+    };
+    let hax::GenericArg::Type(callable_ty) = trait_proof
+        .pred
+        .hax_skip_binder_ref()
+        .generic_args
+        .first()?
+    else {
+        return None;
+    };
+    let item = match callable_ty.kind() {
+        hax::TyKind::Closure(closure_args) => &closure_args.item,
+        hax::TyKind::FnDef { item, .. } => item,
+        _ => return None,
+    };
+    Some((item, target_kind))
+}
+
 #[derive(Clone, Copy)]
 enum Callable<'a> {
     Closure(&'a hax::ClosureArgs),
@@ -240,6 +274,34 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             regions,
             skip_binder: dref,
         })
+    }
+
+    pub(crate) fn translate_callable_method_fn_ptr(
+        &mut self,
+        span: Span,
+        item: &hax::ItemRef,
+    ) -> Result<Option<RegionBinder<FnPtr>>, Error> {
+        if !self.monomorphize() {
+            return Ok(None);
+        }
+        let Some(in_trait) = &item.in_trait else {
+            return Ok(None);
+        };
+        let Some((callable, target_kind)) = recognize_callable_impl_proof(in_trait) else {
+            return Ok(None);
+        };
+        let callable = callable.clone();
+        let kind = TransItemSourceKind::CallableMethod(target_kind);
+        let bound_ref = self.translate_callable_bound_ref_with_method_bound(
+            span,
+            &callable,
+            kind,
+            target_kind,
+        )?;
+        Ok(Some(bound_ref.map(|dref| {
+            let fn_ref: FunDeclRef = dref.try_into().unwrap();
+            FnPtr::new(FnPtrKind::Fun(FunId::Regular(fn_ref.id)), fn_ref.generics)
+        })))
     }
 }
 

--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -91,6 +91,16 @@ pub fn recognize_callable_impl_proof(
     Some((item, target_kind))
 }
 
+/// The built-in `Fn*` impl of the given kind that we generate for this closure or function item.
+pub fn callable_virtual_impl<'a>(
+    def: &'a hax::FullDef<'_>,
+    target_kind: ClosureKind,
+) -> &'a hax::VirtualTraitImpl {
+    CallableFnImpls::from_def(def)
+        .and_then(|impls| impls.vimpl(target_kind))
+        .expect("expected a callable with a Fn* impl")
+}
+
 #[derive(Clone, Copy)]
 enum Callable<'a> {
     Closure(&'a hax::ClosureArgs),
@@ -390,6 +400,29 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             fn_mut_impl,
             fn_impl,
             signature,
+        })
+    }
+
+    /// The type of the `self` argument of the `call_*` method of the `Fn*` impl of this callable,
+    /// i.e. `&closure`, `&mut closure` or `closure` depending on the trait.
+    pub(crate) fn translate_callable_method_receiver_ty(
+        &mut self,
+        span: Span,
+        def: &hax::FullDef<'tcx>,
+        target_kind: ClosureKind,
+    ) -> Result<Ty, Error> {
+        let callable = CallableFnImpls::from_def(def)
+            .expect("callable expected")
+            .callable;
+        let state_ty = self.get_callable_state_ty(span, callable)?;
+        Ok(match target_kind {
+            ClosureKind::FnOnce => state_ty,
+            ClosureKind::Fn | ClosureKind::FnMut => {
+                let rid = self.the_only_binder().closure_call_method_region.unwrap();
+                let region = Region::Var(DeBruijnVar::new_at_zero(rid));
+                let mutability = RefKind::mutable(target_kind == ClosureKind::FnMut);
+                TyKind::Ref(region, state_ty, mutability).into_ty()
+            }
         })
     }
 

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -938,6 +938,9 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         kind: TransItemSourceKind,
         enqueue: bool,
     ) -> Result<RegionBinder<FnPtr>, Error> {
+        if let Some(fn_ptr) = self.translate_callable_method_fn_ptr(span, item)? {
+            return Ok(fn_ptr);
+        }
         if let Some(fn_ptr) = self.translate_method_decl_fn_ptr(span, item)? {
             return Ok(fn_ptr);
         }

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -80,9 +80,10 @@ pub enum TransItemSourceKind {
     /// The initializer function of the `VTableInstance`.
     VTableInstanceInitializer(TransImplSource),
     /// Shim function to store a method in a vtable; give a method with `self: Ptr<Self>` argument,
-    /// this takes a `Ptr<dyn Trait>` and forwards to the method. The `DefId` refers to the method
-    /// implementation.
-    VTableMethod,
+    /// this takes a `Ptr<dyn Trait>` and forwards to the method. For a `Normal` impl the `DefId`
+    /// refers to the method implementation; for a `Callable` one it refers to the closure or fn
+    /// item, whose `call_*` method has no `DefId` of its own.
+    VTableMethod(TransImplSource),
     /// The drop shim function to be used in the vtable as a field.
     VTableDropShim(TransImplSource),
 }
@@ -165,9 +166,11 @@ impl TransItemSource {
     /// not attempt to generally compute the parent of an item. Used to compute names.
     pub(crate) fn parent(&self) -> Option<Self> {
         let parent_kind = match self.kind {
-            TransItemSourceKind::CallableMethod(kind) => {
+            TransItemSourceKind::CallableMethod(kind)
+            | TransItemSourceKind::VTableMethod(TransImplSource::Callable(kind)) => {
                 TransItemSourceKind::TraitImpl(TransImplSource::Callable(kind))
             }
+            TransItemSourceKind::VTableMethod(..) => return None,
             TransItemSourceKind::DropGlueMethod(TransImplSource::Marker)
             | TransItemSourceKind::VTableInstance(TransImplSource::Marker)
             | TransItemSourceKind::VTableInstanceInitializer(TransImplSource::Marker)
@@ -347,7 +350,7 @@ impl<'tcx> TranslateCtx<'tcx> {
                     | ClosureAsFnCast
                     | DropGlueMethod(..)
                     | VTableInstanceInitializer(..)
-                    | VTableMethod
+                    | VTableMethod(..)
                     | VTableDropShim(..) => ItemId::Fun(self.translated.fun_decls.reserve_slot()),
                     InherentImpl | Module => return None,
                 };
@@ -744,6 +747,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                     )
                     | TransItemSourceKind::VTableDropShim(TransImplSource::Callable(..))
                     | TransItemSourceKind::CallableMethod(..)
+                    | TransItemSourceKind::VTableMethod(TransImplSource::Callable(..))
                     | TransItemSourceKind::ClosureAsFnCast = kind
                     {
                         generics.regions.extend(
@@ -756,7 +760,10 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 }
                 _ => {}
             }
-            if let TransItemSourceKind::CallableMethod(ClosureKind::FnMut | ClosureKind::Fn) = kind
+            if let TransItemSourceKind::CallableMethod(ClosureKind::FnMut | ClosureKind::Fn)
+            | TransItemSourceKind::VTableMethod(TransImplSource::Callable(
+                ClosureKind::FnMut | ClosureKind::Fn,
+            )) = kind
             {
                 generics.regions.push(self.translate_erased_region());
             }

--- a/charon/src/bin/charon-driver/translate/translate_generics.rs
+++ b/charon/src/bin/charon-driver/translate/translate_generics.rs
@@ -528,6 +528,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             | TransItemSourceKind::VTableInstanceInitializer(TransImplSource::Callable(..))
             | TransItemSourceKind::VTableDropShim(TransImplSource::Callable(..))
             | TransItemSourceKind::CallableMethod(..)
+            | TransItemSourceKind::VTableMethod(TransImplSource::Callable(..))
             | TransItemSourceKind::ClosureAsFnCast = kind
             {
                 self.the_only_binder_mut()
@@ -539,7 +540,9 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         | hax::FullDefKind::AssocFn { .. }
         | hax::FullDefKind::Closure { .. }
         | hax::FullDefKind::Ctor { .. } = def.kind()
-            && let TransItemSourceKind::CallableMethod(ClosureKind::Fn | ClosureKind::FnMut) = kind
+            && let TransItemSourceKind::CallableMethod(closure)
+            | TransItemSourceKind::VTableMethod(TransImplSource::Callable(closure)) = kind
+            && matches!(closure, ClosureKind::Fn | ClosureKind::FnMut)
         {
             // Add the lifetime generics coming from the method itself.
             let rid = self

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -214,11 +214,15 @@ impl<'tcx> TranslateCtx<'tcx> {
                     bt_ctx.translate_vtable_instance_init(id, item_meta, &def, impl_kind)?;
                 self.translated.fun_decls.set_slot(id, fun_decl);
             }
-            TransItemSourceKind::VTableMethod => {
+            &TransItemSourceKind::VTableMethod(impl_kind) => {
                 let Some(ItemId::Fun(id)) = trans_id else {
                     unreachable!()
                 };
-                let fun_decl = bt_ctx.translate_vtable_shim(id, item_meta, &def)?;
+                let fun_decl = if let TransImplSource::Callable(target_kind) = impl_kind {
+                    bt_ctx.translate_callable_vtable_shim(id, item_meta, &def, target_kind)?
+                } else {
+                    bt_ctx.translate_vtable_shim(id, item_meta, &def)?
+                };
                 self.translated.fun_decls.set_slot(id, fun_decl);
             }
             &TransItemSourceKind::VTableDropShim(impl_kind) => {

--- a/charon/src/bin/charon-driver/translate/translate_meta.rs
+++ b/charon/src/bin/charon-driver/translate/translate_meta.rs
@@ -437,7 +437,7 @@ impl<'tcx> TranslateCtx<'tcx> {
                 name.name
                     .push(PathElem::Ident("{vtable}".into(), Disambiguator::ZERO));
             }
-            TransItemSourceKind::VTableMethod => {
+            TransItemSourceKind::VTableMethod(..) => {
                 name.name.push(PathElem::Ident(
                     "{vtable_method}".into(),
                     Disambiguator::ZERO,

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -380,24 +380,9 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                             TransImplSource::ImplicitDestruct,
                         )?)
                     }
-                    hax::BuiltinTraitData::Other(
-                        li @ (hax::SolverTraitLangItem::FnOnce
-                        | hax::SolverTraitLangItem::FnMut
-                        | hax::SolverTraitLangItem::Fn),
-                    ) if let Some(hax::GenericArg::Type(callable_ty)) =
-                        impl_source.pred.hax_skip_binder_ref().generic_args.first()
-                        && let Some(item) = match callable_ty.kind() {
-                            hax::TyKind::Closure(closure_args) => Some(&closure_args.item),
-                            hax::TyKind::FnDef { item, .. } => Some(item),
-                            _ => None,
-                        } =>
+                    _ if let Some((item, closure_kind)) =
+                        super::translate_closures::recognize_callable_impl_proof(impl_source) =>
                     {
-                        let closure_kind = match li {
-                            hax::SolverTraitLangItem::FnOnce => ClosureKind::FnOnce,
-                            hax::SolverTraitLangItem::FnMut => ClosureKind::FnMut,
-                            hax::SolverTraitLangItem::Fn => ClosureKind::Fn,
-                            _ => unreachable!(),
-                        };
                         let binder =
                             self.translate_region_binder(span, &impl_source.pred, |ctx, _tref| {
                                 ctx.translate_callable_impl_ref(span, item, closure_kind)

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -187,6 +187,19 @@ pub struct VTableData {
     pub supertrait_map: IndexVec<TraitClauseId, Option<FieldId>>,
 }
 
+/// What we need to know about an impl to fill in its vtable.
+struct VTableInstanceData<'a> {
+    implemented_trait_ref: hax::TraitRef,
+    implied_trait_proofs: &'a [hax::TraitProof],
+    methods: VTableMethodSource<'a>,
+}
+
+/// Where the shims stored in a vtable's method fields come from.
+enum VTableMethodSource<'a> {
+    ImplItems(std::slice::Iter<'a, hax::ImplAssocItem>),
+    Callable(&'a hax::ItemRef, ClosureKind),
+}
+
 /// Generate the vtable struct.
 impl<'tcx> ItemTransCtx<'tcx, '_> {
     /// Query whether a trait is dyn compatible.
@@ -631,27 +644,22 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         };
         let ty = TyKind::Ref(Region::Static, vtbl_ty.clone(), RefKind::Shared).into_ty();
 
+        // If this is the built-in `Fn*` impl of a closure or function item, the vtable belongs to
+        // the virtual impl we generate for it, like the impl's own `vtable` field.
+        let callable_impl = super::translate_closures::recognize_callable_impl_proof(trait_proof);
+
         let kind = match &trait_proof.kind {
-            // The marker trait vtable translation pipeline would give incorrect results for these
-            // traits.
-            // FIXME(dyn): translate vtables for the closure traits
-            hax::TraitProofKind::Builtin {
-                trait_data:
-                    hax::BuiltinTraitData::Other(
-                        hax::SolverTraitLangItem::FnOnce
-                        | hax::SolverTraitLangItem::FnMut
-                        | hax::SolverTraitLangItem::Fn,
-                    ),
-                ..
-            } => ConstantExprKind::VTableRef(self.translate_trait_proof(span, trait_proof)?),
             hax::TraitProofKind::Concrete { .. } | hax::TraitProofKind::Builtin { .. } => {
                 // We could return `VTableRef` but we need to enqueue the translation of the static
                 // so may as well reuse that to normalize a bit.
                 let vtable_instance =
                     self.translate_region_binder(span, &trait_proof.pred, |ctx, tref| {
-                        let (impl_item, impl_kind) = match &trait_proof.kind {
-                            hax::TraitProofKind::Concrete(impl_item) => {
+                        let (impl_item, impl_kind) = match (&trait_proof.kind, callable_impl) {
+                            (hax::TraitProofKind::Concrete(impl_item), _) => {
                                 (impl_item, TransImplSource::Normal)
+                            }
+                            (_, Some((item, closure_kind))) => {
+                                (item, TransImplSource::Callable(closure_kind))
                             }
                             _ => (tref, TransImplSource::Marker),
                         };
@@ -734,14 +742,18 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         impl_def: &hax::FullDef<'tcx>,
         impl_kind: TransImplSource,
     ) -> Result<(Option<TraitImplRef>, TypeDeclRef), Error> {
-        let implemented_trait = match impl_def.kind() {
-            hax::FullDefKind::TraitImpl { trait_pred, .. } => {
+        let implemented_trait = match (impl_def.kind(), impl_kind) {
+            (hax::FullDefKind::TraitImpl { trait_pred, .. }, _) => {
                 assert_ne!(impl_kind, TransImplSource::Marker);
                 &trait_pred.trait_ref
             }
-            hax::FullDefKind::Trait { self_predicate, .. } => {
+            (hax::FullDefKind::Trait { self_predicate, .. }, _) => {
                 assert_eq!(impl_kind, TransImplSource::Marker);
                 &self_predicate.trait_ref
+            }
+            (_, TransImplSource::Callable(target_kind)) => {
+                let vimpl = super::translate_closures::callable_virtual_impl(impl_def, target_kind);
+                &vimpl.trait_pred.trait_ref
             }
             _ => unreachable!(),
         };
@@ -815,6 +827,95 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         })
     }
 
+    /// Gather what we need to fill in the vtable of this impl. See `VTableInstanceData`.
+    fn vtable_instance_data<'a>(
+        impl_def: &'a hax::FullDef<'tcx>,
+        impl_kind: TransImplSource,
+    ) -> VTableInstanceData<'a> {
+        if let TransImplSource::Callable(target_kind) = impl_kind {
+            let vimpl = super::translate_closures::callable_virtual_impl(impl_def, target_kind);
+            let callable = impl_def.this();
+            return VTableInstanceData {
+                implemented_trait_ref: vimpl.trait_pred.trait_ref.clone(),
+                implied_trait_proofs: &vimpl.implied_trait_proofs,
+                methods: VTableMethodSource::Callable(callable, target_kind),
+            };
+        }
+        match impl_def.kind() {
+            hax::FullDefKind::TraitImpl {
+                trait_pred,
+                items,
+                implied_trait_proofs,
+                ..
+            } => {
+                assert_ne!(impl_kind, TransImplSource::Marker);
+                VTableInstanceData {
+                    implemented_trait_ref: trait_pred.trait_ref.clone(),
+                    implied_trait_proofs,
+                    methods: VTableMethodSource::ImplItems(items.iter()),
+                }
+            }
+            hax::FullDefKind::Trait {
+                self_predicate,
+                implied_trait_proofs,
+                ..
+            } => {
+                assert_eq!(impl_kind, TransImplSource::Marker);
+                VTableInstanceData {
+                    implemented_trait_ref: self_predicate.trait_ref.clone(),
+                    implied_trait_proofs,
+                    methods: VTableMethodSource::ImplItems([].iter()),
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    /// The shim to store in the next method field of a vtable.
+    fn vtable_method_value(
+        &mut self,
+        span: Span,
+        trait_id: TraitDeclId,
+        method_id: TraitMethodId,
+        implemented_trait: &hax::TraitRef,
+        methods: &mut VTableMethodSource<'_>,
+    ) -> Result<VtableMethodValue, Error> {
+        match methods {
+            VTableMethodSource::ImplItems(items) => {
+                // Bit of a hack: we know the methods are in the right order. This is easier
+                // than trying to index into the items list by name.
+                for item in items.by_ref() {
+                    if let Some(value) = self.add_method_to_vtable_value(span, trait_id, item)? {
+                        return Ok(value);
+                    }
+                }
+                unreachable!("no impl item left for vtable method {method_id:?}")
+            }
+            &mut VTableMethodSource::Callable(callable, target_kind) => {
+                let shim = self.translate_fn_ptr(
+                    span,
+                    callable,
+                    TransItemSourceKind::VTableMethod(TransImplSource::Callable(target_kind)),
+                )?;
+                if !self.monomorphize() {
+                    return Ok(VtableMethodValue::Const(ConstantExprKind::FnPtr(shim)));
+                }
+                // In mono mode the vtable field is an erased pointer, so we must compute the real
+                // type of the shim to cast from.
+                let vtable_sig = self.callable_vtable_method_sig(implemented_trait)?;
+                let bound_sig = self.translate_region_binder(span, &vtable_sig, |ctx, sig| {
+                    ctx.translate_fun_sig(span, sig)
+                })?;
+                let method_ty = TyKind::FnPtr(bound_sig).into_ty();
+                let method_name = self
+                    .translated
+                    .assoc_item_name(trait_id, method_id)
+                    .to_string();
+                Ok(VtableMethodValue::Cast((method_name, method_ty, shim)))
+            }
+        }
+    }
+
     fn add_method_to_vtable_value(
         &mut self,
         span: Span,
@@ -835,8 +936,11 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         let vtable_value = match &item.value {
             Some(value) => {
                 let item_ref = &value.skip_binder.item;
-                let shim_ref =
-                    self.translate_fn_ptr(span, item_ref, TransItemSourceKind::VTableMethod)?;
+                let shim_ref = self.translate_fn_ptr(
+                    span,
+                    item_ref,
+                    TransItemSourceKind::VTableMethod(TransImplSource::Normal),
+                )?;
                 // In mono mode, we cannot get real types of shim functions by looking up the ones in `struct vtable`
                 // because they are erased function pointers.
                 // Therefore, below we compute real types that are used for casting.
@@ -850,7 +954,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                     self.translate_item_generics(
                         span,
                         &assoc_fun_def,
-                        &TransItemSourceKind::VTableMethod,
+                        &TransItemSourceKind::VTableMethod(TransImplSource::Normal),
                     )?;
                     let vtable_sig = match assoc_fun_def.kind() {
                         hax::FullDefKind::AssocFn {
@@ -902,19 +1006,11 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         vtable_struct_ref: TypeDeclRef,
         impl_kind: TransImplSource,
     ) -> Result<Body, Error> {
-        let (implemented_trait_ref, impl_items) = match impl_def.kind() {
-            hax::FullDefKind::TraitImpl {
-                trait_pred, items, ..
-            } => {
-                assert_ne!(impl_kind, TransImplSource::Marker);
-                (trait_pred.trait_ref.clone(), items.as_slice())
-            }
-            hax::FullDefKind::Trait { self_predicate, .. } => {
-                assert_eq!(impl_kind, TransImplSource::Marker);
-                (self_predicate.trait_ref.clone(), &[] as &[_])
-            }
-            _ => unreachable!(),
-        };
+        let VTableInstanceData {
+            implemented_trait_ref,
+            implied_trait_proofs,
+            mut methods,
+        } = Self::vtable_instance_data(impl_def, impl_kind);
 
         let trait_def = self.hax_def(&implemented_trait_ref)?;
         // We use `poly_trait_def` to fetch `implied_preds`, which is used to fetch supertrait in `prepare_vtable_fields`.
@@ -961,7 +1057,6 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
         // Construct a list with one operand per vtable field.
         let mut aggregate_fields = vec![];
-        let mut items_iter = impl_items.iter();
         for (field, ty) in vtable_data.fields.into_iter().zip(field_tys) {
             // In poly mode, all fields of vtables can be filled with const values.
             let mk_const = |kind| Operand::Const(ConstantExpr::new(kind, ty.clone()));
@@ -1064,34 +1159,21 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                         mk_const(ConstantExprKind::FnPtr(drop_shim))
                     }
                 }
-                TrVTableField::Method(..) => 'a: {
-                    // Bit of a hack: we know the methods are in the right order. This is easier
-                    // than trying to index into the items list by name.
-                    for item in items_iter.by_ref() {
-                        if let Some(kind) = self.add_method_to_vtable_value(span, trait_id, item)? {
-                            match kind {
-                                VtableMethodValue::Const(const_kind) => {
-                                    break 'a mk_const(const_kind);
-                                }
-                                VtableMethodValue::Cast(method) => break 'a mk_cast(method),
-                            }
-                        }
+                TrVTableField::Method(method_id, _) => {
+                    let value = self.vtable_method_value(
+                        span,
+                        trait_id,
+                        method_id,
+                        &implemented_trait_ref,
+                        &mut methods,
+                    )?;
+                    match value {
+                        VtableMethodValue::Const(const_kind) => mk_const(const_kind),
+                        VtableMethodValue::Cast(method) => mk_cast(method),
                     }
-                    unreachable!()
                 }
                 TrVTableField::SuperTrait(clause_id, _) => {
-                    let supertrait_proofs = match impl_def.kind() {
-                        hax::FullDefKind::TraitImpl {
-                            implied_trait_proofs,
-                            ..
-                        }
-                        | hax::FullDefKind::Trait {
-                            implied_trait_proofs,
-                            ..
-                        } => implied_trait_proofs,
-                        _ => unreachable!(),
-                    };
-                    let trait_proof = &supertrait_proofs[clause_id.index()];
+                    let trait_proof = &implied_trait_proofs[clause_id.index()];
                     Operand::Const(self.translate_vtable_instance_const(span, trait_proof)?)
                 }
             };
@@ -1142,7 +1224,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
         let body = match impl_kind {
             _ if item_meta.opacity.with_private_contents().is_opaque() => Body::Opaque,
-            TransImplSource::Marker | TransImplSource::Normal => {
+            TransImplSource::Marker | TransImplSource::Normal | TransImplSource::Callable(..) => {
                 self.gen_vtable_instance_init_body(span, impl_def, vtable_struct_ref, impl_kind)?
             }
             _ => {
@@ -1186,7 +1268,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         span: Span,
         target_receiver: &Ty,
         shim_signature: &FunSig,
-        impl_func_def: &hax::FullDef,
+        target_fn: FnPtr,
     ) -> Result<Body, Error> {
         let mut builder = BodyBuilder::new(span, shim_signature.inputs.len());
 
@@ -1213,10 +1295,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         );
         builder.push_statement(StatementKind::Assign(target_self.clone(), rval));
 
-        let fun_id = self.register_item(span, impl_func_def.this(), TransItemSourceKind::Fun);
-        let generics = self.outermost_binder().params.identity_args();
         builder.call(Call {
-            func: FnOperand::Regular(FnPtr::new(FnPtrKind::Fun(fun_id), generics)),
+            func: FnOperand::Regular(target_fn),
             args: method_args.into_iter().map(Operand::Move).collect(),
             dest: ret_place,
         });
@@ -1278,22 +1358,46 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
     ) -> Result<FunDecl, Error> {
         let span = item_meta.span;
 
-        let (dyn_self, trait_pred) = match impl_def.kind() {
-            hax::FullDefKind::TraitImpl {
-                dyn_self: Some(dyn_self),
-                trait_pred,
-                ..
-            } => {
+        // For a callable the def is the closure or fn item, whose virtual `Fn*` impl has no
+        // `dyn_self` field; we ask rustc for the `dyn Fn*<..>` type of the implemented trait ref.
+        let callable_dyn_self;
+        let (dyn_self, trait_pred) = match (impl_def.kind(), impl_kind) {
+            (
+                hax::FullDefKind::TraitImpl {
+                    dyn_self: Some(dyn_self),
+                    trait_pred,
+                    ..
+                },
+                _,
+            ) => {
                 assert_ne!(impl_kind, TransImplSource::Marker);
                 (dyn_self, trait_pred)
             }
-            hax::FullDefKind::Trait {
-                dyn_self: Some(dyn_self),
-                self_predicate,
-                ..
-            } => {
+            (
+                hax::FullDefKind::Trait {
+                    dyn_self: Some(dyn_self),
+                    self_predicate,
+                    ..
+                },
+                _,
+            ) => {
                 assert_eq!(impl_kind, TransImplSource::Marker);
                 (dyn_self, self_predicate)
+            }
+            (_, TransImplSource::Callable(target_kind)) => {
+                let trait_pred =
+                    &super::translate_closures::callable_virtual_impl(impl_def, target_kind)
+                        .trait_pred;
+                callable_dyn_self =
+                    hax::trait_ref_dyn_self(self.hax_state_with_id(), &trait_pred.trait_ref);
+                match &callable_dyn_self {
+                    Some(dyn_self) => (dyn_self, trait_pred),
+                    None => raise_error!(
+                        self,
+                        span,
+                        "Trying to generate a vtable drop shim for a non-dyn-compatible trait"
+                    ),
+                }
             }
             _ => {
                 raise_error!(
@@ -1372,7 +1476,78 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         let body = if item_meta.opacity.with_private_contents().is_opaque() {
             Body::Opaque
         } else {
-            self.translate_vtable_shim_body(span, &target_receiver, &signature, impl_func_def)?
+            let fun_id = self.register_item(span, impl_func_def.this(), TransItemSourceKind::Fun);
+            let target_fn = FnPtr::new(
+                FnPtrKind::Fun(fun_id),
+                self.outermost_binder().params.identity_args(),
+            );
+            self.translate_vtable_shim_body(span, &target_receiver, &signature, target_fn)?
+        };
+
+        Ok(FunDecl {
+            def_id: fun_id,
+            item_meta,
+            generics: self.into_generics(),
+            signature: Box::new(signature),
+            src: FunSource::VTableShim,
+            body,
+        })
+    }
+
+    /// The signature the `call`/`call_mut`/`call_once` shim of this `Fn*` trait ref must have,
+    /// i.e. with `Self` replaced by `dyn Fn*<..>`.
+    fn callable_vtable_method_sig(
+        &mut self,
+        trait_ref: &hax::TraitRef,
+    ) -> Result<hax::PolyFnSig, Error> {
+        let sigs = hax::virtual_impl_vtable_sigs(self.hax_state_with_id(), trait_ref);
+        Ok(sigs.into_iter().exactly_one()?.unwrap())
+    }
+
+    /// Same as `translate_vtable_shim`, for the `call`/`call_mut`/`call_once` method of the `Fn*`
+    /// impl we generate for a closure or fn item.
+    pub(crate) fn translate_callable_vtable_shim(
+        mut self,
+        fun_id: FunDeclId,
+        item_meta: ItemMeta,
+        def: &hax::FullDef<'tcx>,
+        target_kind: ClosureKind,
+    ) -> Result<FunDecl, Error> {
+        let span = item_meta.span;
+
+        let vimpl = super::translate_closures::callable_virtual_impl(def, target_kind);
+        let vtable_sig = self.callable_vtable_method_sig(&vimpl.trait_pred.trait_ref)?;
+
+        // The signature of the shim function. Its only late-bound region is the one of the
+        // `call`/`call_mut` method, for which we have a dedicated parameter.
+        let signature = {
+            let bound_sig = self.translate_region_binder(span, &vtable_sig, |ctx, sig| {
+                ctx.translate_fun_sig(span, sig)
+            })?;
+            bound_sig.apply(
+                self.the_only_binder()
+                    .closure_call_method_region
+                    .iter()
+                    .map(|r| Region::Var(DeBruijnVar::new_at_zero(*r)))
+                    .collect(),
+            )
+        };
+        // The concrete receiver we will cast to.
+        let target_receiver = self.translate_callable_method_receiver_ty(span, def, target_kind)?;
+
+        let body = if item_meta.opacity.with_private_contents().is_opaque() {
+            Body::Opaque
+        } else {
+            let fun_id = self.register_item(
+                span,
+                def.this(),
+                TransItemSourceKind::CallableMethod(target_kind),
+            );
+            let target_fn = FnPtr::new(
+                FnPtrKind::Fun(fun_id),
+                self.outermost_binder().params.identity_args(),
+            );
+            self.translate_vtable_shim_body(span, &target_receiver, &signature, target_fn)?
         };
 
         Ok(FunDecl {

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -885,7 +885,9 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                 // Bit of a hack: we know the methods are in the right order. This is easier
                 // than trying to index into the items list by name.
                 for item in items.by_ref() {
-                    if let Some(value) = self.add_method_to_vtable_value(span, trait_id, item)? {
+                    if let Some(value) =
+                        self.add_method_to_vtable_value(span, trait_id, implemented_trait, item)?
+                    {
                         return Ok(value);
                     }
                 }
@@ -920,6 +922,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         &mut self,
         span: Span,
         trait_id: TraitDeclId,
+        implemented_trait: &hax::TraitRef,
         item: &hax::ImplAssocItem,
     ) -> Result<Option<VtableMethodValue>, Error> {
         // Exit if the item isn't a vtable safe method.
@@ -933,61 +936,65 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         };
 
         // The method is vtable safe so it has no generics, hence we can skip the binder.
-        let vtable_value = match &item.value {
-            Some(value) => {
-                let item_ref = &value.skip_binder.item;
-                let shim_ref = self.translate_fn_ptr(
-                    span,
-                    item_ref,
-                    TransItemSourceKind::VTableMethod(TransImplSource::Normal),
-                )?;
-                // In mono mode, we cannot get real types of shim functions by looking up the ones in `struct vtable`
-                // because they are erased function pointers.
-                // Therefore, below we compute real types that are used for casting.
-                if self.monomorphize() {
-                    // Manually translate region params for dyn trait.
-                    // We create a new binding level by `translate_item_generics`
-                    // and restore the orginal one after computing `method_ty`.
-                    assert!(self.binding_levels.len() == 1);
-                    let orginal_binding = self.binding_levels.pop();
-                    let assoc_fun_def = self.hax_def(item_ref)?;
-                    self.translate_item_generics(
-                        span,
-                        &assoc_fun_def,
-                        &TransItemSourceKind::VTableMethod(TransImplSource::Normal),
-                    )?;
-                    let vtable_sig = match assoc_fun_def.kind() {
-                        hax::FullDefKind::AssocFn {
-                            vtable_sig: Some(vtable_sig),
-                            ..
-                        } => vtable_sig.clone(),
-                        _ => unreachable!("MONO: only assoc fun is supported"),
-                    };
-
-                    let signature = self.translate_fun_sig(span, &vtable_sig.value)?;
-                    // Add regions. this is ad-hoc...
-                    let method_ty = Ty::new(TyKind::FnPtr(RegionBinder {
-                        regions: self.outermost_generics().regions.clone(),
-                        skip_binder: signature,
-                    }));
-
-                    // Restore the orignal binding_levels.
-                    self.binding_levels.pop();
-                    if let Some(binding_level) = orginal_binding {
-                        self.binding_levels.push(binding_level);
-                    }
-
-                    let method_id = self.translate_trait_method_id(trait_id, item.decl_def_id())?;
-                    let method_name = self.translated.assoc_item_name(trait_id, method_id);
-
-                    VtableMethodValue::Cast((method_name.to_string(), method_ty, shim_ref))
-                } else {
-                    VtableMethodValue::Const(ConstantExprKind::FnPtr(shim_ref))
-                }
+        let item_ref = match &item.value {
+            Some(value) => value.skip_binder.item.clone(),
+            None => {
+                let hax_state = self.hax_state_with_id();
+                let trait_args = implemented_trait.rustc_args(hax_state);
+                hax::ItemRef::translate_from_hax_def_id(
+                    hax_state,
+                    item.decl_def_id.clone(),
+                    trait_args,
+                )
             }
-            None => VtableMethodValue::Const(ConstantExprKind::Opaque(
-                "shim for default methods aren't yet supported".into(),
-            )),
+        };
+        let shim_ref = self.translate_fn_ptr(
+            span,
+            &item_ref,
+            TransItemSourceKind::VTableMethod(TransImplSource::Normal),
+        )?;
+        // In mono mode, we cannot get real types of shim functions by looking up the ones in
+        // `struct vtable` because they are erased function pointers.
+        // Therefore, below we compute real types that are used for casting.
+        let vtable_value = if self.monomorphize() {
+            // Manually translate region params for dyn trait.
+            // We create a new binding level by `translate_item_generics`
+            // and restore the orginal one after computing `method_ty`.
+            assert!(self.binding_levels.len() == 1);
+            let orginal_binding = self.binding_levels.pop();
+            let assoc_fun_def = self.hax_def(&item_ref)?;
+            self.translate_item_generics(
+                span,
+                &assoc_fun_def,
+                &TransItemSourceKind::VTableMethod(TransImplSource::Normal),
+            )?;
+            let vtable_sig = match assoc_fun_def.kind() {
+                hax::FullDefKind::AssocFn {
+                    vtable_sig: Some(vtable_sig),
+                    ..
+                } => vtable_sig.clone(),
+                _ => unreachable!("MONO: only assoc fun is supported"),
+            };
+
+            let signature = self.translate_fun_sig(span, &vtable_sig.value)?;
+            // Add regions. this is ad-hoc...
+            let method_ty = Ty::new(TyKind::FnPtr(RegionBinder {
+                regions: self.outermost_generics().regions.clone(),
+                skip_binder: signature,
+            }));
+
+            // Restore the orignal binding_levels.
+            self.binding_levels.pop();
+            if let Some(binding_level) = orginal_binding {
+                self.binding_levels.push(binding_level);
+            }
+
+            let method_id = self.translate_trait_method_id(trait_id, item.decl_def_id())?;
+            let method_name = self.translated.assoc_item_name(trait_id, method_id);
+
+            VtableMethodValue::Cast((method_name.to_string(), method_ty, shim_ref))
+        } else {
+            VtableMethodValue::Const(ConstantExprKind::FnPtr(shim_ref))
         };
 
         Ok(Some(vtable_value))

--- a/charon/src/transform/normalize/transform_dyn_trait_calls.rs
+++ b/charon/src/transform/normalize/transform_dyn_trait_calls.rs
@@ -54,10 +54,27 @@ fn transform_dyn_trait_call(
     };
     supertrait_path.reverse();
 
+    // The drop glue of the `Destruct` implied clause is the drop function, which
+    // we must manually desugar, because `Destruct` is not dyn-compatible.
+    let is_drop_glue = ctx
+        .ctx
+        .translated
+        .trait_decls
+        .get(trait_ref.trait_id())
+        .and_then(|decl| decl.item_meta.lang_item.as_ref())
+        == Some(&from_rustc::LangItem::Destruct);
+
+    let (vtable_tref, target_field) = if is_drop_glue {
+        supertrait_path.clear(); // we actually don't need to go up; the drop is here!
+        (dyn_proof, VTableField::Drop)
+    } else {
+        (trait_ref, VTableField::Method(*method_id))
+    };
+
     // Get the type of the vtable struct.
     let vtable_decl_ref: TypeDeclRef = {
         // Get the trait declaration by its ID
-        let Some(trait_decl) = ctx.ctx.translated.trait_decls.get(trait_ref.trait_id()) else {
+        let Some(trait_decl) = ctx.ctx.translated.trait_decls.get(vtable_tref.trait_id()) else {
             return Ok(()); // Unknown trait
         };
         // Get vtable ref from definition for correct ID.
@@ -66,10 +83,10 @@ fn transform_dyn_trait_call(
                 ctx.ctx,
                 ctx.span,
                 "Found a `dyn Trait` method call for non-dyn-compatible trait `{}`!",
-                trait_ref.trait_id().with_ctx(fmt_ctx)
+                vtable_tref.trait_id().with_ctx(fmt_ctx)
             );
         };
-        vtable_ty.clone().substitute_with_tref(trait_ref)
+        vtable_ty.clone().substitute_with_tref(vtable_tref)
     };
 
     let Some(vtable_decl) = ctx.ctx.translated.type_decls.get(vtable_decl_ref.id) else {
@@ -82,10 +99,10 @@ fn transform_dyn_trait_call(
     let TypeSource::VTable { field_map, .. } = &vtable_decl.src else {
         return Ok(()); // Weird
     };
-    // Retrieve the method field from the vtable struct definition.
+    // Retrieve the target field from the vtable struct definition.
     let Some((method_field_id, _)) = field_map
         .iter_enumerated()
-        .find(|(_, field)| **field == VTableField::Method(*method_id))
+        .find(|(_, field)| **field == target_field)
     else {
         let vtable_name = vtable_decl_ref.id.with_ctx(fmt_ctx).to_string();
         raise_error!(

--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -211,6 +211,8 @@ impl TypeCheckVisitor<'_> {
             }
             // Can happen with `Box`, where the RHS is `Box`. FIXME(#1163): check for Box here.
             (TyKind::DynTrait(..), TyKind::Adt(..)) => {}
+            // The vtable shim of the `Fn*` impl of a function item concretizes to the function item type.
+            (TyKind::DynTrait(..), TyKind::FnDef(..)) => {}
             _ => {
                 let fmt = &self.ctx.into_fmt();
                 self.error(format!(

--- a/charon/tests/ui/dyn/dyn-drop-glue-through-vtable-mono.out
+++ b/charon/tests/ui/dyn/dyn-drop-glue-through-vtable-mono.out
@@ -1,0 +1,97 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+struct test_crate::T::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+// Full name: test_crate::T
+trait T<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Destruct)
+    vtable: test_crate::T::{vtable}
+}
+
+// Full name: core::ptr::drop_glue::<(dyn T)>
+#[lang_item(DropGlue)]
+unsafe fn drop_glue::<(dyn T)><'_0>(_1: &'_0 mut (dyn T))
+{
+    let ret: (); // return
+    let _1: &'_0 mut (dyn T + '0); // arg #1
+    let drop_arg: &'_ mut (dyn T + '2); // local
+    let drop_ret: (); // local
+    let _4: unsafe fn(&'_ mut (dyn T + '2)); // anonymous local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(drop_arg)
+    drop_arg = &mut (*_1) with_metadata(copy _1.metadata)
+    storage_live(drop_ret)
+    storage_live(_4)
+    _4 = cast<*const (), unsafe fn(&'_ mut (dyn T + '2))>(copy (*drop_arg.metadata).drop)
+    drop_ret = (copy _4)(move drop_arg)
+    ↳⚡ unwind_continue
+    return
+}
+
+// Full name: core::ptr::drop_in_place::<(dyn T)>
+#[diagnostic_item("ptr_drop_in_place")]
+pub unsafe fn drop_in_place::<(dyn T)>(to_drop: *mut (dyn T))
+{
+    let _0: (); // return
+    let to_drop: *mut (dyn T + '0); // arg #1
+    let _2: &'3 mut (dyn T + '4); // anonymous local
+    let _3: &'5 mut (dyn T + '6); // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(_2)
+    storage_live(_3)
+    _3 = &mut (*to_drop) with_metadata(copy to_drop.metadata)
+    _2 = &two-phase-mut (*_3) with_metadata(copy _3.metadata)
+    _0 = drop_glue::<(dyn T)><'10>(move _2)
+    ↳⚡ unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    return
+}
+
+// Full name: test_crate::f
+unsafe fn f(p: *mut (dyn T + 'static))
+{
+    let _0: (); // return
+    let p: *mut (dyn T + '2); // arg #1
+    let _2: *mut (dyn T + '3); // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(_2)
+    _2 = copy p
+    _0 = drop_in_place::<(dyn T)>(move _2)
+    ↳⚡ unwind_continue
+    storage_dead(_2)
+    return
+}
+
+
+

--- a/charon/tests/ui/dyn/dyn-drop-glue-through-vtable-mono.rs
+++ b/charon/tests/ui/dyn/dyn-drop-glue-through-vtable-mono.rs
@@ -1,0 +1,8 @@
+//@ no-default-options
+//@ charon-args=--monomorphize --precise-drops --desugar-drops --include core::ptr::drop_in_place
+
+trait T {}
+
+unsafe fn f(p: *mut dyn T) {
+    std::ptr::drop_in_place(p)
+}

--- a/charon/tests/ui/dyn/dyn-drop-glue-through-vtable.out
+++ b/charon/tests/ui/dyn/dyn-drop-glue-through-vtable.out
@@ -1,0 +1,284 @@
+# Final LLBC before serialization:
+
+// Full name: core::alloc::layout::Layout
+#[lang_item(AllocLayout)]
+pub opaque type Layout
+
+// Full name: core::alloc::AllocError
+pub struct AllocError {}
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+// Full name: core::alloc::AllocError::{impl Destruct for AllocError}::drop_glue
+unsafe fn impl_Destruct_for_AllocError::drop_glue<'_0>(_1: &'_0 mut AllocError)
+= <opaque>
+
+// Full name: core::alloc::AllocError::{impl Destruct for AllocError}
+impl "impl_Destruct_for_AllocError" Destruct for AllocError {
+    fn drop_glue<'_0_1> = impl_Destruct_for_AllocError::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+// Full name: {impl Destruct for [T]}::drop_glue
+unsafe fn impl_Destruct_for_slice::drop_glue<'_0, T>(_1: &'_0 mut [T])
+where
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
+    TypeOutlives0: T: '_0,
+{
+    let _0: (); // return
+    let _1: &'1 mut [T]; // arg #1
+    let _2: usize; // anonymous local
+    let _3: usize; // anonymous local
+    let _4: *mut T; // anonymous local
+    let _5: bool; // anonymous local
+    let _6: *mut T; // anonymous local
+    let _7: bool; // anonymous local
+    let drop_arg_8: &'_ mut T; // local
+    let drop_ret_9: (); // local
+    let drop_arg_10: &'_ mut T; // local
+    let drop_ret_11: (); // local
+
+    storage_live(_0)
+    storage_live(_2)
+    storage_live(_3)
+    storage_live(_4)
+    storage_live(_5)
+    storage_live(_6)
+    storage_live(_7)
+    _0 = ()
+    _2 = copy _1.metadata
+    _3 = const 0usize
+    loop {
+        _7 = copy _3 == copy _2
+        if move _7 {
+            break 0
+        } else {
+            _6 = &raw mut (*_1)[copy _3]
+            _3 = move _3 wrap.+ const 1usize
+            storage_live(drop_arg_8)
+            drop_arg_8 = &mut (*_6)
+            storage_live(drop_ret_9)
+            drop_ret_9 = TraitClause1::drop_glue<'2>(move drop_arg_8)
+            ↳⚡ loop {
+                    _5 = copy _3 == copy _2
+                    if move _5 {
+                        break 0
+                    } else {
+                        _4 = &raw mut (*_1)[copy _3]
+                        _3 = move _3 wrap.+ const 1usize
+                        storage_live(drop_arg_10)
+                        drop_arg_10 = &mut (*_4)
+                        storage_live(drop_ret_11)
+                        drop_ret_11 = TraitClause1::drop_glue<'3>(move drop_arg_10)
+                        ↳⚡ unwind_terminate
+                        continue 0
+                    }
+                }
+                unwind_continue
+            continue 0
+        }
+    }
+    return
+}
+
+// Full name: {impl Destruct for [T]}
+impl<T> "impl_Destruct_for_slice" Destruct for [T]
+where
+    TraitClause0: (T: Sized),
+    TraitClause1: (T: Destruct),
+{
+    fn drop_glue<'_0_1> = impl_Destruct_for_slice::drop_glue<'_0_1, T>[TraitClause0, TraitClause1]
+    non-dyn-compatible
+}
+
+// Full name: core::result::Result
+#[diagnostic_item("Result")]
+pub enum Result<T, E>
+where
+    TraitClause0: (T: Sized),
+    TraitClause1: (E: Sized),
+    TraitClause2: (T: Destruct),
+    TraitClause3: (E: Destruct),
+{
+  Ok { _0: T },
+  Err { _0: E },
+}
+
+// Full name: core::ptr::non_null::NonNull
+#[diagnostic_item("NonNull")]
+pub opaque type NonNull<T>
+where
+    TraitClause0: (T: Destruct),
+
+// Full name: core::ptr::non_null::NonNull::{impl Destruct for NonNull<T>[TraitClause0]}::drop_glue
+unsafe fn impl_Destruct_for_NonNull::drop_glue<'_0, T>(_1: &'_0 mut NonNull<T>[TraitClause0])
+where
+    TraitClause0: (T: Destruct),
+    TypeOutlives0: T: '_0,
+= <opaque>
+
+// Full name: core::ptr::non_null::NonNull::{impl Destruct for NonNull<T>[TraitClause0]}
+impl<T> "impl_Destruct_for_NonNull" Destruct for NonNull<T>[TraitClause0]
+where
+    TraitClause0: (T: Destruct),
+{
+    fn drop_glue<'_0_1> = impl_Destruct_for_NonNull::drop_glue<'_0_1, T>[TraitClause0]
+    non-dyn-compatible
+}
+
+// Full name: core::alloc::Allocator
+pub trait Allocator<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Destruct)
+    fn allocate<'_0_1>;
+    fn deallocate<'_0_1>;
+    vtable: core::alloc::Allocator::{vtable}
+}
+
+// Full name: alloc::alloc::Global
+#[lang_item(GlobalAlloc)]
+pub struct Global {}
+
+// Full name: alloc::alloc::Global::{impl Destruct for Global}::drop_glue
+unsafe fn impl_Destruct_for_Global::drop_glue<'_0>(_1: &'_0 mut Global)
+= <opaque>
+
+// Full name: alloc::alloc::Global::{impl Destruct for Global}
+impl "impl_Destruct_for_Global" Destruct for Global {
+    fn drop_glue<'_0_1> = impl_Destruct_for_Global::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: alloc::alloc::{impl Allocator for Global}::deallocate
+#[track_caller]
+pub unsafe fn deallocate<'_0>(_1: &'_0 Global, _2: NonNull<u8>[{built_in impl Destruct for u8}], _3: Layout)
+= <opaque>
+
+// Full name: alloc::alloc::{impl Allocator for Global}::allocate
+#[track_caller]
+pub fn allocate<'_0>(_1: &'_0 Global, _2: Layout) -> Result<NonNull<[u8]>[impl_Destruct_for_slice<u8>[{built_in impl Sized for u8}, {built_in impl Destruct for u8}]], AllocError>[{built_in impl Sized for NonNull<[u8]>[impl_Destruct_for_slice<u8>[{built_in impl Sized for u8}, {built_in impl Destruct for u8}]]}, {built_in impl Sized for AllocError}, impl_Destruct_for_NonNull<[u8]>[impl_Destruct_for_slice<u8>[{built_in impl Sized for u8}, {built_in impl Destruct for u8}]], impl_Destruct_for_AllocError]
+= <opaque>
+
+// Full name: alloc::alloc::{impl Allocator for Global}
+impl "impl_Allocator_for_Global" Allocator for Global {
+    proof ImpliedClause0: (Global: MetaSized) = {built_in impl MetaSized for Global}
+    proof ImpliedClause1: (Global: Destruct) = impl_Destruct_for_Global
+    fn allocate<'_0_1> = allocate<'_0_1>
+    fn deallocate<'_0_1> = deallocate<'_0_1>
+    vtable: impl_Allocator_for_Global::{vtable}
+}
+
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T, A>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (A: Allocator),
+    TraitClause3: (T: Destruct),
+    TraitClause4: (A: Destruct),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4])
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TraitClause2: (A: Allocator),
+    TraitClause3: (T: Destruct),
+    TraitClause4: (A: Destruct),
+    TypeOutlives0: T: '_0,
+    TypeOutlives1: A: '_0,
+= <opaque>
+
+struct test_crate::T::{vtable} {
+  size: usize,
+  align: usize,
+  drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn T)),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+// Full name: test_crate::T
+trait T<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: Destruct)
+    vtable: test_crate::T::{vtable}
+}
+
+// Full name: test_crate::A
+struct A {
+  _0: (dyn T + 'static),
+}
+
+// Full name: test_crate::A::{impl Destruct for A}::drop_glue
+unsafe fn impl_Destruct_for_A::drop_glue<'_0>(_1: &'_0 mut A)
+{
+    let _0: (); // return
+    let _1: &'1 mut A; // arg #1
+    let drop_arg: &'_ mut (dyn T + '6); // local
+    let drop_ret: (); // local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(drop_arg)
+    drop_arg = &mut (*_1)._0 with_metadata(copy _1.metadata)
+    storage_live(drop_ret)
+    drop_ret = (copy (*drop_arg.metadata).drop)(move drop_arg)
+    ↳⚡ unwind_continue
+    return
+}
+
+// Full name: test_crate::A::{impl Destruct for A}
+impl "impl_Destruct_for_A" Destruct for A {
+    fn drop_glue<'_0_1> = impl_Destruct_for_A::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::f
+fn f(_1: Box<A, Global>[{built_in impl MetaSized for A}, {built_in impl Sized for Global}, impl_Allocator_for_Global, impl_Destruct_for_A, impl_Destruct_for_Global])
+{
+    let _0: (); // return
+    let _1: Box<A, Global>[{built_in impl MetaSized for A}, {built_in impl Sized for Global}, impl_Allocator_for_Global, impl_Destruct_for_A, impl_Destruct_for_Global]; // arg #1
+    let drop_arg: &'_ mut Box<A, Global>[{built_in impl MetaSized for A}, {built_in impl Sized for Global}, impl_Allocator_for_Global, impl_Destruct_for_A, impl_Destruct_for_Global]; // local
+    let drop_ret: (); // local
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    storage_live(drop_arg)
+    drop_arg = &mut _1
+    storage_live(drop_ret)
+    drop_ret = impl_Destruct_for_Box::drop_glue<'0, A, Global>[{built_in impl MetaSized for A}, {built_in impl Sized for Global}, impl_Allocator_for_Global, impl_Destruct_for_A, impl_Destruct_for_Global](move drop_arg)
+    ↳⚡ unwind_continue
+    return
+}
+
+
+

--- a/charon/tests/ui/dyn/dyn-drop-glue-through-vtable.rs
+++ b/charon/tests/ui/dyn/dyn-drop-glue-through-vtable.rs
@@ -1,0 +1,8 @@
+//@ no-default-options
+//@ charon-args=--precise-drops --desugar-drops
+
+trait T {}
+
+struct A(dyn T);
+
+fn f(_: Box<A>) {}

--- a/charon/tests/ui/dyn/dyn-fn.out
+++ b/charon/tests/ui/dyn/dyn-fn.out
@@ -16,6 +16,11 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+fn core::marker::MetaSized::{vtable}<Self>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}<Self>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}<Self>()
+
 struct () {}
 
 // Full name: core::marker::Destruct
@@ -150,6 +155,13 @@ fn takes_fn<'_0>(f: &'_0 (dyn for<'a> Fn<(&'a mut u32,), ImpliedClause1::Implied
     return
 }
 
+// Full name: test_crate::gives_fn::{impl FnMut<(&'_ mut u32,)> for closure}::{vtable}
+fn impl_FnMut_tuple_for_closure::{vtable}<'_0>() -> core::ops::function::FnMut::{vtable}<(&'_ mut u32,), bool>
+= <opaque>
+
+// Full name: test_crate::gives_fn::{impl FnMut<(&'_ mut u32,)> for closure}::{vtable}
+static impl_FnMut_tuple_for_closure::{vtable}<'_0>: core::ops::function::FnMut::{vtable}<(&'_ mut u32,), bool> = impl_FnMut_tuple_for_closure::{vtable}<'_0>()
+
 // Full name: test_crate::gives_fn::closure
 struct closure {}
 
@@ -176,6 +188,91 @@ fn call<'_0, '_1>(_1: &'_1 closure, tupled_args: (&'_0 mut u32,)) -> bool
     return
 }
 
+// Full name: test_crate::gives_fn::{impl Fn<(&'_ mut u32,)> for closure}::{vtable_method}
+extern "rust-call" fn {vtable_method}<'_0, '_1>(_1: &'_1 (dyn Fn<(&'_ mut u32,), ImpliedClause1::ImpliedClause1::Output = bool>), _2: (&'_ mut u32,)) -> bool
+{
+    let _0: bool; // return
+    let _1: &'_1 (dyn Fn<(&'0 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '1); // arg #1
+    let _2: (&'5 mut u32,); // arg #2
+    let _3: &'_1 closure; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_1 (dyn Fn<(&'6 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '7), &'_1 closure>(move _1)
+    _0 = call<'_0, '_1>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::gives_fn::closure::{impl Destruct for closure}::drop_glue
+unsafe fn drop_glue<'_0>(_1: &'_0 mut closure)
+{
+    let _0: (); // return
+    let _1: &'1 mut closure; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::gives_fn::{impl Fn<(&'_ mut u32,)> for closure}::{vtable_drop_shim}
+unsafe fn {vtable_drop_shim}<'_0, '_1>(dyn_self: &'_1 mut (dyn Fn<(&'_ mut u32,), ImpliedClause1::ImpliedClause1::Output = bool>))
+{
+    let ret: (); // return
+    let dyn_self: &'_1 mut (dyn Fn<(&'0 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '1); // arg #1
+    let target_self: &'_1 mut closure; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_1 mut (dyn Fn<(&'5 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '6), &'_1 mut closure>(move dyn_self)
+    drop[drop_glue<'15>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::gives_fn::{impl Fn<(&'_ mut u32,)> for closure}::{vtable}
+fn impl_Fn_tuple_for_closure::{vtable}<'_0>() -> core::ops::function::Fn::{vtable}<(&'_ mut u32,), bool>
+{
+    let ret: core::ops::function::Fn::{vtable}<(&'0 mut u32,), bool>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(&'4 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '5)); // anonymous local
+    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(&'10 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '11), (&'15 mut u32,)) -> bool; // anonymous local
+    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _6: &'static core::ops::function::FnMut::{vtable}<(&'35 mut u32,), bool>; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<closure>
+    storage_live(align)
+    align = align_of<closure>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {vtable_drop_shim}<'_0, '3>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(&'4 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '5))>(const {vtable_drop_shim}<'_0, '3>)
+    storage_live(_4)
+    _4 = cast<for<'_0_1> {vtable_method}<'_0, '9>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(&'10 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '11), (&'15 mut u32,)) -> bool>(const {vtable_method}<'_0, '9>)
+    storage_live(_5)
+    _5 = &core::marker::MetaSized::{vtable}<closure>
+    storage_live(_6)
+    _6 = &impl_FnMut_tuple_for_closure::{vtable}<'_0>
+    ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move _3, method_call: move _4, super_trait_0: move _5, super_trait_1: move _6 }
+    return
+}
+
+// Full name: test_crate::gives_fn::{impl Fn<(&'_ mut u32,)> for closure}::{vtable}
+static impl_Fn_tuple_for_closure::{vtable}<'_0>: core::ops::function::Fn::{vtable}<(&'_ mut u32,), bool> = impl_Fn_tuple_for_closure::{vtable}<'_0>()
+
 // Full name: test_crate::gives_fn::{impl FnMut<(&'_ mut u32,)> for closure}::call_mut
 fn call_mut<'_0, '_1>(state: &'_1 mut closure, args: (&'_0 mut u32,)) -> bool
 {
@@ -195,18 +292,6 @@ fn call_mut<'_0, '_1>(state: &'_1 mut closure, args: (&'_0 mut u32,)) -> bool
     storage_dead(_3)
     storage_dead(args)
     storage_dead(state)
-    return
-}
-
-// Full name: test_crate::gives_fn::closure::{impl Destruct for closure}::drop_glue
-unsafe fn drop_glue<'_0>(_1: &'_0 mut closure)
-{
-    let _0: (); // return
-    let _1: &'1 mut closure; // arg #1
-
-    storage_live(_0)
-    _0 = ()
-    storage_dead(_1)
     return
 }
 
@@ -300,7 +385,7 @@ fn gives_fn()
     _4 = move _5
     _3 = &(*_4)
     _2 = &(*_3)
-    _1 = unsize_cast<&'11 closure, &'15 (dyn for<'a> Fn<(&'a mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '16), &vtable_of(impl_Fn_tuple_for_closure<'21>)>(move _2)
+    _1 = unsize_cast<&'11 closure, &'15 (dyn for<'a> Fn<(&'a mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '16), &impl_Fn_tuple_for_closure::{vtable}<'21>>(move _2)
     storage_dead(_2)
     _0 = takes_fn<'24>(move _1)
     ↳⚡ storage_dead(_4)

--- a/charon/tests/ui/dyn/dyn-sized.out
+++ b/charon/tests/ui/dyn/dyn-sized.out
@@ -1,5 +1,5 @@
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:233:14:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:246:14:
 trait should be dyn-compatible
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: Thread panicked when extracting item `test_crate::DynSized`.

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.out
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.out
@@ -110,315 +110,12 @@ struct (_,)<A> {
   _0: A,
 }
 
-// Full name: test_crate::takes_fn
-fn takes_fn<'_0>(_1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '_0))
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
 {
-    let _0: (); // return
-    let _1: &'3 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4); // arg #1
-
-    storage_live(_0)
-    _0 = ()
-    _0 = ()
-    storage_dead(_1)
-    return
-}
-
-// Full name: test_crate::some_fn
-fn some_fn(x: u32) -> u32
-{
-    let _0: u32; // return
-    let x: u32; // arg #1
-
-    storage_live(_0)
-    _0 = copy x
-    storage_dead(x)
-    return
-}
-
-// Full name: test_crate::{impl FnOnce<(u32,)> for some_fn}::call_once
-fn {impl FnOnce<(u32,)> for some_fn}::call_once(state: some_fn, args: (u32,)) -> u32
-{
-    let _0: u32; // return
-    let state: some_fn; // arg #1
-    let args: (u32,); // arg #2
-
-    storage_live(_0)
-    _0 = some_fn(move args._0)
-    ↳⚡ storage_dead(args)
-        storage_dead(state)
-        unwind_continue
-    storage_dead(args)
-    storage_dead(state)
-    return
-}
-
-// Full name: test_crate::{impl FnOnce<(u32,)> for some_fn}::{vtable_method}
-extern "rust-call" fn {impl FnOnce<(u32,)> for some_fn}::{vtable_method}(_1: (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
-{
-    let _0: u32; // return
-    let _1: (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
-    let _2: (u32,); // arg #2
-    let _3: some_fn; // anonymous local
-
-    storage_live(_0)
-    storage_live(_3)
-    _3 = concretize<(dyn FnOnce<(u32,), Output = u32> + '1), some_fn>(move _1)
-    _0 = {impl FnOnce<(u32,)> for some_fn}::call_once(move _3, move _2)
-    ↳⚡ storage_dead(_3)
-        storage_dead(_2)
-        storage_dead(_1)
-        unwind_continue
-    storage_dead(_3)
-    storage_dead(_2)
-    storage_dead(_1)
-    return
-}
-
-// Full name: test_crate::{impl FnOnce<(u32,)> for some_fn}::{vtable_drop_shim}
-unsafe fn {impl FnOnce<(u32,)> for some_fn}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32>))
-{
-    let ret: (); // return
-    let dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
-    let target_self: &'_0 mut some_fn; // local
-
-    storage_live(ret)
-    ret = ()
-    storage_live(target_self)
-    target_self = concretize<&'_0 mut (dyn FnOnce<(u32,), Output = u32> + '1), &'_0 mut some_fn>(move dyn_self)
-    storage_dead(target_self)
-    storage_dead(dyn_self)
-    return
-}
-
-// Full name: test_crate::{impl FnOnce<(u32,)> for some_fn}::{vtable}
-fn {impl FnOnce<(u32,)> for some_fn}::{vtable}() -> core::ops::function::FnOnce::{vtable}<(u32,), u32>
-{
-    let ret: core::ops::function::FnOnce::{vtable}<(u32,), u32>; // return
-    let size: usize; // local
-    let align: usize; // local
-    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(u32,), Output = u32> + '1)); // anonymous local
-    let _4: extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32; // anonymous local
-    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
-
-    storage_live(ret)
-    storage_live(size)
-    size = size_of<some_fn>
-    storage_live(align)
-    align = align_of<some_fn>
-    storage_live(_3)
-    _3 = cast<for<'_0_1> {impl FnOnce<(u32,)> for some_fn}::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(u32,), Output = u32> + '1))>(const {impl FnOnce<(u32,)> for some_fn}::{vtable_drop_shim}<'0>)
-    storage_live(_4)
-    _4 = cast<{impl FnOnce<(u32,)> for some_fn}::{vtable_method}, extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32>(const {impl FnOnce<(u32,)> for some_fn}::{vtable_method})
-    storage_live(_5)
-    _5 = &core::marker::MetaSized::{vtable}<some_fn>
-    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: move _5 }
-    return
-}
-
-// Full name: test_crate::{impl FnOnce<(u32,)> for some_fn}::{vtable}
-static {impl FnOnce<(u32,)> for some_fn}::{vtable}: core::ops::function::FnOnce::{vtable}<(u32,), u32> = {impl FnOnce<(u32,)> for some_fn}::{vtable}()
-
-// Full name: test_crate::{impl FnMut<(u32,)> for some_fn}::call_mut
-fn {impl FnMut<(u32,)> for some_fn}::call_mut<'_0>(state: &'_0 mut some_fn, args: (u32,)) -> u32
-{
-    let _0: u32; // return
-    let state: &'_0 mut some_fn; // arg #1
-    let args: (u32,); // arg #2
-
-    storage_live(_0)
-    _0 = some_fn(move args._0)
-    ↳⚡ storage_dead(args)
-        storage_dead(state)
-        unwind_continue
-    storage_dead(args)
-    storage_dead(state)
-    return
-}
-
-// Full name: test_crate::{impl FnMut<(u32,)> for some_fn}::{vtable_method}
-extern "rust-call" fn {impl FnMut<(u32,)> for some_fn}::{vtable_method}<'_0>(_1: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
-{
-    let _0: u32; // return
-    let _1: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
-    let _2: (u32,); // arg #2
-    let _3: &'_0 mut some_fn; // anonymous local
-
-    storage_live(_0)
-    storage_live(_3)
-    _3 = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut some_fn>(move _1)
-    _0 = {impl FnMut<(u32,)> for some_fn}::call_mut<'_0>(move _3, move _2)
-    ↳⚡ storage_dead(_3)
-        storage_dead(_2)
-        storage_dead(_1)
-        unwind_continue
-    storage_dead(_3)
-    storage_dead(_2)
-    storage_dead(_1)
-    return
-}
-
-// Full name: test_crate::{impl FnMut<(u32,)> for some_fn}::{vtable_drop_shim}
-unsafe fn {impl FnMut<(u32,)> for some_fn}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>))
-{
-    let ret: (); // return
-    let dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
-    let target_self: &'_0 mut some_fn; // local
-
-    storage_live(ret)
-    ret = ()
-    storage_live(target_self)
-    target_self = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut some_fn>(move dyn_self)
-    storage_dead(target_self)
-    storage_dead(dyn_self)
-    return
-}
-
-// Full name: test_crate::{impl FnMut<(u32,)> for some_fn}::{vtable}
-fn {impl FnMut<(u32,)> for some_fn}::{vtable}() -> core::ops::function::FnMut::{vtable}<(u32,), u32>
-{
-    let ret: core::ops::function::FnMut::{vtable}<(u32,), u32>; // return
-    let size: usize; // local
-    let align: usize; // local
-    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1)); // anonymous local
-    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '3), (u32,)) -> u32; // anonymous local
-    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
-    let _6: &'static core::ops::function::FnOnce::{vtable}<(u32,), u32>; // anonymous local
-
-    storage_live(ret)
-    storage_live(size)
-    size = size_of<some_fn>
-    storage_live(align)
-    align = align_of<some_fn>
-    storage_live(_3)
-    _3 = cast<for<'_0_1> {impl FnMut<(u32,)> for some_fn}::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1))>(const {impl FnMut<(u32,)> for some_fn}::{vtable_drop_shim}<'0>)
-    storage_live(_4)
-    _4 = cast<for<'_0_1> {impl FnMut<(u32,)> for some_fn}::{vtable_method}<'2>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '3), (u32,)) -> u32>(const {impl FnMut<(u32,)> for some_fn}::{vtable_method}<'2>)
-    storage_live(_5)
-    _5 = &core::marker::MetaSized::{vtable}<some_fn>
-    storage_live(_6)
-    _6 = &{impl FnOnce<(u32,)> for some_fn}::{vtable}
-    ret = core::ops::function::FnMut::{vtable} { size: move size, align: move align, drop: move _3, method_call_mut: move _4, super_trait_0: move _5, super_trait_1: move _6 }
-    return
-}
-
-// Full name: test_crate::{impl FnMut<(u32,)> for some_fn}::{vtable}
-static {impl FnMut<(u32,)> for some_fn}::{vtable}: core::ops::function::FnMut::{vtable}<(u32,), u32> = {impl FnMut<(u32,)> for some_fn}::{vtable}()
-
-// Full name: test_crate::{impl Fn<(u32,)> for some_fn}::call
-fn {impl Fn<(u32,)> for some_fn}::call<'_0>(state: &'_0 some_fn, args: (u32,)) -> u32
-{
-    let _0: u32; // return
-    let state: &'_0 some_fn; // arg #1
-    let args: (u32,); // arg #2
-
-    storage_live(_0)
-    _0 = some_fn(move args._0)
-    ↳⚡ storage_dead(args)
-        storage_dead(state)
-        unwind_continue
-    storage_dead(args)
-    storage_dead(state)
-    return
-}
-
-// Full name: test_crate::{impl Fn<(u32,)> for some_fn}::{vtable_method}
-extern "rust-call" fn {impl Fn<(u32,)> for some_fn}::{vtable_method}<'_0>(_1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
-{
-    let _0: u32; // return
-    let _1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
-    let _2: (u32,); // arg #2
-    let _3: &'_0 some_fn; // anonymous local
-
-    storage_live(_0)
-    storage_live(_3)
-    _3 = concretize<&'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 some_fn>(move _1)
-    _0 = {impl Fn<(u32,)> for some_fn}::call<'_0>(move _3, move _2)
-    ↳⚡ storage_dead(_3)
-        storage_dead(_2)
-        storage_dead(_1)
-        unwind_continue
-    storage_dead(_3)
-    storage_dead(_2)
-    storage_dead(_1)
-    return
-}
-
-// Full name: test_crate::{impl Fn<(u32,)> for some_fn}::{vtable_drop_shim}
-unsafe fn {impl Fn<(u32,)> for some_fn}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>))
-{
-    let ret: (); // return
-    let dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
-    let target_self: &'_0 mut some_fn; // local
-
-    storage_live(ret)
-    ret = ()
-    storage_live(target_self)
-    target_self = concretize<&'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 mut some_fn>(move dyn_self)
-    storage_dead(target_self)
-    storage_dead(dyn_self)
-    return
-}
-
-// Full name: test_crate::{impl Fn<(u32,)> for some_fn}::{vtable}
-fn {impl Fn<(u32,)> for some_fn}::{vtable}() -> core::ops::function::Fn::{vtable}<(u32,), u32>
-{
-    let ret: core::ops::function::Fn::{vtable}<(u32,), u32>; // return
-    let size: usize; // local
-    let align: usize; // local
-    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1)); // anonymous local
-    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '3), (u32,)) -> u32; // anonymous local
-    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
-    let _6: &'static core::ops::function::FnMut::{vtable}<(u32,), u32>; // anonymous local
-
-    storage_live(ret)
-    storage_live(size)
-    size = size_of<some_fn>
-    storage_live(align)
-    align = align_of<some_fn>
-    storage_live(_3)
-    _3 = cast<for<'_0_1> {impl Fn<(u32,)> for some_fn}::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1))>(const {impl Fn<(u32,)> for some_fn}::{vtable_drop_shim}<'0>)
-    storage_live(_4)
-    _4 = cast<for<'_0_1> {impl Fn<(u32,)> for some_fn}::{vtable_method}<'2>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '3), (u32,)) -> u32>(const {impl Fn<(u32,)> for some_fn}::{vtable_method}<'2>)
-    storage_live(_5)
-    _5 = &core::marker::MetaSized::{vtable}<some_fn>
-    storage_live(_6)
-    _6 = &{impl FnMut<(u32,)> for some_fn}::{vtable}
-    ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move _3, method_call: move _4, super_trait_0: move _5, super_trait_1: move _6 }
-    return
-}
-
-// Full name: test_crate::{impl Fn<(u32,)> for some_fn}::{vtable}
-static {impl Fn<(u32,)> for some_fn}::{vtable}: core::ops::function::Fn::{vtable}<(u32,), u32> = {impl Fn<(u32,)> for some_fn}::{vtable}()
-
-// Full name: test_crate::{impl FnOnce<(u32,)> for some_fn}
-impl FnOnce<(u32,)> for some_fn {
-    proof ImpliedClause0: (some_fn: MetaSized) = {built_in impl MetaSized for some_fn}
-    proof ImpliedClause1: ((u32,): Sized) = {built_in impl Sized for (u32,)}
-    proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
-    proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
-    type Output = u32
-    fn call_once = {impl FnOnce<(u32,)> for some_fn}::call_once
-    vtable: {impl FnOnce<(u32,)> for some_fn}::{vtable}
-}
-
-// Full name: test_crate::{impl FnMut<(u32,)> for some_fn}
-impl FnMut<(u32,)> for some_fn {
-    proof ImpliedClause0: (some_fn: MetaSized) = {built_in impl MetaSized for some_fn}
-    proof ImpliedClause1: (some_fn: FnOnce<(u32,)>) = {impl FnOnce<(u32,)> for some_fn}
-    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
-    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
-    fn call_mut<'_0_1> = {impl FnMut<(u32,)> for some_fn}::call_mut<'_0_1>
-    vtable: {impl FnMut<(u32,)> for some_fn}::{vtable}
-}
-
-// Full name: test_crate::{impl Fn<(u32,)> for some_fn}
-impl Fn<(u32,)> for some_fn {
-    proof ImpliedClause0: (some_fn: MetaSized) = {built_in impl MetaSized for some_fn}
-    proof ImpliedClause1: (some_fn: FnMut<(u32,)>) = {impl FnMut<(u32,)> for some_fn}
-    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
-    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
-    fn call<'_0_1> = {impl Fn<(u32,)> for some_fn}::call<'_0_1>
-    vtable: {impl Fn<(u32,)> for some_fn}::{vtable}
+  _0: A,
+  _1: B,
 }
 
 // Full name: test_crate::main::closure
@@ -437,25 +134,33 @@ unsafe fn drop_glue<'_0>(_1: &'_0 mut closure)
 }
 
 // Full name: test_crate::main::{impl Fn<(u32,)> for closure}::call
-fn impl_Fn_tuple_for_closure::call<'_0>(_1: &'_0 closure, tupled_args: (u32,)) -> u32
+fn call<'_0>(_1: &'_0 closure, tupled_args: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: &'1 closure; // arg #1
     let tupled_args: (u32,); // arg #2
-    let _3: u32; // anonymous local
+    let x: u32; // local
+    let _4: u32; // anonymous local
+    let _5: u32; // anonymous local
 
     storage_live(_0)
-    storage_live(_3)
-    _3 = move tupled_args._0
-    _0 = const 42u32
-    storage_dead(_3)
+    storage_live(x)
+    storage_live(_5)
+    x = move tupled_args._0
+    storage_live(_4)
+    _4 = copy x
+    _5 = copy _4 panic.+ const 1u32
+    _0 = move _5
+    storage_dead(_4)
+    storage_dead(_5)
+    storage_dead(x)
     storage_dead(tupled_args)
     storage_dead(_1)
     return
 }
 
 // Full name: test_crate::main::{impl FnMut<(u32,)> for closure}::call_mut
-fn impl_FnMut_tuple_for_closure::call_mut<'_0>(state: &'_0 mut closure, args: (u32,)) -> u32
+fn call_mut<'_0>(state: &'_0 mut closure, args: (u32,)) -> u32
 {
     let _0: u32; // return
     let state: &'_0 mut closure; // arg #1
@@ -465,7 +170,7 @@ fn impl_FnMut_tuple_for_closure::call_mut<'_0>(state: &'_0 mut closure, args: (u
     storage_live(_0)
     storage_live(_3)
     _3 = &(*state)
-    _0 = impl_Fn_tuple_for_closure::call<'2>(move _3, move args)
+    _0 = call<'2>(move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -477,7 +182,7 @@ fn impl_FnMut_tuple_for_closure::call_mut<'_0>(state: &'_0 mut closure, args: (u
 }
 
 // Full name: test_crate::main::{impl FnOnce<(u32,)> for closure}::call_once
-fn impl_FnOnce_tuple_for_closure::call_once(_1: closure, _2: (u32,)) -> u32
+fn call_once(_1: closure, _2: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: closure; // arg #1
@@ -487,7 +192,7 @@ fn impl_FnOnce_tuple_for_closure::call_once(_1: closure, _2: (u32,)) -> u32
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = impl_FnMut_tuple_for_closure::call_mut<'2>(move _3, move _2)
+    _0 = call_mut<'2>(move _3, move _2)
     ↳⚡ drop[drop_glue<'3>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
@@ -519,7 +224,7 @@ extern "rust-call" fn impl_FnOnce_tuple_for_closure::{vtable_method}(_1: (dyn Fn
     storage_live(_0)
     storage_live(_3)
     _3 = concretize<(dyn FnOnce<(u32,), Output = u32> + '1), closure>(move _1)
-    _0 = impl_FnOnce_tuple_for_closure::call_once(move _3, move _2)
+    _0 = call_once(move _3, move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -589,7 +294,7 @@ extern "rust-call" fn impl_FnMut_tuple_for_closure::{vtable_method}<'_0>(_1: &'_
     storage_live(_0)
     storage_live(_3)
     _3 = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut closure>(move _1)
-    _0 = impl_FnMut_tuple_for_closure::call_mut<'_0>(move _3, move _2)
+    _0 = call_mut<'_0>(move _3, move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -662,7 +367,7 @@ extern "rust-call" fn impl_Fn_tuple_for_closure::{vtable_method}<'_0>(_1: &'_0 (
     storage_live(_0)
     storage_live(_3)
     _3 = concretize<&'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 closure>(move _1)
-    _0 = impl_Fn_tuple_for_closure::call<'_0>(move _3, move _2)
+    _0 = call<'_0>(move _3, move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -731,7 +436,7 @@ impl "impl_FnOnce_tuple_for_closure" FnOnce<(u32,)> for closure {
     proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
     proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
     type Output = u32
-    fn call_once = impl_FnOnce_tuple_for_closure::call_once
+    fn call_once = call_once
     vtable: impl_FnOnce_tuple_for_closure::{vtable}
 }
 
@@ -741,7 +446,7 @@ impl "impl_FnMut_tuple_for_closure" FnMut<(u32,)> for closure {
     proof ImpliedClause1: (closure: FnOnce<(u32,)>) = impl_FnOnce_tuple_for_closure
     proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
     proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
-    fn call_mut<'_0_1> = impl_FnMut_tuple_for_closure::call_mut<'_0_1>
+    fn call_mut<'_0_1> = call_mut<'_0_1>
     vtable: impl_FnMut_tuple_for_closure::{vtable}
 }
 
@@ -751,7 +456,7 @@ impl "impl_Fn_tuple_for_closure" Fn<(u32,)> for closure {
     proof ImpliedClause1: (closure: FnMut<(u32,)>) = impl_FnMut_tuple_for_closure
     proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
     proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
-    fn call<'_0_1> = impl_Fn_tuple_for_closure::call<'_0_1>
+    fn call<'_0_1> = call<'_0_1>
     vtable: impl_Fn_tuple_for_closure::{vtable}
 }
 
@@ -759,80 +464,55 @@ impl "impl_Fn_tuple_for_closure" Fn<(u32,)> for closure {
 fn main()
 {
     let _0: (); // return
-    let _1: (); // anonymous local
-    let _2: &'3 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4); // anonymous local
-    let _3: &'6 some_fn; // anonymous local
-    let _4: &'7 some_fn; // anonymous local
-    let _5: (); // anonymous local
-    let _6: &'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9); // anonymous local
-    let _7: &'11 closure; // anonymous local
-    let _8: &'12 closure; // anonymous local
-    let _9: &'13 closure; // anonymous local
-    let _10: &'14 some_fn; // anonymous local
-    let _11: &'15 some_fn; // anonymous local
-    let _12: &'20 closure; // anonymous local
-    let _13: &'25 some_fn; // anonymous local
-    let _14: some_fn; // anonymous local
-    let _15: &'26 closure; // anonymous local
-    let _16: closure; // anonymous local
+    let f: &'3 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4); // local
+    let _2: &'6 closure; // anonymous local
+    let _3: &'7 closure; // anonymous local
+    let _y: u32; // local
+    let _5: &'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9); // anonymous local
+    let _6: (u32,); // anonymous local
+    let _7: &'10 closure; // anonymous local
+    let _8: &'11 closure; // anonymous local
+    let _9: &'20 closure; // anonymous local
+    let _10: closure; // anonymous local
 
-    storage_live(_11)
-    storage_live(_13)
-    storage_live(_14)
-    _14 = const some_fn
-    _13 = &_14
-    _11 = move _13
-    storage_live(_0)
+    storage_live(_8)
     storage_live(_9)
     storage_live(_10)
+    _10 = closure {  }
+    _9 = &_10
+    _8 = move _9
+    storage_live(_0)
+    storage_live(_7)
     _0 = ()
-    storage_live(_1)
+    storage_live(f)
     storage_live(_2)
     storage_live(_3)
-    storage_live(_4)
-    _10 = move _11
-    _4 = &(*_10)
-    _3 = &(*_4)
-    _2 = unsize_cast<&'6 some_fn, &'16 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '17), &{impl Fn<(u32,)> for some_fn}::{vtable}>(move _3)
-    storage_dead(_3)
-    _1 = takes_fn<'19>(move _2)
-    ↳⚡ storage_dead(_10)
-        storage_dead(_9)
-        unwind_continue
-    storage_live(_12)
-    storage_live(_15)
-    storage_live(_16)
-    _16 = closure {  }
-    _15 = &_16
-    _12 = move _15
+    _7 = move _8
+    _3 = &(*_7)
+    _2 = &(*_3)
+    f = unsize_cast<&'6 closure, &'12 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '13), &impl_Fn_tuple_for_closure::{vtable}>(move _2)
     storage_dead(_2)
-    storage_dead(_4)
-    storage_dead(_1)
+    fake_read(f)
+    set_type(typeof(f) == &'14 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '15))
+    storage_dead(_3)
+    storage_live(_y)
     storage_live(_5)
+    _5 = &(*f) with_metadata(copy f.metadata)
     storage_live(_6)
-    storage_live(_7)
-    storage_live(_8)
-    _9 = move _12
-    _8 = &(*_9)
-    _7 = &(*_8)
-    _6 = unsize_cast<&'11 closure, &'21 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '22), &impl_Fn_tuple_for_closure::{vtable}>(move _7)
-    storage_dead(_7)
-    _5 = takes_fn<'24>(move _6)
-    ↳⚡ storage_dead(_10)
-        storage_dead(_9)
+    _6 = (const 1u32,)
+    _y = (copy (*_5.metadata).method_call)(move _5, move _6)
+    ↳⚡ storage_dead(_7)
         unwind_continue
     storage_dead(_6)
-    storage_dead(_8)
     storage_dead(_5)
+    fake_read(_y)
     _0 = ()
+    storage_dead(_y)
+    storage_dead(f)
+    storage_dead(_7)
     storage_dead(_10)
     storage_dead(_9)
-    storage_dead(_16)
-    storage_dead(_15)
-    storage_dead(_14)
-    storage_dead(_13)
-    storage_dead(_12)
-    storage_dead(_11)
+    storage_dead(_8)
     return
 }
 

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.rs
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.rs
@@ -1,0 +1,6 @@
+//@ charon-args=--include=core::ops::function
+
+fn main() {
+    let f: &dyn Fn(u32) -> u32 = &|x| x + 1;
+    let _y = f(1);
+}

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable.out
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable.out
@@ -1,0 +1,553 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+fn core::marker::MetaSized::{vtable}::<closure>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<closure>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<closure>()
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Tuple
+#[fundamental]
+#[lang_item(Tuple)]
+pub trait Tuple<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct core::ops::function::FnOnce::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  method_call_once: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+struct core::ops::function::FnMut::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  method_call_mut: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+  super_trait_1: &'static core::ops::function::FnOnce::{vtable},
+}
+
+struct core::ops::function::Fn::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  method_call: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+  super_trait_1: &'static core::ops::function::FnMut::{vtable},
+}
+
+// Full name: core::ops::function::FnOnce
+#[fundamental]
+#[lang_item(FnOnce)]
+pub trait FnOnce<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    vtable: core::ops::function::FnOnce::{vtable}
+}
+
+// Full name: core::ops::function::FnMut
+#[fundamental]
+#[lang_item(FnMut)]
+pub trait FnMut<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    vtable: core::ops::function::FnMut::{vtable}
+}
+
+// Full name: core::ops::function::Fn
+#[fundamental]
+#[lang_item(Fn)]
+pub trait Fn<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    vtable: core::ops::function::Fn::{vtable}
+}
+
+struct (_,)::<u32> {
+  _0: u32,
+}
+
+struct (_, _)::<u32, bool> {
+  _0: u32,
+  _1: bool,
+}
+
+// Full name: test_crate::main::closure
+struct closure {}
+
+// Full name: test_crate::main::closure::{impl Destruct for closure}::drop_glue
+unsafe fn drop_glue<'_0>(_1: &'_0 mut closure)
+{
+    let _0: (); // return
+    let _1: &'1 mut closure; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for closure}::call
+fn call<'_0>(_1: &'_0 closure, tupled_args: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'1 closure; // arg #1
+    let tupled_args: (u32,); // arg #2
+    let x: u32; // local
+    let _4: u32; // anonymous local
+    let _5: u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(x)
+    storage_live(_5)
+    x = move tupled_args._0
+    storage_live(_4)
+    _4 = copy x
+    _5 = copy _4 panic.+ const 1u32
+    _0 = move _5
+    storage_dead(_4)
+    storage_dead(_5)
+    storage_dead(x)
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for closure}::call_mut
+fn call_mut<'_0>(state: &'_0 mut closure, args: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let state: &'_0 mut closure; // arg #1
+    let args: (u32,); // arg #2
+    let _3: &'0 closure; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &(*state)
+    _0 = call<'2>(move _3, move args)
+    ↳⚡ storage_dead(_3)
+        storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for closure}::call_once
+fn call_once(_1: closure, _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: closure; // arg #1
+    let _2: (u32,); // arg #2
+    let _3: &'1 mut closure; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = call_mut<'3>(move _3, move _2)
+    ↳⚡ drop[drop_glue<'4>] _1
+        ↳⚡ storage_dead(_3)
+            storage_dead(_2)
+            storage_dead(_1)
+            unwind_terminate
+        storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    drop[drop_glue<'5>] _1
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for closure}::{vtable_method}
+extern "rust-call" fn impl_FnOnce_for_closure::{vtable_method}(_1: (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
+    let _2: (u32,); // arg #2
+    let _3: closure; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<(dyn FnOnce<(u32,), Output = u32> + '1), closure>(move _1)
+    _0 = call_once(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for closure}::{vtable_drop_shim}
+unsafe fn impl_FnOnce_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
+    let target_self: &'_0 mut closure; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnOnce<(u32,), Output = u32> + '1), &'_0 mut closure>(move dyn_self)
+    drop[drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for closure}::{vtable}
+fn impl_FnOnce_for_closure::{vtable}() -> core::ops::function::FnOnce::{vtable}
+{
+    let ret: core::ops::function::FnOnce::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call_once: extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '1), (u32,)) -> u32; // local
+    let erased_call_once: *const (); // local
+    let _7: unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<closure>
+    storage_live(align)
+    align = align_of<closure>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<impl_FnOnce_for_closure::{vtable_drop_shim}<'3>, unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '4))>(const impl_FnOnce_for_closure::{vtable_drop_shim}<'3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call_once)
+    storage_live(erased_call_once)
+    storage_live(_8)
+    _8 = cast<impl_FnOnce_for_closure::{vtable_method}, extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32>(const impl_FnOnce_for_closure::{vtable_method})
+    call_once = move _8
+    erased_call_once = cast<extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '9), (u32,)) -> u32, *const ()>(move call_once)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<closure>
+    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_once: move erased_call_once, super_trait_0: move _9 }
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for closure}::{vtable}
+static impl_FnOnce_for_closure::{vtable}: core::ops::function::FnOnce::{vtable} = impl_FnOnce_for_closure::{vtable}()
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for closure}::{vtable_method}
+extern "rust-call" fn impl_FnMut_for_closure::{vtable_method}<'_0>(_1: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
+    let _2: (u32,); // arg #2
+    let _3: &'_0 mut closure; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut closure>(move _1)
+    _0 = call_mut<'_0>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for closure}::{vtable_drop_shim}
+unsafe fn impl_FnMut_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
+    let target_self: &'_0 mut closure; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut closure>(move dyn_self)
+    drop[drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for closure}::{vtable}
+fn impl_FnMut_for_closure::{vtable}() -> core::ops::function::FnMut::{vtable}
+{
+    let ret: core::ops::function::FnMut::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call_mut: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), (u32,)) -> u32; // local
+    let erased_call_mut: *const (); // local
+    let _7: unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '9), (u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _10: &'static core::ops::function::FnOnce::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<closure>
+    storage_live(align)
+    align = align_of<closure>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<impl_FnMut_for_closure::{vtable_drop_shim}<'3>, unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '4))>(const impl_FnMut_for_closure::{vtable_drop_shim}<'3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call_mut)
+    storage_live(erased_call_mut)
+    storage_live(_8)
+    _8 = cast<for<'_0_1> impl_FnMut_for_closure::{vtable_method}<'8>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(const impl_FnMut_for_closure::{vtable_method}<'8>)
+    call_mut = move _8
+    erased_call_mut = cast<extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '10), (u32,)) -> u32, *const ()>(move call_mut)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<closure>
+    storage_live(_10)
+    _10 = &impl_FnOnce_for_closure::{vtable}
+    ret = core::ops::function::FnMut::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_mut: move erased_call_mut, super_trait_0: move _9, super_trait_1: move _10 }
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for closure}::{vtable}
+static impl_FnMut_for_closure::{vtable}: core::ops::function::FnMut::{vtable} = impl_FnMut_for_closure::{vtable}()
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for closure}::{vtable_method}
+extern "rust-call" fn impl_Fn_for_closure::{vtable_method}<'_0>(_1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
+    let _2: (u32,); // arg #2
+    let _3: &'_0 closure; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 closure>(move _1)
+    _0 = call<'_0>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for closure}::{vtable_drop_shim}
+unsafe fn impl_Fn_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
+    let target_self: &'_0 mut closure; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 mut closure>(move dyn_self)
+    drop[drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for closure}::{vtable}
+fn impl_Fn_for_closure::{vtable}() -> core::ops::function::Fn::{vtable}
+{
+    let ret: core::ops::function::Fn::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), (u32,)) -> u32; // local
+    let erased_call: *const (); // local
+    let _7: unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _10: &'static core::ops::function::FnMut::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<closure>
+    storage_live(align)
+    align = align_of<closure>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<impl_Fn_for_closure::{vtable_drop_shim}<'3>, unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4))>(const impl_Fn_for_closure::{vtable_drop_shim}<'3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call)
+    storage_live(erased_call)
+    storage_live(_8)
+    _8 = cast<for<'_0_1> impl_Fn_for_closure::{vtable_method}<'8>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(const impl_Fn_for_closure::{vtable_method}<'8>)
+    call = move _8
+    erased_call = cast<extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '10), (u32,)) -> u32, *const ()>(move call)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<closure>
+    storage_live(_10)
+    _10 = &impl_FnMut_for_closure::{vtable}
+    ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call: move erased_call, super_trait_0: move _9, super_trait_1: move _10 }
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for closure}::{vtable}
+static impl_Fn_for_closure::{vtable}: core::ops::function::Fn::{vtable} = impl_Fn_for_closure::{vtable}()
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for closure}
+impl "impl_FnOnce_for_closure" FnOnce<(u32,)> for closure {
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    vtable: impl_FnOnce_for_closure::{vtable}
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for closure}
+impl "impl_FnMut_for_closure" FnMut<(u32,)> for closure {
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnOnce<(u32,)>) = impl_FnOnce_for_closure
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    vtable: impl_FnMut_for_closure::{vtable}
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for closure}
+impl "impl_Fn_for_closure" Fn<(u32,)> for closure {
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: (closure: FnMut<(u32,)>) = impl_FnMut_for_closure
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    vtable: impl_Fn_for_closure::{vtable}
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let f: &'3 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4); // local
+    let _2: &'6 closure; // anonymous local
+    let _3: &'7 closure; // anonymous local
+    let _y: u32; // local
+    let _5: &'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9); // anonymous local
+    let _6: (u32,); // anonymous local
+    let _7: &'10 closure; // anonymous local
+    let _8: unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32; // anonymous local
+    let _9: &'11 closure; // anonymous local
+    let _10: &'20 closure; // anonymous local
+    let _11: closure; // anonymous local
+
+    storage_live(_9)
+    storage_live(_10)
+    storage_live(_11)
+    _11 = closure {  }
+    _10 = &_11
+    _9 = move _10
+    storage_live(_0)
+    storage_live(_7)
+    _0 = ()
+    storage_live(f)
+    storage_live(_2)
+    storage_live(_3)
+    _7 = move _9
+    _3 = &(*_7)
+    _2 = &(*_3)
+    f = unsize_cast<&'6 closure, &'12 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '13), &impl_Fn_for_closure::{vtable}>(move _2)
+    storage_dead(_2)
+    fake_read(f)
+    set_type(typeof(f) == &'14 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '15))
+    storage_dead(_3)
+    storage_live(_y)
+    storage_live(_5)
+    _5 = &(*f) with_metadata(copy f.metadata)
+    storage_live(_6)
+    _6 = (const 1u32,)
+    storage_live(_8)
+    _8 = cast<*const (), unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(copy (*_5.metadata).method_call)
+    _y = (copy _8)(move _5, move _6)
+    ↳⚡ storage_dead(_7)
+        unwind_continue
+    storage_dead(_6)
+    storage_dead(_5)
+    fake_read(_y)
+    _0 = ()
+    storage_dead(_y)
+    storage_dead(f)
+    storage_dead(_7)
+    storage_dead(_11)
+    storage_dead(_10)
+    storage_dead(_9)
+    storage_dead(_8)
+    return
+}
+
+// Full name: test_crate::main::closure::{impl Destruct for closure}
+impl "impl_Destruct_for_closure" Destruct for closure {
+    fn drop_glue<'_0_1> = drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+
+

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable.rs
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable.rs
@@ -1,0 +1,7 @@
+//@ charon-args=--monomorphize
+//@ charon-args=--include=core::ops::function
+
+fn main() {
+    let f: &dyn Fn(u32) -> u32 = &|x| x + 1;
+    let _y = f(1);
+}

--- a/charon/tests/ui/dyn/mono-vtable-default-method.out
+++ b/charon/tests/ui/dyn/mono-vtable-default-method.out
@@ -1,0 +1,274 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+fn core::marker::MetaSized::{vtable}::<Struct>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<Struct>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<Struct>()
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+struct (_, _)::<i32, bool> {
+  _0: i32,
+  _1: bool,
+}
+
+struct test_crate::Trait::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  method_base: *const (),
+  method_dflt: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+// Full name: test_crate::Trait
+pub trait Trait<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    vtable: test_crate::Trait::{vtable}
+}
+
+// Full name: test_crate::Struct
+pub struct Struct {}
+
+// Full name: test_crate::{impl Trait for Struct}::base
+pub fn base<'_0>(self: &'_0 Struct) -> i32
+{
+    let _0: i32; // return
+    let self: &'1 Struct; // arg #1
+
+    storage_live(_0)
+    _0 = const 1i32
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::Trait::dflt::<Struct>
+pub fn dflt::<Struct><'_0>(self: &'_0 Struct) -> i32
+{
+    let _0: i32; // return
+    let self: &'1 Struct; // arg #1
+    let _2: i32; // anonymous local
+    let _3: &'2 Struct; // anonymous local
+    let _4: i32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_4)
+    storage_live(_2)
+    storage_live(_3)
+    _3 = &(*self)
+    _2 = base<'4>(move _3)
+    ↳⚡ storage_dead(_4)
+        storage_dead(self)
+        unwind_continue
+    storage_dead(_3)
+    _4 = copy _2 panic.+ const 1i32
+    _0 = move _4
+    storage_dead(_2)
+    storage_dead(_4)
+    storage_dead(self)
+    return
+}
+
+fn test_crate::Trait::dflt::{vtable_method}::<Struct><'_0>(_1: &'_0 (dyn Trait)) -> i32
+{
+    let _0: i32; // return
+    let _1: &'_0 (dyn Trait + '0); // arg #1
+    let _2: &'_0 Struct; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<&'_0 (dyn Trait + '1), &'_0 Struct>(move _1)
+    _0 = dflt::<Struct><'_0>(move _2)
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::Struct::{impl Destruct for Struct}::drop_glue
+unsafe fn drop_glue<'_0>(_1: &'_0 mut Struct)
+{
+    let _0: (); // return
+    let _1: &'1 mut Struct; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::Struct::{impl Destruct for Struct}
+impl "impl_Destruct_for_Struct" Destruct for Struct {
+    fn drop_glue<'_0_1> = drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl Trait for Struct}::base::{vtable_method}
+fn impl_Trait_for_Struct::base::{vtable_method}<'_0>(_1: &'_0 (dyn Trait)) -> i32
+{
+    let _0: i32; // return
+    let _1: &'_0 (dyn Trait + '0); // arg #1
+    let _2: &'_0 Struct; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<&'_0 (dyn Trait + '1), &'_0 Struct>(move _1)
+    _0 = base<'_0>(move _2)
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Trait for Struct}::{vtable_drop_shim}
+unsafe fn {vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Trait))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Trait + '0); // arg #1
+    let target_self: &'_0 mut Struct; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Trait + '1), &'_0 mut Struct>(move dyn_self)
+    drop[drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl Trait for Struct}::{vtable}
+fn impl_Trait_for_Struct::{vtable}() -> test_crate::Trait::{vtable}
+{
+    let ret: test_crate::Trait::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn Trait + '0)); // local
+    let erased_drop: *const (); // local
+    let base: fn<'_0_1>(&'_0_1 (dyn Trait + '1)) -> i32; // local
+    let erased_base: *const (); // local
+    let dflt: fn<'_0_1>(&'_0_1 (dyn Trait + '2)) -> i32; // local
+    let erased_dflt: *const (); // local
+    let _9: unsafe fn(*mut (dyn Trait + '5)); // anonymous local
+    let _10: fn<'_0_1>(&'_0_1 (dyn Trait + '10)) -> i32; // anonymous local
+    let _11: fn<'_0_1>(&'_0_1 (dyn Trait + '15)) -> i32; // anonymous local
+    let _12: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<Struct>
+    storage_live(align)
+    align = align_of<Struct>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_9)
+    _9 = cast<{vtable_drop_shim}<'4>, unsafe fn(*mut (dyn Trait + '5))>(const {vtable_drop_shim}<'4>)
+    drop = move _9
+    erased_drop = cast<unsafe fn(*mut (dyn Trait + '6)), *const ()>(move drop)
+    storage_live(base)
+    storage_live(erased_base)
+    storage_live(_10)
+    _10 = cast<for<'_0_1> impl_Trait_for_Struct::base::{vtable_method}<'9>, fn<'_0_1>(&'_0_1 (dyn Trait + '10)) -> i32>(const impl_Trait_for_Struct::base::{vtable_method}<'9>)
+    base = move _10
+    erased_base = cast<fn<'_0_1>(&'_0_1 (dyn Trait + '11)) -> i32, *const ()>(move base)
+    storage_live(dflt)
+    storage_live(erased_dflt)
+    storage_live(_11)
+    _11 = cast<for<'_0_1> test_crate::Trait::dflt::{vtable_method}::<Struct><'14>, fn<'_0_1>(&'_0_1 (dyn Trait + '15)) -> i32>(const test_crate::Trait::dflt::{vtable_method}::<Struct><'14>)
+    dflt = move _11
+    erased_dflt = cast<fn<'_0_1>(&'_0_1 (dyn Trait + '16)) -> i32, *const ()>(move dflt)
+    storage_live(_12)
+    _12 = &core::marker::MetaSized::{vtable}::<Struct>
+    ret = test_crate::Trait::{vtable} { size: move size, align: move align, drop: move erased_drop, method_base: move erased_base, method_dflt: move erased_dflt, super_trait_0: move _12 }
+    return
+}
+
+// Full name: test_crate::{impl Trait for Struct}::{vtable}
+static impl_Trait_for_Struct::{vtable}: test_crate::Trait::{vtable} = impl_Trait_for_Struct::{vtable}()
+
+// Full name: test_crate::{impl Trait for Struct}
+impl "impl_Trait_for_Struct" Trait for Struct {
+    proof ImpliedClause0: (Struct: MetaSized) = {built_in impl MetaSized for Struct}
+    vtable: impl_Trait_for_Struct::{vtable}
+}
+
+// Full name: test_crate::main
+pub fn main()
+{
+    let _0: (); // return
+    let b: &'3 (dyn Trait + '4); // local
+    let _2: &'6 Struct; // anonymous local
+    let _3: &'7 Struct; // anonymous local
+    let _4: i32; // anonymous local
+    let _5: &'8 (dyn Trait + '9); // anonymous local
+    let _6: &'10 Struct; // anonymous local
+    let _7: unsafe fn(&'8 (dyn Trait + '9)) -> i32; // anonymous local
+    let _8: &'11 Struct; // anonymous local
+    let _9: &'20 Struct; // anonymous local
+    let _10: Struct; // anonymous local
+
+    storage_live(_8)
+    storage_live(_9)
+    storage_live(_10)
+    _10 = Struct {  }
+    _9 = &_10
+    _8 = move _9
+    storage_live(_0)
+    storage_live(_6)
+    _0 = ()
+    storage_live(b)
+    storage_live(_2)
+    storage_live(_3)
+    _6 = move _8
+    _3 = &(*_6)
+    _2 = &(*_3)
+    b = unsize_cast<&'6 Struct, &'12 (dyn Trait + '13), &impl_Trait_for_Struct::{vtable}>(move _2)
+    storage_dead(_2)
+    fake_read(b)
+    set_type(typeof(b) == &'14 (dyn Trait + '15))
+    storage_dead(_3)
+    storage_live(_4)
+    storage_live(_5)
+    _5 = &(*b) with_metadata(copy b.metadata)
+    storage_live(_7)
+    _7 = cast<*const (), unsafe fn(&'8 (dyn Trait + '9)) -> i32>(copy (*_5.metadata).method_dflt)
+    _4 = (copy _7)(move _5)
+    ↳⚡ storage_dead(_6)
+        unwind_continue
+    storage_dead(_5)
+    storage_dead(_4)
+    _0 = ()
+    storage_dead(b)
+    storage_dead(_6)
+    storage_dead(_10)
+    storage_dead(_9)
+    storage_dead(_8)
+    storage_dead(_7)
+    return
+}
+
+
+

--- a/charon/tests/ui/dyn/mono-vtable-default-method.rs
+++ b/charon/tests/ui/dyn/mono-vtable-default-method.rs
@@ -1,0 +1,21 @@
+//@ charon-args=--monomorphize
+
+pub trait Trait {
+    fn base(&self) -> i32;
+    fn dflt(&self) -> i32 {
+        self.base() + 1
+    }
+}
+
+pub struct Struct;
+
+impl Trait for Struct {
+    fn base(&self) -> i32 {
+        1
+    }
+}
+
+pub fn main() {
+    let b: &dyn Trait = &Struct;
+    let _ = b.dflt();
+}

--- a/charon/tests/ui/dyn/vtable-default-method.out
+++ b/charon/tests/ui/dyn/vtable-default-method.out
@@ -1,0 +1,299 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+fn core::marker::MetaSized::{vtable}<Self>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}<Self>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}<Self>()
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
+{
+  _0: A,
+  _1: B,
+}
+
+struct test_crate::Trait::{vtable} {
+  size: usize,
+  align: usize,
+  drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn Trait)),
+  method_base: fn<'_0_1>(&'_0_1 (dyn Trait)) -> i32,
+  method_dflt: fn<'_0_1>(&'_0_1 (dyn Trait)) -> i32,
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+// Full name: test_crate::Trait
+pub trait Trait<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    fn base<'_0_1>;
+    fn dflt<'_0_1> = test_crate::Trait::dflt<'_0_1, Self>[Self]
+    vtable: test_crate::Trait::{vtable}
+}
+
+pub fn test_crate::Trait::dflt<'_0, Self>(self: &'_0 Self) -> i32
+where
+    TraitClause0: (Self: Trait),
+    TypeOutlives0: Self: '_0,
+{
+    let _0: i32; // return
+    let self: &'1 Self; // arg #1
+    let _2: i32; // anonymous local
+    let _3: &'2 Self; // anonymous local
+    let _4: i32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_4)
+    storage_live(_2)
+    storage_live(_3)
+    _3 = &(*self) with_metadata(copy self.metadata)
+    _2 = TraitClause0::base<'3>(move _3)
+    ↳⚡ storage_dead(_4)
+        storage_dead(self)
+        unwind_continue
+    storage_dead(_3)
+    _4 = copy _2 panic.+ const 1i32
+    _0 = move _4
+    storage_dead(_2)
+    storage_dead(_4)
+    storage_dead(self)
+    return
+}
+
+fn test_crate::Trait::dflt::{vtable_method}<'_0, Self>(_1: &'_0 (dyn Trait)) -> i32
+where
+    TraitClause0: (Self: Trait),
+{
+    let _0: i32; // return
+    let _1: &'_0 (dyn Trait + '0); // arg #1
+    let _2: &'_0 Self; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<&'_0 (dyn Trait + '1), &'_0 Self>(move _1)
+    _0 = test_crate::Trait::dflt<'_0, Self>[TraitClause0](move _2)
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::Struct
+pub struct Struct {}
+
+// Full name: test_crate::Struct::{impl Destruct for Struct}::drop_glue
+unsafe fn drop_glue<'_0>(_1: &'_0 mut Struct)
+{
+    let _0: (); // return
+    let _1: &'1 mut Struct; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::Struct::{impl Destruct for Struct}
+impl "impl_Destruct_for_Struct" Destruct for Struct {
+    fn drop_glue<'_0_1> = drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl Trait for Struct}::base
+pub fn base<'_0>(self: &'_0 Struct) -> i32
+{
+    let _0: i32; // return
+    let self: &'1 Struct; // arg #1
+
+    storage_live(_0)
+    _0 = const 1i32
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Trait for Struct}::base::{vtable_method}
+fn impl_Trait_for_Struct::base::{vtable_method}<'_0>(_1: &'_0 (dyn Trait)) -> i32
+{
+    let _0: i32; // return
+    let _1: &'_0 (dyn Trait + '0); // arg #1
+    let _2: &'_0 Struct; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<&'_0 (dyn Trait + '1), &'_0 Struct>(move _1)
+    _0 = base<'_0>(move _2)
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Trait for Struct}::dflt
+pub fn impl_Trait_for_Struct::dflt<'_0>(self: &'_0 Struct) -> i32
+{
+    let _0: i32; // return
+    let self: &'1 Struct; // arg #1
+    let _2: i32; // anonymous local
+    let _3: &'2 Struct; // anonymous local
+    let _4: i32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_4)
+    storage_live(_2)
+    storage_live(_3)
+    _3 = &(*self)
+    _2 = base<'3>(move _3)
+    ↳⚡ storage_dead(_4)
+        storage_dead(self)
+        unwind_continue
+    storage_dead(_3)
+    _4 = copy _2 panic.+ const 1i32
+    _0 = move _4
+    storage_dead(_2)
+    storage_dead(_4)
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Trait for Struct}::{vtable_drop_shim}
+unsafe fn {vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Trait))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Trait + '0); // arg #1
+    let target_self: &'_0 mut Struct; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Trait + '1), &'_0 mut Struct>(move dyn_self)
+    drop[drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl Trait for Struct}
+impl "impl_Trait_for_Struct" Trait for Struct {
+    proof ImpliedClause0: (Struct: MetaSized) = {built_in impl MetaSized for Struct}
+    fn base<'_0_1> = base<'_0_1>
+    fn dflt<'_0_1> = impl_Trait_for_Struct::dflt<'_0_1>
+    vtable: impl_Trait_for_Struct::{vtable}
+}
+
+// Full name: test_crate::{impl Trait for Struct}::{vtable}
+fn impl_Trait_for_Struct::{vtable}() -> test_crate::Trait::{vtable}
+{
+    let ret: test_crate::Trait::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Trait + '1)); // anonymous local
+    let _4: fn<'_0_1>(&'_0_1 (dyn Trait + '3)) -> i32; // anonymous local
+    let _5: fn<'_0_1>(&'_0_1 (dyn Trait + '5)) -> i32; // anonymous local
+    let _6: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<Struct>
+    storage_live(align)
+    align = align_of<Struct>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Trait + '1))>(const {vtable_drop_shim}<'0>)
+    storage_live(_4)
+    _4 = cast<for<'_0_1> impl_Trait_for_Struct::base::{vtable_method}<'2>, fn<'_0_1>(&'_0_1 (dyn Trait + '3)) -> i32>(const impl_Trait_for_Struct::base::{vtable_method}<'2>)
+    storage_live(_5)
+    _5 = cast<for<'_0_1> test_crate::Trait::dflt::{vtable_method}<'4, Struct>[impl_Trait_for_Struct], fn<'_0_1>(&'_0_1 (dyn Trait + '5)) -> i32>(const test_crate::Trait::dflt::{vtable_method}<'4, Struct>[impl_Trait_for_Struct])
+    storage_live(_6)
+    _6 = &core::marker::MetaSized::{vtable}<Struct>
+    ret = test_crate::Trait::{vtable} { size: move size, align: move align, drop: move _3, method_base: move _4, method_dflt: move _5, super_trait_0: move _6 }
+    return
+}
+
+// Full name: test_crate::{impl Trait for Struct}::{vtable}
+static impl_Trait_for_Struct::{vtable}: test_crate::Trait::{vtable} = impl_Trait_for_Struct::{vtable}()
+
+// Full name: test_crate::main
+pub fn main()
+{
+    let _0: (); // return
+    let b: &'3 (dyn Trait + '4); // local
+    let _2: &'6 Struct; // anonymous local
+    let _3: &'7 Struct; // anonymous local
+    let _4: i32; // anonymous local
+    let _5: &'8 (dyn Trait + '9); // anonymous local
+    let _6: &'10 Struct; // anonymous local
+    let _7: &'11 Struct; // anonymous local
+    let _8: &'20 Struct; // anonymous local
+    let _9: Struct; // anonymous local
+
+    storage_live(_7)
+    storage_live(_8)
+    storage_live(_9)
+    _9 = Struct {  }
+    _8 = &_9
+    _7 = move _8
+    storage_live(_0)
+    storage_live(_6)
+    _0 = ()
+    storage_live(b)
+    storage_live(_2)
+    storage_live(_3)
+    _6 = move _7
+    _3 = &(*_6)
+    _2 = &(*_3)
+    b = unsize_cast<&'6 Struct, &'12 (dyn Trait + '13), &impl_Trait_for_Struct::{vtable}>(move _2)
+    storage_dead(_2)
+    fake_read(b)
+    set_type(typeof(b) == &'14 (dyn Trait + '15))
+    storage_dead(_3)
+    storage_live(_4)
+    storage_live(_5)
+    _5 = &(*b) with_metadata(copy b.metadata)
+    _4 = (copy (*_5.metadata).method_dflt)(move _5)
+    ↳⚡ storage_dead(_6)
+        unwind_continue
+    storage_dead(_5)
+    storage_dead(_4)
+    _0 = ()
+    storage_dead(b)
+    storage_dead(_6)
+    storage_dead(_9)
+    storage_dead(_8)
+    storage_dead(_7)
+    return
+}
+
+
+

--- a/charon/tests/ui/dyn/vtable-default-method.rs
+++ b/charon/tests/ui/dyn/vtable-default-method.rs
@@ -1,0 +1,19 @@
+pub trait Trait {
+    fn base(&self) -> i32;
+    fn dflt(&self) -> i32 {
+        self.base() + 1
+    }
+}
+
+pub struct Struct;
+
+impl Trait for Struct {
+    fn base(&self) -> i32 {
+        1
+    }
+}
+
+pub fn main() {
+    let b: &dyn Trait = &Struct;
+    let _ = b.dflt();
+}

--- a/charon/tests/ui/dyn/vtables.out
+++ b/charon/tests/ui/dyn/vtables.out
@@ -686,6 +686,33 @@ where
     return
 }
 
+fn test_crate::Both32And64::both_operate::{vtable_method}<'_0, '_1, '_2, Self>(_1: &'_0 (dyn Both32And64), _2: &'_1 i32, _3: &'_2 i64)
+where
+    TraitClause0: (Self: Both32And64),
+{
+    let _0: (); // return
+    let _1: &'_0 (dyn Both32And64 + '0); // arg #1
+    let _2: &'_1 i32; // arg #2
+    let _3: &'_2 i64; // arg #3
+    let _4: &'_0 Self; // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(_4)
+    _4 = concretize<&'_0 (dyn Both32And64 + '1), &'_0 Self>(move _1)
+    _0 = test_crate::Both32And64::both_operate<'_0, '_1, '_2, Self>[TraitClause0](move _4, move _2, move _3)
+    ↳⚡ storage_dead(_4)
+        storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_4)
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
 // Full name: test_crate::{impl BaseOn<i32> for i32}::operate_on
 fn impl_BaseOn_i32_for_i32::operate_on<'_0, '_1>(self: &'_0 i32, t: &'_1 i32)
 {
@@ -898,53 +925,6 @@ impl "impl_BaseOn_i64_for_i32" BaseOn<i64> for i32 {
     vtable: impl_BaseOn_i64_for_i32::{vtable}
 }
 
-// Full name: test_crate::{impl Both32And64 for i32}::{vtable_drop_shim}
-unsafe fn impl_Both32And64_for_i32::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Both32And64))
-{
-    let ret: (); // return
-    let dyn_self: &'_0 mut (dyn Both32And64 + '0); // arg #1
-    let target_self: &'_0 mut i32; // local
-
-    storage_live(ret)
-    ret = ()
-    storage_live(target_self)
-    target_self = concretize<&'_0 mut (dyn Both32And64 + '1), &'_0 mut i32>(move dyn_self)
-    storage_dead(target_self)
-    storage_dead(dyn_self)
-    return
-}
-
-// Full name: test_crate::{impl Both32And64 for i32}::{vtable}
-fn impl_Both32And64_for_i32::{vtable}() -> test_crate::Both32And64::{vtable}
-{
-    let ret: test_crate::Both32And64::{vtable}; // return
-    let size: usize; // local
-    let align: usize; // local
-    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Both32And64 + '1)); // anonymous local
-    let _4: &'static core::marker::MetaSized::{vtable}; // anonymous local
-    let _5: &'static test_crate::BaseOn::{vtable}<i32>; // anonymous local
-    let _6: &'static test_crate::BaseOn::{vtable}<i64>; // anonymous local
-
-    storage_live(ret)
-    storage_live(size)
-    size = size_of<i32>
-    storage_live(align)
-    align = align_of<i32>
-    storage_live(_3)
-    _3 = cast<for<'_0_1> impl_Both32And64_for_i32::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Both32And64 + '1))>(const impl_Both32And64_for_i32::{vtable_drop_shim}<'0>)
-    storage_live(_4)
-    _4 = &core::marker::MetaSized::{vtable}<i32>
-    storage_live(_5)
-    _5 = &impl_BaseOn_i32_for_i32::{vtable}
-    storage_live(_6)
-    _6 = &impl_BaseOn_i64_for_i32::{vtable}
-    ret = test_crate::Both32And64::{vtable} { size: move size, align: move align, drop: move _3, method_both_operate: const Opaque(shim for default methods aren't yet supported), super_trait_0: move _4, super_trait_1: move _5, super_trait_2: move _6 }
-    return
-}
-
-// Full name: test_crate::{impl Both32And64 for i32}::{vtable}
-static impl_Both32And64_for_i32::{vtable}: test_crate::Both32And64::{vtable} = impl_Both32And64_for_i32::{vtable}()
-
 // Full name: test_crate::{impl Both32And64 for i32}::both_operate
 fn impl_Both32And64_for_i32::both_operate<'_0, '_1, '_2>(self: &'_0 i32, t32: &'_1 i32, t64: &'_2 i64)
 {
@@ -994,6 +974,22 @@ fn impl_Both32And64_for_i32::both_operate<'_0, '_1, '_2>(self: &'_0 i32, t32: &'
     return
 }
 
+// Full name: test_crate::{impl Both32And64 for i32}::{vtable_drop_shim}
+unsafe fn impl_Both32And64_for_i32::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Both32And64))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Both32And64 + '0); // arg #1
+    let target_self: &'_0 mut i32; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Both32And64 + '1), &'_0 mut i32>(move dyn_self)
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
 // Full name: test_crate::{impl Both32And64 for i32}
 impl "impl_Both32And64_for_i32" Both32And64 for i32 {
     proof ImpliedClause0: (i32: MetaSized) = {built_in impl MetaSized for i32}
@@ -1002,6 +998,40 @@ impl "impl_Both32And64_for_i32" Both32And64 for i32 {
     fn both_operate<'_0_1, '_1_1, '_2_1> = impl_Both32And64_for_i32::both_operate<'_0_1, '_1_1, '_2_1>
     vtable: impl_Both32And64_for_i32::{vtable}
 }
+
+// Full name: test_crate::{impl Both32And64 for i32}::{vtable}
+fn impl_Both32And64_for_i32::{vtable}() -> test_crate::Both32And64::{vtable}
+{
+    let ret: test_crate::Both32And64::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Both32And64 + '1)); // anonymous local
+    let _4: fn<'_0_1, '_1_1, '_2_1>(&'_0_1 (dyn Both32And64 + '5), &'_1_1 i32, &'_2_1 i64); // anonymous local
+    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _6: &'static test_crate::BaseOn::{vtable}<i32>; // anonymous local
+    let _7: &'static test_crate::BaseOn::{vtable}<i64>; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<i32>
+    storage_live(align)
+    align = align_of<i32>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> impl_Both32And64_for_i32::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Both32And64 + '1))>(const impl_Both32And64_for_i32::{vtable_drop_shim}<'0>)
+    storage_live(_4)
+    _4 = cast<for<'_0_1, '_1_1, '_2_1> test_crate::Both32And64::both_operate::{vtable_method}<'2, '3, '4, i32>[impl_Both32And64_for_i32], fn<'_0_1, '_1_1, '_2_1>(&'_0_1 (dyn Both32And64 + '5), &'_1_1 i32, &'_2_1 i64)>(const test_crate::Both32And64::both_operate::{vtable_method}<'2, '3, '4, i32>[impl_Both32And64_for_i32])
+    storage_live(_5)
+    _5 = &core::marker::MetaSized::{vtable}<i32>
+    storage_live(_6)
+    _6 = &impl_BaseOn_i32_for_i32::{vtable}
+    storage_live(_7)
+    _7 = &impl_BaseOn_i64_for_i32::{vtable}
+    ret = test_crate::Both32And64::{vtable} { size: move size, align: move align, drop: move _3, method_both_operate: move _4, super_trait_0: move _5, super_trait_1: move _6, super_trait_2: move _7 }
+    return
+}
+
+// Full name: test_crate::{impl Both32And64 for i32}::{vtable}
+static impl_Both32And64_for_i32::{vtable}: test_crate::Both32And64::{vtable} = impl_Both32And64_for_i32::{vtable}()
 
 // Full name: test_crate::Alias
 trait Alias<Self>

--- a/charon/tests/ui/monomorphization/closure-fn.out
+++ b/charon/tests/ui/monomorphization/closure-fn.out
@@ -92,242 +92,6 @@ struct closure<'_0, '_1> {
   _1: &'_1 u8,
 }
 
-// Full name: test_crate::main::{impl FnOnce<(u8, u8)> for closure<'_0, '_1>}
-impl<'_0, '_1> "impl_FnOnce_for_closure" FnOnce<(u8, u8)> for closure<'_0, '_1> {
-    proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
-    proof ImpliedClause1: ((u8, u8): Sized) = {built_in impl Sized for (u8, u8)}
-    proof ImpliedClause2: ((u8, u8): Tuple) = {built_in impl Tuple for (u8, u8)}
-    vtable: impl_FnOnce_for_closure::{vtable}<'_0, '_1>
-}
-
-// Full name: test_crate::main::{impl FnMut<(u8, u8)> for closure<'_0, '_1>}
-impl<'_0, '_1> "impl_FnMut_for_closure" FnMut<(u8, u8)> for closure<'_0, '_1> {
-    proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
-    proof ImpliedClause1: (closure<'_0, '_1>: FnOnce<(u8, u8)>) = impl_FnOnce_for_closure<'_0, '_1>
-    proof ImpliedClause2: ((u8, u8): Sized) = {built_in impl Sized for (u8, u8)}
-    proof ImpliedClause3: ((u8, u8): Tuple) = {built_in impl Tuple for (u8, u8)}
-    vtable: impl_FnMut_for_closure::{vtable}<'_0, '_1>
-}
-
-// Full name: test_crate::main::{impl Fn<(u8, u8)> for closure<'_0, '_1>}
-impl<'_0, '_1> "impl_Fn_for_closure" Fn<(u8, u8)> for closure<'_0, '_1> {
-    proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
-    proof ImpliedClause1: (closure<'_0, '_1>: FnMut<(u8, u8)>) = impl_FnMut_for_closure<'_0, '_1>
-    proof ImpliedClause2: ((u8, u8): Sized) = {built_in impl Sized for (u8, u8)}
-    proof ImpliedClause3: ((u8, u8): Tuple) = {built_in impl Tuple for (u8, u8)}
-    vtable: impl_Fn_for_closure::{vtable}<'_0, '_1>
-}
-
-// Full name: test_crate::apply_to::<closure<'_, '_>>
-fn apply_to::<closure<'_, '_>><'_0>(f: &'_0 closure<'_, '_>) -> u8
-{
-    let _0: u8; // return
-    let f: &'3 closure<'4, '5>; // arg #1
-    let _2: &'6 closure<'7, '8>; // anonymous local
-    let _3: (u8, u8); // anonymous local
-
-    storage_live(_0)
-    storage_live(_2)
-    _2 = &(*f)
-    storage_live(_3)
-    _3 = (const 10u8, const 20u8)
-    _0 = impl_Fn_for_closure<'15, '16>::call<'17>(move _2, move _3)
-    ↳⚡ storage_dead(f)
-        unwind_continue
-    storage_dead(_3)
-    storage_dead(_2)
-    storage_dead(f)
-    return
-}
-
-// Full name: test_crate::apply_to_mut::<closure<'_, '_>>
-fn apply_to_mut::<closure<'_, '_>><'_0>(f: &'_0 mut closure<'_, '_>) -> u8
-{
-    let _0: u8; // return
-    let f: &'3 mut closure<'4, '5>; // arg #1
-    let _2: &'6 mut closure<'7, '8>; // anonymous local
-    let _3: (u8, u8); // anonymous local
-
-    storage_live(_0)
-    storage_live(_2)
-    _2 = &mut (*f)
-    storage_live(_3)
-    _3 = (const 10u8, const 20u8)
-    _0 = impl_FnMut_for_closure<'15, '16>::call_mut<'17>(move _2, move _3)
-    ↳⚡ storage_dead(f)
-        unwind_continue
-    storage_dead(_3)
-    storage_dead(_2)
-    storage_dead(f)
-    return
-}
-
-// Full name: test_crate::main::closure::{impl Destruct for closure<'_0, '_1>}::drop_glue
-unsafe fn drop_glue<'_0, '_1, '_2>(_1: &'_2 mut closure<'_0, '_1>)
-where
-    RegionOutlives0: '_0: '_2,
-    RegionOutlives1: '_1: '_2,
-{
-    let _0: (); // return
-    let _1: &'1 mut closure<'_0, '_1>; // arg #1
-
-    storage_live(_0)
-    _0 = ()
-    storage_dead(_1)
-    return
-}
-
-// Full name: test_crate::apply_to_once::<closure<'_, '_>>
-fn apply_to_once::<closure<'_, '_>>(f: closure<'_, '_>) -> u8
-{
-    let _0: u8; // return
-    let f: closure<'0, '1>; // arg #1
-    let _2: closure<'2, '3>; // anonymous local
-    let _3: (u8, u8); // anonymous local
-
-    storage_live(_0)
-    storage_live(_2)
-    _2 = move f
-    storage_live(_3)
-    _3 = (const 10u8, const 20u8)
-    _0 = impl_FnOnce_for_closure<'8, '9>::call_once(move _2, move _3)
-    ↳⚡ conditional_drop[drop_glue<'14, '15, '16>] _2
-        ↳⚡ storage_dead(f)
-            unwind_terminate
-        conditional_drop[drop_glue<'28, '29, '30>] f
-        ↳⚡ storage_dead(f)
-            unwind_terminate
-        storage_dead(f)
-        unwind_continue
-    storage_dead(_3)
-    storage_dead(_2)
-    conditional_drop[drop_glue<'21, '22, '23>] f
-    ↳⚡ storage_dead(f)
-        unwind_continue
-    storage_dead(f)
-    return
-}
-
-// Full name: test_crate::main
-fn main()
-{
-    let _0: (); // return
-    let v: u8; // local
-    let z: u8; // local
-    let f: closure<'2, '3>; // local
-    let _4: &'5 u8; // anonymous local
-    let _5: &'6 u8; // anonymous local
-    let _6: u8; // anonymous local
-    let _7: &'10 closure<'11, '12>; // anonymous local
-    let _8: (u8, u8); // anonymous local
-    let _9: u8; // anonymous local
-    let _10: &'13 closure<'14, '15>; // anonymous local
-    let _11: &'16 closure<'17, '18>; // anonymous local
-    let _12: u8; // anonymous local
-    let _13: &'22 mut closure<'23, '24>; // anonymous local
-    let _14: &'25 mut closure<'26, '27>; // anonymous local
-    let _15: u8; // anonymous local
-    let _16: closure<'28, '29>; // anonymous local
-
-    storage_live(_0)
-    _0 = ()
-    storage_live(v)
-    v = const 5u8
-    fake_read(v)
-    storage_live(z)
-    z = const 1u8
-    fake_read(z)
-    storage_live(f)
-    storage_live(_4)
-    _4 = &v
-    storage_live(_5)
-    _5 = &z
-    f = closure { _0: move _4, _1: move _5 }
-    storage_dead(_5)
-    storage_dead(_4)
-    fake_read(f)
-    storage_live(_6)
-    storage_live(_7)
-    _7 = &f
-    storage_live(_8)
-    _8 = (const 10u8, const 20u8)
-    _6 = impl_Fn_for_closure<'36, '37>::call<'38>(move _7, move _8)
-    ↳⚡ unwind_continue
-    storage_dead(_8)
-    storage_dead(_7)
-    storage_dead(_6)
-    storage_live(_9)
-    storage_live(_10)
-    storage_live(_11)
-    _11 = &f
-    _10 = &(*_11)
-    _9 = apply_to::<closure<'_, '_>><'42>(move _10)
-    ↳⚡ unwind_continue
-    storage_dead(_10)
-    storage_dead(_11)
-    storage_dead(_9)
-    storage_live(_12)
-    storage_live(_13)
-    storage_live(_14)
-    _14 = &mut f
-    _13 = &two-phase-mut (*_14)
-    _12 = apply_to_mut::<closure<'_, '_>><'46>(move _13)
-    ↳⚡ unwind_continue
-    storage_dead(_13)
-    storage_dead(_14)
-    storage_dead(_12)
-    storage_live(_15)
-    storage_live(_16)
-    _16 = copy f
-    _15 = apply_to_once::<closure<'_, '_>>(move _16)
-    ↳⚡ unwind_continue
-    storage_dead(_16)
-    storage_dead(_15)
-    _0 = ()
-    storage_dead(f)
-    storage_dead(z)
-    storage_dead(v)
-    return
-}
-
-// Full name: test_crate::main::closure::{impl Destruct for closure<'_0, '_1>}
-impl<'_0, '_1> "impl_Destruct_for_closure" Destruct for closure<'_0, '_1> {
-    fn drop_glue<'_0_1> = drop_glue<'_0, '_1, '_0_1>
-    non-dyn-compatible
-}
-
-// Full name: test_crate::main::{impl FnOnce<(u8, u8)> for closure<'_0, '_1>}::call_once
-fn call_once<'_0, '_1>(_1: closure<'_0, '_1>, _2: (u8, u8)) -> u8
-{
-    let _0: u8; // return
-    let _1: closure<'_0, '_1>; // arg #1
-    let _2: (u8, u8); // arg #2
-    let _3: &'1 mut closure<'_0, '_1>; // anonymous local
-
-    storage_live(_0)
-    storage_live(_3)
-    _3 = &mut _1
-    _0 = impl_FnMut_for_closure<'_0, '_1>::call_mut<'6>(move _3, move _2)
-    ↳⚡ drop[drop_glue<'_0, '_1, '11>] _1
-        ↳⚡ storage_dead(_3)
-            storage_dead(_2)
-            storage_dead(_1)
-            unwind_terminate
-        storage_dead(_3)
-        storage_dead(_2)
-        storage_dead(_1)
-        unwind_continue
-    drop[drop_glue<'_0, '_1, '16>] _1
-    ↳⚡ storage_dead(_3)
-        storage_dead(_2)
-        storage_dead(_1)
-        unwind_continue
-    storage_dead(_3)
-    storage_dead(_2)
-    storage_dead(_1)
-    return
-}
-
 // Full name: test_crate::main::{impl Fn<(u8, u8)> for closure<'_0, '_1>}::call
 fn call<'_0, '_1, '_2>(_1: &'_2 closure<'_0, '_1>, tupled_args: (u8, u8)) -> u8
 where
@@ -389,6 +153,28 @@ where
     return
 }
 
+// Full name: test_crate::apply_to::<closure<'_, '_>>
+fn apply_to::<closure<'_, '_>><'_0>(f: &'_0 closure<'_, '_>) -> u8
+{
+    let _0: u8; // return
+    let f: &'3 closure<'4, '5>; // arg #1
+    let _2: &'6 closure<'7, '8>; // anonymous local
+    let _3: (u8, u8); // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = &(*f)
+    storage_live(_3)
+    _3 = (const 10u8, const 20u8)
+    _0 = call<'11, '12, '14>(move _2, move _3)
+    ↳⚡ storage_dead(f)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(f)
+    return
+}
+
 // Full name: test_crate::main::{impl FnMut<(u8, u8)> for closure<'_0, '_1>}::call_mut
 fn call_mut<'_0, '_1, '_2>(state: &'_2 mut closure<'_0, '_1>, args: (u8, u8)) -> u8
 where
@@ -412,6 +198,220 @@ where
     storage_dead(args)
     storage_dead(state)
     return
+}
+
+// Full name: test_crate::apply_to_mut::<closure<'_, '_>>
+fn apply_to_mut::<closure<'_, '_>><'_0>(f: &'_0 mut closure<'_, '_>) -> u8
+{
+    let _0: u8; // return
+    let f: &'3 mut closure<'4, '5>; // arg #1
+    let _2: &'6 mut closure<'7, '8>; // anonymous local
+    let _3: (u8, u8); // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = &mut (*f)
+    storage_live(_3)
+    _3 = (const 10u8, const 20u8)
+    _0 = call_mut<'11, '12, '14>(move _2, move _3)
+    ↳⚡ storage_dead(f)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(f)
+    return
+}
+
+// Full name: test_crate::main::closure::{impl Destruct for closure<'_0, '_1>}::drop_glue
+unsafe fn drop_glue<'_0, '_1, '_2>(_1: &'_2 mut closure<'_0, '_1>)
+where
+    RegionOutlives0: '_0: '_2,
+    RegionOutlives1: '_1: '_2,
+{
+    let _0: (); // return
+    let _1: &'1 mut closure<'_0, '_1>; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u8, u8)> for closure<'_0, '_1>}::call_once
+fn call_once<'_0, '_1>(_1: closure<'_0, '_1>, _2: (u8, u8)) -> u8
+{
+    let _0: u8; // return
+    let _1: closure<'_0, '_1>; // arg #1
+    let _2: (u8, u8); // arg #2
+    let _3: &'1 mut closure<'_0, '_1>; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = call_mut<'_0, '_1, '5>(move _3, move _2)
+    ↳⚡ drop[drop_glue<'_0, '_1, '10>] _1
+        ↳⚡ storage_dead(_3)
+            storage_dead(_2)
+            storage_dead(_1)
+            unwind_terminate
+        storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    drop[drop_glue<'_0, '_1, '15>] _1
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::apply_to_once::<closure<'_, '_>>
+fn apply_to_once::<closure<'_, '_>>(f: closure<'_, '_>) -> u8
+{
+    let _0: u8; // return
+    let f: closure<'0, '1>; // arg #1
+    let _2: closure<'2, '3>; // anonymous local
+    let _3: (u8, u8); // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = move f
+    storage_live(_3)
+    _3 = (const 10u8, const 20u8)
+    _0 = call_once<'4, '5>(move _2, move _3)
+    ↳⚡ conditional_drop[drop_glue<'10, '11, '12>] _2
+        ↳⚡ storage_dead(f)
+            unwind_terminate
+        conditional_drop[drop_glue<'24, '25, '26>] f
+        ↳⚡ storage_dead(f)
+            unwind_terminate
+        storage_dead(f)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    conditional_drop[drop_glue<'17, '18, '19>] f
+    ↳⚡ storage_dead(f)
+        unwind_continue
+    storage_dead(f)
+    return
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let v: u8; // local
+    let z: u8; // local
+    let f: closure<'2, '3>; // local
+    let _4: &'5 u8; // anonymous local
+    let _5: &'6 u8; // anonymous local
+    let _6: u8; // anonymous local
+    let _7: &'10 closure<'11, '12>; // anonymous local
+    let _8: (u8, u8); // anonymous local
+    let _9: u8; // anonymous local
+    let _10: &'13 closure<'14, '15>; // anonymous local
+    let _11: &'16 closure<'17, '18>; // anonymous local
+    let _12: u8; // anonymous local
+    let _13: &'22 mut closure<'23, '24>; // anonymous local
+    let _14: &'25 mut closure<'26, '27>; // anonymous local
+    let _15: u8; // anonymous local
+    let _16: closure<'28, '29>; // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(v)
+    v = const 5u8
+    fake_read(v)
+    storage_live(z)
+    z = const 1u8
+    fake_read(z)
+    storage_live(f)
+    storage_live(_4)
+    _4 = &v
+    storage_live(_5)
+    _5 = &z
+    f = closure { _0: move _4, _1: move _5 }
+    storage_dead(_5)
+    storage_dead(_4)
+    fake_read(f)
+    storage_live(_6)
+    storage_live(_7)
+    _7 = &f
+    storage_live(_8)
+    _8 = (const 10u8, const 20u8)
+    _6 = call<'32, '33, '35>(move _7, move _8)
+    ↳⚡ unwind_continue
+    storage_dead(_8)
+    storage_dead(_7)
+    storage_dead(_6)
+    storage_live(_9)
+    storage_live(_10)
+    storage_live(_11)
+    _11 = &f
+    _10 = &(*_11)
+    _9 = apply_to::<closure<'_, '_>><'39>(move _10)
+    ↳⚡ unwind_continue
+    storage_dead(_10)
+    storage_dead(_11)
+    storage_dead(_9)
+    storage_live(_12)
+    storage_live(_13)
+    storage_live(_14)
+    _14 = &mut f
+    _13 = &two-phase-mut (*_14)
+    _12 = apply_to_mut::<closure<'_, '_>><'43>(move _13)
+    ↳⚡ unwind_continue
+    storage_dead(_13)
+    storage_dead(_14)
+    storage_dead(_12)
+    storage_live(_15)
+    storage_live(_16)
+    _16 = copy f
+    _15 = apply_to_once::<closure<'_, '_>>(move _16)
+    ↳⚡ unwind_continue
+    storage_dead(_16)
+    storage_dead(_15)
+    _0 = ()
+    storage_dead(f)
+    storage_dead(z)
+    storage_dead(v)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u8, u8)> for closure<'_0, '_1>}
+impl<'_0, '_1> "impl_FnOnce_for_closure" FnOnce<(u8, u8)> for closure<'_0, '_1> {
+    proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
+    proof ImpliedClause1: ((u8, u8): Sized) = {built_in impl Sized for (u8, u8)}
+    proof ImpliedClause2: ((u8, u8): Tuple) = {built_in impl Tuple for (u8, u8)}
+    vtable: impl_FnOnce_for_closure::{vtable}<'_0, '_1>
+}
+
+// Full name: test_crate::main::{impl FnMut<(u8, u8)> for closure<'_0, '_1>}
+impl<'_0, '_1> "impl_FnMut_for_closure" FnMut<(u8, u8)> for closure<'_0, '_1> {
+    proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
+    proof ImpliedClause1: (closure<'_0, '_1>: FnOnce<(u8, u8)>) = impl_FnOnce_for_closure<'_0, '_1>
+    proof ImpliedClause2: ((u8, u8): Sized) = {built_in impl Sized for (u8, u8)}
+    proof ImpliedClause3: ((u8, u8): Tuple) = {built_in impl Tuple for (u8, u8)}
+    vtable: impl_FnMut_for_closure::{vtable}<'_0, '_1>
+}
+
+// Full name: test_crate::main::{impl Fn<(u8, u8)> for closure<'_0, '_1>}
+impl<'_0, '_1> "impl_Fn_for_closure" Fn<(u8, u8)> for closure<'_0, '_1> {
+    proof ImpliedClause0: (closure<'_0, '_1>: MetaSized) = {built_in impl MetaSized for closure<'_0, '_1>}
+    proof ImpliedClause1: (closure<'_0, '_1>: FnMut<(u8, u8)>) = impl_FnMut_for_closure<'_0, '_1>
+    proof ImpliedClause2: ((u8, u8): Sized) = {built_in impl Sized for (u8, u8)}
+    proof ImpliedClause3: ((u8, u8): Tuple) = {built_in impl Tuple for (u8, u8)}
+    vtable: impl_Fn_for_closure::{vtable}<'_0, '_1>
+}
+
+// Full name: test_crate::main::closure::{impl Destruct for closure<'_0, '_1>}
+impl<'_0, '_1> "impl_Destruct_for_closure" Destruct for closure<'_0, '_1> {
+    fn drop_glue<'_0_1> = drop_glue<'_0, '_1, '_0_1>
+    non-dyn-compatible
 }
 
 

--- a/charon/tests/ui/monomorphization/closure-fnonce.out
+++ b/charon/tests/ui/monomorphization/closure-fnonce.out
@@ -82,12 +82,43 @@ unsafe fn drop_glue<'_0>(_1: &'_0 mut closure)
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(u8,)> for closure}
-impl "impl_FnOnce_for_closure" FnOnce<(u8,)> for closure {
-    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
-    proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
-    proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
-    vtable: impl_FnOnce_for_closure::{vtable}
+// Full name: test_crate::main::{impl FnOnce<(u8,)> for closure}::call_once
+fn call_once(_1: closure, tupled_args: (u8,)) -> u8
+{
+    let _0: u8; // return
+    let _1: closure; // arg #1
+    let tupled_args: (u8,); // arg #2
+    let x: u8; // local
+    let _4: (); // anonymous local
+    let _5: NotCopy; // anonymous local
+    let _6: u8; // anonymous local
+    let _7: u8; // anonymous local
+
+    storage_live(_0)
+    storage_live(x)
+    storage_live(_7)
+    x = move tupled_args._0
+    storage_live(_4)
+    storage_live(_5)
+    _5 = move _1._0
+    _4 = drop::<NotCopy>(move _5)
+    ↳⚡ storage_dead(_7)
+        storage_dead(x)
+        storage_dead(tupled_args)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_live(_6)
+    _6 = copy x
+    _7 = copy _6 panic.+ const 1u8
+    _0 = move _7
+    storage_dead(_6)
+    storage_dead(_7)
+    storage_dead(x)
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
 }
 
 // Full name: test_crate::apply_to_zero_once::<closure>
@@ -103,7 +134,7 @@ fn apply_to_zero_once::<closure>(f: closure) -> u8
     _2 = move f
     storage_live(_3)
     _3 = (const 0u8,)
-    _0 = impl_FnOnce_for_closure::call_once(move _2, move _3)
+    _0 = call_once(move _2, move _3)
     ↳⚡ conditional_drop[drop_glue<'0>] _2
         ↳⚡ storage_dead(f)
             unwind_terminate
@@ -146,49 +177,18 @@ fn main()
     return
 }
 
+// Full name: test_crate::main::{impl FnOnce<(u8,)> for closure}
+impl "impl_FnOnce_for_closure" FnOnce<(u8,)> for closure {
+    proof ImpliedClause0: (closure: MetaSized) = {built_in impl MetaSized for closure}
+    proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
+    vtable: impl_FnOnce_for_closure::{vtable}
+}
+
 // Full name: test_crate::main::closure::{impl Destruct for closure}
 impl "impl_Destruct_for_closure" Destruct for closure {
     fn drop_glue<'_0_1> = drop_glue<'_0_1>
     non-dyn-compatible
-}
-
-// Full name: test_crate::main::{impl FnOnce<(u8,)> for closure}::call_once
-fn call_once(_1: closure, tupled_args: (u8,)) -> u8
-{
-    let _0: u8; // return
-    let _1: closure; // arg #1
-    let tupled_args: (u8,); // arg #2
-    let x: u8; // local
-    let _4: (); // anonymous local
-    let _5: NotCopy; // anonymous local
-    let _6: u8; // anonymous local
-    let _7: u8; // anonymous local
-
-    storage_live(_0)
-    storage_live(x)
-    storage_live(_7)
-    x = move tupled_args._0
-    storage_live(_4)
-    storage_live(_5)
-    _5 = move _1._0
-    _4 = drop::<NotCopy>(move _5)
-    ↳⚡ storage_dead(_7)
-        storage_dead(x)
-        storage_dead(tupled_args)
-        storage_dead(_1)
-        unwind_continue
-    storage_dead(_5)
-    storage_dead(_4)
-    storage_live(_6)
-    _6 = copy x
-    _7 = copy _6 panic.+ const 1u8
-    _0 = move _7
-    storage_dead(_6)
-    storage_dead(_7)
-    storage_dead(x)
-    storage_dead(tupled_args)
-    storage_dead(_1)
-    return
 }
 
 

--- a/charon/tests/ui/monomorphization/closure-method-calls.out
+++ b/charon/tests/ui/monomorphization/closure-method-calls.out
@@ -1,0 +1,690 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Tuple
+#[fundamental]
+#[lang_item(Tuple)]
+pub trait Tuple<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+opaque type core::ops::function::Fn::{vtable}
+
+opaque type core::ops::function::FnOnce::{vtable}
+
+// Full name: core::ops::function::FnOnce
+#[fundamental]
+#[lang_item(FnOnce)]
+pub trait FnOnce<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    vtable: core::ops::function::FnOnce::{vtable}
+}
+
+opaque type core::ops::function::FnMut::{vtable}
+
+// Full name: core::ops::function::FnMut
+#[fundamental]
+#[lang_item(FnMut)]
+pub trait FnMut<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    vtable: core::ops::function::FnMut::{vtable}
+}
+
+// Full name: core::ops::function::Fn
+#[fundamental]
+#[lang_item(Fn)]
+pub trait Fn<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    vtable: core::ops::function::Fn::{vtable}
+}
+
+struct (_,)::<i32> {
+  _0: i32,
+}
+
+struct (_, _)::<i32, bool> {
+  _0: i32,
+  _1: bool,
+}
+
+struct test_crate::main::closure {}
+
+// Full name: test_crate::main::closure::{impl Destruct for test_crate::main::closure}::drop_glue
+unsafe fn {impl Destruct for test_crate::main::closure}::drop_glue<'_0>(_1: &'_0 mut test_crate::main::closure)
+{
+    let _0: (); // return
+    let _1: &'1 mut test_crate::main::closure; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(i32,)> for test_crate::main::closure}::call
+fn impl_Fn_for_closure::call<'_0>(_1: &'_0 test_crate::main::closure, tupled_args: (i32,)) -> i32
+{
+    let _0: i32; // return
+    let _1: &'1 test_crate::main::closure; // arg #1
+    let tupled_args: (i32,); // arg #2
+    let x: i32; // local
+    let _4: i32; // anonymous local
+    let _5: i32; // anonymous local
+
+    storage_live(_0)
+    storage_live(x)
+    storage_live(_5)
+    x = move tupled_args._0
+    storage_live(_4)
+    _4 = copy x
+    _5 = copy _4 panic.+ const 1i32
+    _0 = move _5
+    storage_dead(_4)
+    storage_dead(_5)
+    storage_dead(x)
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::apply::<test_crate::main::closure>
+fn apply::<test_crate::main::closure>(f: test_crate::main::closure, x: i32) -> i32
+{
+    let _0: i32; // return
+    let f: test_crate::main::closure; // arg #1
+    let x: i32; // arg #2
+    let _3: &'1 test_crate::main::closure; // anonymous local
+    let _4: (i32,); // anonymous local
+    let _5: i32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &f
+    storage_live(_4)
+    storage_live(_5)
+    _5 = copy x
+    _4 = (move _5,)
+    _0 = impl_Fn_for_closure::call<'3>(move _3, move _4)
+    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::closure}::drop_glue<'4>] f
+        ↳⚡ storage_dead(x)
+            storage_dead(f)
+            unwind_terminate
+        storage_dead(x)
+        storage_dead(f)
+        unwind_continue
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_dead(_3)
+    conditional_drop[{impl Destruct for test_crate::main::closure}::drop_glue<'5>] f
+    ↳⚡ storage_dead(x)
+        storage_dead(f)
+        unwind_continue
+    storage_dead(x)
+    storage_dead(f)
+    return
+}
+
+// Full name: test_crate::plain
+fn plain(x: i32) -> i32
+{
+    let _0: i32; // return
+    let x: i32; // arg #1
+    let _2: i32; // anonymous local
+    let _3: i32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    storage_live(_2)
+    _2 = copy x
+    _3 = copy _2 panic.+ const 1i32
+    _0 = move _3
+    storage_dead(_2)
+    storage_dead(_3)
+    storage_dead(x)
+    return
+}
+
+// Full name: test_crate::{impl Fn<(i32,)> for plain}::call
+fn {impl Fn<(i32,)> for plain}::call<'_0>(state: &'_0 plain, args: (i32,)) -> i32
+{
+    let _0: i32; // return
+    let state: &'_0 plain; // arg #1
+    let args: (i32,); // arg #2
+
+    storage_live(_0)
+    _0 = plain(move args._0)
+    ↳⚡ storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::apply::<plain>
+fn apply::<plain>(f: plain, x: i32) -> i32
+{
+    let _0: i32; // return
+    let f: plain; // arg #1
+    let x: i32; // arg #2
+    let _3: &'1 plain; // anonymous local
+    let _4: (i32,); // anonymous local
+    let _5: i32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &f
+    storage_live(_4)
+    storage_live(_5)
+    _5 = copy x
+    _4 = (move _5,)
+    _0 = {impl Fn<(i32,)> for plain}::call<'3>(move _3, move _4)
+    ↳⚡ storage_dead(x)
+        storage_dead(f)
+        unwind_continue
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_dead(_3)
+    storage_dead(x)
+    storage_dead(f)
+    return
+}
+
+struct test_crate::main::closure#1 {}
+
+// Full name: test_crate::main::closure#1::{impl Destruct for test_crate::main::closure#1}::drop_glue
+unsafe fn {impl Destruct for test_crate::main::closure#1}::drop_glue<'_0>(_1: &'_0 mut test_crate::main::closure#1)
+{
+    let _0: (); // return
+    let _1: &'1 mut test_crate::main::closure#1; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(i32,)> for test_crate::main::closure#1}::call_mut
+fn {impl FnMut<(i32,)> for test_crate::main::closure#1}::call_mut<'_0>(_1: &'_0 mut test_crate::main::closure#1, tupled_args: (i32,)) -> i32
+{
+    let _0: i32; // return
+    let _1: &'1 mut test_crate::main::closure#1; // arg #1
+    let tupled_args: (i32,); // arg #2
+    let x: i32; // local
+    let _4: i32; // anonymous local
+    let _5: i32; // anonymous local
+
+    storage_live(_0)
+    storage_live(x)
+    storage_live(_5)
+    x = move tupled_args._0
+    storage_live(_4)
+    _4 = copy x
+    _5 = copy _4 panic.+ const 1i32
+    _0 = move _5
+    storage_dead(_4)
+    storage_dead(_5)
+    storage_dead(x)
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::apply_mut::<test_crate::main::closure#1>
+fn apply_mut::<test_crate::main::closure#1>(f: test_crate::main::closure#1, x: i32) -> i32
+{
+    let _0: i32; // return
+    let f: test_crate::main::closure#1; // arg #1
+    let x: i32; // arg #2
+    let _3: &'1 mut test_crate::main::closure#1; // anonymous local
+    let _4: (i32,); // anonymous local
+    let _5: i32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &mut f
+    storage_live(_4)
+    storage_live(_5)
+    _5 = copy x
+    _4 = (move _5,)
+    _0 = {impl FnMut<(i32,)> for test_crate::main::closure#1}::call_mut<'3>(move _3, move _4)
+    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::closure#1}::drop_glue<'4>] f
+        ↳⚡ storage_dead(x)
+            storage_dead(f)
+            unwind_terminate
+        storage_dead(x)
+        storage_dead(f)
+        unwind_continue
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_dead(_3)
+    conditional_drop[{impl Destruct for test_crate::main::closure#1}::drop_glue<'5>] f
+    ↳⚡ storage_dead(x)
+        storage_dead(f)
+        unwind_continue
+    storage_dead(x)
+    storage_dead(f)
+    return
+}
+
+// Full name: test_crate::{impl FnMut<(i32,)> for plain}::call_mut
+fn {impl FnMut<(i32,)> for plain}::call_mut<'_0>(state: &'_0 mut plain, args: (i32,)) -> i32
+{
+    let _0: i32; // return
+    let state: &'_0 mut plain; // arg #1
+    let args: (i32,); // arg #2
+
+    storage_live(_0)
+    _0 = plain(move args._0)
+    ↳⚡ storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::apply_mut::<plain>
+fn apply_mut::<plain>(f: plain, x: i32) -> i32
+{
+    let _0: i32; // return
+    let f: plain; // arg #1
+    let x: i32; // arg #2
+    let _3: &'1 mut plain; // anonymous local
+    let _4: (i32,); // anonymous local
+    let _5: i32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &mut f
+    storage_live(_4)
+    storage_live(_5)
+    _5 = copy x
+    _4 = (move _5,)
+    _0 = {impl FnMut<(i32,)> for plain}::call_mut<'3>(move _3, move _4)
+    ↳⚡ storage_dead(x)
+        storage_dead(f)
+        unwind_continue
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_dead(_3)
+    storage_dead(x)
+    storage_dead(f)
+    return
+}
+
+struct test_crate::main::closure#2 {}
+
+// Full name: test_crate::main::closure#2::{impl Destruct for test_crate::main::closure#2}::drop_glue
+unsafe fn {impl Destruct for test_crate::main::closure#2}::drop_glue<'_0>(_1: &'_0 mut test_crate::main::closure#2)
+{
+    let _0: (); // return
+    let _1: &'1 mut test_crate::main::closure#2; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(i32,)> for test_crate::main::closure#2}::call_once
+fn {impl FnOnce<(i32,)> for test_crate::main::closure#2}::call_once(_1: test_crate::main::closure#2, tupled_args: (i32,)) -> i32
+{
+    let _0: i32; // return
+    let _1: test_crate::main::closure#2; // arg #1
+    let tupled_args: (i32,); // arg #2
+    let x: i32; // local
+    let _4: i32; // anonymous local
+    let _5: i32; // anonymous local
+
+    storage_live(_0)
+    storage_live(x)
+    storage_live(_5)
+    x = move tupled_args._0
+    storage_live(_4)
+    _4 = copy x
+    _5 = copy _4 panic.+ const 1i32
+    _0 = move _5
+    storage_dead(_4)
+    storage_dead(_5)
+    storage_dead(x)
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::apply_once::<test_crate::main::closure#2>
+fn apply_once::<test_crate::main::closure#2>(f: test_crate::main::closure#2, x: i32) -> i32
+{
+    let _0: i32; // return
+    let f: test_crate::main::closure#2; // arg #1
+    let x: i32; // arg #2
+    let _3: test_crate::main::closure#2; // anonymous local
+    let _4: (i32,); // anonymous local
+    let _5: i32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = move f
+    storage_live(_4)
+    storage_live(_5)
+    _5 = copy x
+    _4 = (move _5,)
+    _0 = {impl FnOnce<(i32,)> for test_crate::main::closure#2}::call_once(move _3, move _4)
+    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::closure#2}::drop_glue<'0>] _3
+        ↳⚡ storage_dead(x)
+            storage_dead(f)
+            unwind_terminate
+        conditional_drop[{impl Destruct for test_crate::main::closure#2}::drop_glue<'2>] f
+        ↳⚡ storage_dead(x)
+            storage_dead(f)
+            unwind_terminate
+        storage_dead(x)
+        storage_dead(f)
+        unwind_continue
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_dead(_3)
+    conditional_drop[{impl Destruct for test_crate::main::closure#2}::drop_glue<'1>] f
+    ↳⚡ storage_dead(x)
+        storage_dead(f)
+        unwind_continue
+    storage_dead(x)
+    storage_dead(f)
+    return
+}
+
+// Full name: test_crate::{impl FnOnce<(i32,)> for plain}::call_once
+fn {impl FnOnce<(i32,)> for plain}::call_once(state: plain, args: (i32,)) -> i32
+{
+    let _0: i32; // return
+    let state: plain; // arg #1
+    let args: (i32,); // arg #2
+
+    storage_live(_0)
+    _0 = plain(move args._0)
+    ↳⚡ storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::apply_once::<plain>
+fn apply_once::<plain>(f: plain, x: i32) -> i32
+{
+    let _0: i32; // return
+    let f: plain; // arg #1
+    let x: i32; // arg #2
+    let _3: plain; // anonymous local
+    let _4: (i32,); // anonymous local
+    let _5: i32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = move f
+    storage_live(_4)
+    storage_live(_5)
+    _5 = copy x
+    _4 = (move _5,)
+    _0 = {impl FnOnce<(i32,)> for plain}::call_once(move _3, move _4)
+    ↳⚡ storage_dead(x)
+        storage_dead(f)
+        unwind_continue
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_dead(_3)
+    storage_dead(x)
+    storage_dead(f)
+    return
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let _1: i32; // anonymous local
+    let _2: test_crate::main::closure; // anonymous local
+    let _3: i32; // anonymous local
+    let _4: test_crate::main::closure#1; // anonymous local
+    let _5: i32; // anonymous local
+    let _6: test_crate::main::closure#2; // anonymous local
+    let _7: i32; // anonymous local
+    let _8: i32; // anonymous local
+    let _9: i32; // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(_1)
+    storage_live(_2)
+    _2 = test_crate::main::closure {  }
+    _1 = apply::<test_crate::main::closure>(move _2, const 1i32)
+    ↳⚡ unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    storage_live(_3)
+    storage_live(_4)
+    _4 = test_crate::main::closure#1 {  }
+    _3 = apply_mut::<test_crate::main::closure#1>(move _4, const 1i32)
+    ↳⚡ unwind_continue
+    storage_dead(_4)
+    storage_dead(_3)
+    storage_live(_5)
+    storage_live(_6)
+    _6 = test_crate::main::closure#2 {  }
+    _5 = apply_once::<test_crate::main::closure#2>(move _6, const 1i32)
+    ↳⚡ unwind_continue
+    storage_dead(_6)
+    storage_dead(_5)
+    storage_live(_7)
+    _7 = apply::<plain>(const plain, const 1i32)
+    ↳⚡ unwind_continue
+    storage_dead(_7)
+    storage_live(_8)
+    _8 = apply_mut::<plain>(const plain, const 1i32)
+    ↳⚡ unwind_continue
+    storage_dead(_8)
+    storage_live(_9)
+    _9 = apply_once::<plain>(const plain, const 1i32)
+    ↳⚡ unwind_continue
+    storage_dead(_9)
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(i32,)> for test_crate::main::closure}
+impl FnOnce<(i32,)> for test_crate::main::closure {
+    proof ImpliedClause0: (test_crate::main::closure: MetaSized) = {built_in impl MetaSized for test_crate::main::closure}
+    proof ImpliedClause1: ((i32,): Sized) = {built_in impl Sized for (i32,)}
+    proof ImpliedClause2: ((i32,): Tuple) = {built_in impl Tuple for (i32,)}
+    vtable: {impl FnOnce<(i32,)> for test_crate::main::closure}::{vtable}
+}
+
+// Full name: test_crate::main::{impl FnMut<(i32,)> for test_crate::main::closure}
+impl FnMut<(i32,)> for test_crate::main::closure {
+    proof ImpliedClause0: (test_crate::main::closure: MetaSized) = {built_in impl MetaSized for test_crate::main::closure}
+    proof ImpliedClause1: (test_crate::main::closure: FnOnce<(i32,)>) = {impl FnOnce<(i32,)> for test_crate::main::closure}
+    proof ImpliedClause2: ((i32,): Sized) = {built_in impl Sized for (i32,)}
+    proof ImpliedClause3: ((i32,): Tuple) = {built_in impl Tuple for (i32,)}
+    vtable: {impl FnMut<(i32,)> for test_crate::main::closure}::{vtable}
+}
+
+// Full name: test_crate::main::{impl Fn<(i32,)> for test_crate::main::closure}
+impl "impl_Fn_for_closure" Fn<(i32,)> for test_crate::main::closure {
+    proof ImpliedClause0: (test_crate::main::closure: MetaSized) = {built_in impl MetaSized for test_crate::main::closure}
+    proof ImpliedClause1: (test_crate::main::closure: FnMut<(i32,)>) = {impl FnMut<(i32,)> for test_crate::main::closure}
+    proof ImpliedClause2: ((i32,): Sized) = {built_in impl Sized for (i32,)}
+    proof ImpliedClause3: ((i32,): Tuple) = {built_in impl Tuple for (i32,)}
+    vtable: impl_Fn_for_closure::{vtable}
+}
+
+// Full name: test_crate::main::closure::{impl Destruct for test_crate::main::closure}
+impl Destruct for test_crate::main::closure {
+    fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::closure}::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::main::{impl FnMut<(i32,)> for test_crate::main::closure}::call_mut
+fn {impl FnMut<(i32,)> for test_crate::main::closure}::call_mut<'_0>(state: &'_0 mut test_crate::main::closure, args: (i32,)) -> i32
+{
+    let _0: i32; // return
+    let state: &'_0 mut test_crate::main::closure; // arg #1
+    let args: (i32,); // arg #2
+    let _3: &'0 test_crate::main::closure; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &(*state)
+    _0 = impl_Fn_for_closure::call<'2>(move _3, move args)
+    ↳⚡ storage_dead(_3)
+        storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(i32,)> for test_crate::main::closure}::call_once
+fn {impl FnOnce<(i32,)> for test_crate::main::closure}::call_once(_1: test_crate::main::closure, _2: (i32,)) -> i32
+{
+    let _0: i32; // return
+    let _1: test_crate::main::closure; // arg #1
+    let _2: (i32,); // arg #2
+    let _3: &'1 mut test_crate::main::closure; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = {impl FnMut<(i32,)> for test_crate::main::closure}::call_mut<'3>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::main::closure}::drop_glue<'4>] _1
+        ↳⚡ storage_dead(_3)
+            storage_dead(_2)
+            storage_dead(_1)
+            unwind_terminate
+        storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    drop[{impl Destruct for test_crate::main::closure}::drop_glue<'5>] _1
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(i32,)> for test_crate::main::closure#1}
+impl FnOnce<(i32,)> for test_crate::main::closure#1 {
+    proof ImpliedClause0: (test_crate::main::closure#1: MetaSized) = {built_in impl MetaSized for test_crate::main::closure#1}
+    proof ImpliedClause1: ((i32,): Sized) = {built_in impl Sized for (i32,)}
+    proof ImpliedClause2: ((i32,): Tuple) = {built_in impl Tuple for (i32,)}
+    vtable: {impl FnOnce<(i32,)> for test_crate::main::closure#1}::{vtable}
+}
+
+// Full name: test_crate::main::{impl FnMut<(i32,)> for test_crate::main::closure#1}
+impl FnMut<(i32,)> for test_crate::main::closure#1 {
+    proof ImpliedClause0: (test_crate::main::closure#1: MetaSized) = {built_in impl MetaSized for test_crate::main::closure#1}
+    proof ImpliedClause1: (test_crate::main::closure#1: FnOnce<(i32,)>) = {impl FnOnce<(i32,)> for test_crate::main::closure#1}
+    proof ImpliedClause2: ((i32,): Sized) = {built_in impl Sized for (i32,)}
+    proof ImpliedClause3: ((i32,): Tuple) = {built_in impl Tuple for (i32,)}
+    vtable: {impl FnMut<(i32,)> for test_crate::main::closure#1}::{vtable}
+}
+
+// Full name: test_crate::main::closure#1::{impl Destruct for test_crate::main::closure#1}
+impl Destruct for test_crate::main::closure#1 {
+    fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::closure#1}::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::main::{impl FnOnce<(i32,)> for test_crate::main::closure#1}::call_once
+fn {impl FnOnce<(i32,)> for test_crate::main::closure#1}::call_once(_1: test_crate::main::closure#1, _2: (i32,)) -> i32
+{
+    let _0: i32; // return
+    let _1: test_crate::main::closure#1; // arg #1
+    let _2: (i32,); // arg #2
+    let _3: &'1 mut test_crate::main::closure#1; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = {impl FnMut<(i32,)> for test_crate::main::closure#1}::call_mut<'3>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::main::closure#1}::drop_glue<'4>] _1
+        ↳⚡ storage_dead(_3)
+            storage_dead(_2)
+            storage_dead(_1)
+            unwind_terminate
+        storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    drop[{impl Destruct for test_crate::main::closure#1}::drop_glue<'5>] _1
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(i32,)> for test_crate::main::closure#2}
+impl FnOnce<(i32,)> for test_crate::main::closure#2 {
+    proof ImpliedClause0: (test_crate::main::closure#2: MetaSized) = {built_in impl MetaSized for test_crate::main::closure#2}
+    proof ImpliedClause1: ((i32,): Sized) = {built_in impl Sized for (i32,)}
+    proof ImpliedClause2: ((i32,): Tuple) = {built_in impl Tuple for (i32,)}
+    vtable: {impl FnOnce<(i32,)> for test_crate::main::closure#2}::{vtable}
+}
+
+// Full name: test_crate::main::closure#2::{impl Destruct for test_crate::main::closure#2}
+impl Destruct for test_crate::main::closure#2 {
+    fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::closure#2}::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+
+

--- a/charon/tests/ui/monomorphization/closure-method-calls.rs
+++ b/charon/tests/ui/monomorphization/closure-method-calls.rs
@@ -1,0 +1,27 @@
+//@ charon-args=--monomorphize
+//@ charon-args=--start-from=crate::main
+
+fn apply(f: impl Fn(i32) -> i32, x: i32) -> i32 {
+    f(x)
+}
+
+fn apply_mut(mut f: impl FnMut(i32) -> i32, x: i32) -> i32 {
+    f(x)
+}
+
+fn apply_once(f: impl FnOnce(i32) -> i32, x: i32) -> i32 {
+    f(x)
+}
+
+fn plain(x: i32) -> i32 {
+    x + 1
+}
+
+fn main() {
+    apply(|x| x + 1, 1);
+    apply_mut(|x| x + 1, 1);
+    apply_once(|x| x + 1, 1);
+    apply(plain, 1);
+    apply_mut(plain, 1);
+    apply_once(plain, 1);
+}

--- a/charon/tests/ui/monomorphization/closures.out
+++ b/charon/tests/ui/monomorphization/closures.out
@@ -111,30 +111,36 @@ where
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure<'_0>}
-impl<'_0> FnOnce<(u8,)> for test_crate::main::closure<'_0> {
-    proof ImpliedClause0: (test_crate::main::closure<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure<'_0>}
-    proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
-    proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
-    vtable: {impl FnOnce<(u8,)> for test_crate::main::closure<'_0>}::{vtable}<'_0>
-}
+// Full name: test_crate::main::{impl Fn<(u8,)> for test_crate::main::closure<'_0>}::call
+fn call<'_0, '_1>(_1: &'_1 test_crate::main::closure<'_0>, tupled_args: (u8,)) -> u8
+where
+    RegionOutlives0: '_0: '_1,
+{
+    let _0: u8; // return
+    let _1: &'1 test_crate::main::closure<'_0>; // arg #1
+    let tupled_args: (u8,); // arg #2
+    let x: u8; // local
+    let _4: u8; // anonymous local
+    let _5: u8; // anonymous local
+    let _6: u8; // anonymous local
 
-// Full name: test_crate::main::{impl FnMut<(u8,)> for test_crate::main::closure<'_0>}
-impl<'_0> FnMut<(u8,)> for test_crate::main::closure<'_0> {
-    proof ImpliedClause0: (test_crate::main::closure<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure<'_0>}
-    proof ImpliedClause1: (test_crate::main::closure<'_0>: FnOnce<(u8,)>) = {impl FnOnce<(u8,)> for test_crate::main::closure<'_0>}<'_0>
-    proof ImpliedClause2: ((u8,): Sized) = {built_in impl Sized for (u8,)}
-    proof ImpliedClause3: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
-    vtable: {impl FnMut<(u8,)> for test_crate::main::closure<'_0>}::{vtable}<'_0>
-}
-
-// Full name: test_crate::main::{impl Fn<(u8,)> for test_crate::main::closure<'_0>}
-impl<'_0> "impl_Fn_for_closure" Fn<(u8,)> for test_crate::main::closure<'_0> {
-    proof ImpliedClause0: (test_crate::main::closure<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure<'_0>}
-    proof ImpliedClause1: (test_crate::main::closure<'_0>: FnMut<(u8,)>) = {impl FnMut<(u8,)> for test_crate::main::closure<'_0>}<'_0>
-    proof ImpliedClause2: ((u8,): Sized) = {built_in impl Sized for (u8,)}
-    proof ImpliedClause3: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
-    vtable: impl_Fn_for_closure::{vtable}<'_0>
+    storage_live(_0)
+    storage_live(x)
+    storage_live(_6)
+    x = move tupled_args._0
+    storage_live(_4)
+    _4 = copy x
+    storage_live(_5)
+    _5 = copy (*(*_1)._0)
+    _6 = copy _4 panic.+ copy _5
+    _0 = move _6
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_dead(_6)
+    storage_dead(x)
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
 }
 
 // Full name: test_crate::apply_to_zero::<test_crate::main::closure<'_>>
@@ -150,15 +156,15 @@ fn apply_to_zero::<test_crate::main::closure<'_>>(f: test_crate::main::closure<'
     _2 = &f
     storage_live(_3)
     _3 = (const 0u8,)
-    _0 = impl_Fn_for_closure<'7>::call<'8>(move _2, move _3)
-    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::closure<'_0>}::drop_glue<'11, '12>] f
+    _0 = call<'5, '7>(move _2, move _3)
+    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::closure<'_0>}::drop_glue<'10, '11>] f
         ↳⚡ storage_dead(f)
             unwind_terminate
         storage_dead(f)
         unwind_continue
     storage_dead(_3)
     storage_dead(_2)
-    conditional_drop[{impl Destruct for test_crate::main::closure<'_0>}::drop_glue<'15, '16>] f
+    conditional_drop[{impl Destruct for test_crate::main::closure<'_0>}::drop_glue<'14, '15>] f
     ↳⚡ storage_dead(f)
         unwind_continue
     storage_dead(f)
@@ -183,21 +189,41 @@ where
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure#1<'_0>}
-impl<'_0> FnOnce<(u8,)> for test_crate::main::closure#1<'_0> {
-    proof ImpliedClause0: (test_crate::main::closure#1<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure#1<'_0>}
-    proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
-    proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
-    vtable: {impl FnOnce<(u8,)> for test_crate::main::closure#1<'_0>}::{vtable}<'_0>
-}
+// Full name: test_crate::main::{impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}::call_mut
+fn {impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}::call_mut<'_0, '_1>(_1: &'_1 mut test_crate::main::closure#1<'_0>, tupled_args: (u8,)) -> u8
+where
+    RegionOutlives0: '_0: '_1,
+{
+    let _0: u8; // return
+    let _1: &'1 mut test_crate::main::closure#1<'_0>; // arg #1
+    let tupled_args: (u8,); // arg #2
+    let x: u8; // local
+    let _4: u8; // anonymous local
+    let _5: u8; // anonymous local
+    let _6: u8; // anonymous local
+    let _7: u8; // anonymous local
 
-// Full name: test_crate::main::{impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}
-impl<'_0> FnMut<(u8,)> for test_crate::main::closure#1<'_0> {
-    proof ImpliedClause0: (test_crate::main::closure#1<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure#1<'_0>}
-    proof ImpliedClause1: (test_crate::main::closure#1<'_0>: FnOnce<(u8,)>) = {impl FnOnce<(u8,)> for test_crate::main::closure#1<'_0>}<'_0>
-    proof ImpliedClause2: ((u8,): Sized) = {built_in impl Sized for (u8,)}
-    proof ImpliedClause3: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
-    vtable: {impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}::{vtable}<'_0>
+    storage_live(_0)
+    storage_live(x)
+    storage_live(_4)
+    storage_live(_7)
+    x = move tupled_args._0
+    _4 = copy (*(*_1)._0) panic.+ const 1u8
+    (*(*_1)._0) = move _4
+    storage_live(_5)
+    _5 = copy x
+    storage_live(_6)
+    _6 = copy (*(*_1)._0)
+    _7 = copy _5 panic.+ copy _6
+    _0 = move _7
+    storage_dead(_6)
+    storage_dead(_5)
+    storage_dead(_7)
+    storage_dead(_4)
+    storage_dead(x)
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
 }
 
 // Full name: test_crate::apply_to_zero_mut::<test_crate::main::closure#1<'_>>
@@ -213,15 +239,15 @@ fn apply_to_zero_mut::<test_crate::main::closure#1<'_>>(f: test_crate::main::clo
     _2 = &mut f
     storage_live(_3)
     _3 = (const 0u8,)
-    _0 = {impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}<'7>::call_mut<'8>(move _2, move _3)
-    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::closure#1<'_0>}::drop_glue<'11, '12>] f
+    _0 = {impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}::call_mut<'5, '7>(move _2, move _3)
+    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::closure#1<'_0>}::drop_glue<'10, '11>] f
         ↳⚡ storage_dead(f)
             unwind_terminate
         storage_dead(f)
         unwind_continue
     storage_dead(_3)
     storage_dead(_2)
-    conditional_drop[{impl Destruct for test_crate::main::closure#1<'_0>}::drop_glue<'15, '16>] f
+    conditional_drop[{impl Destruct for test_crate::main::closure#1<'_0>}::drop_glue<'14, '15>] f
     ↳⚡ storage_dead(f)
         unwind_continue
     storage_dead(f)
@@ -244,12 +270,43 @@ unsafe fn {impl Destruct for test_crate::main::closure#2}::drop_glue<'_0>(_1: &'
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure#2}
-impl FnOnce<(u8,)> for test_crate::main::closure#2 {
-    proof ImpliedClause0: (test_crate::main::closure#2: MetaSized) = {built_in impl MetaSized for test_crate::main::closure#2}
-    proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
-    proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
-    vtable: {impl FnOnce<(u8,)> for test_crate::main::closure#2}::{vtable}
+// Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure#2}::call_once
+fn {impl FnOnce<(u8,)> for test_crate::main::closure#2}::call_once(_1: test_crate::main::closure#2, tupled_args: (u8,)) -> u8
+{
+    let _0: u8; // return
+    let _1: test_crate::main::closure#2; // arg #1
+    let tupled_args: (u8,); // arg #2
+    let x: u8; // local
+    let _4: (); // anonymous local
+    let _5: Thing; // anonymous local
+    let _6: u8; // anonymous local
+    let _7: u8; // anonymous local
+
+    storage_live(_0)
+    storage_live(x)
+    storage_live(_7)
+    x = move tupled_args._0
+    storage_live(_4)
+    storage_live(_5)
+    _5 = move _1._0
+    _4 = drop::<Thing>(move _5)
+    ↳⚡ storage_dead(_7)
+        storage_dead(x)
+        storage_dead(tupled_args)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_live(_6)
+    _6 = copy x
+    _7 = copy _6 panic.+ const 1u8
+    _0 = move _7
+    storage_dead(_6)
+    storage_dead(_7)
+    storage_dead(x)
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
 }
 
 // Full name: test_crate::apply_to_zero_once::<test_crate::main::closure#2>
@@ -344,74 +401,36 @@ fn main()
     return
 }
 
+// Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure<'_0>}
+impl<'_0> FnOnce<(u8,)> for test_crate::main::closure<'_0> {
+    proof ImpliedClause0: (test_crate::main::closure<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure<'_0>}
+    proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
+    vtable: {impl FnOnce<(u8,)> for test_crate::main::closure<'_0>}::{vtable}<'_0>
+}
+
+// Full name: test_crate::main::{impl FnMut<(u8,)> for test_crate::main::closure<'_0>}
+impl<'_0> FnMut<(u8,)> for test_crate::main::closure<'_0> {
+    proof ImpliedClause0: (test_crate::main::closure<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure<'_0>}
+    proof ImpliedClause1: (test_crate::main::closure<'_0>: FnOnce<(u8,)>) = {impl FnOnce<(u8,)> for test_crate::main::closure<'_0>}<'_0>
+    proof ImpliedClause2: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause3: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
+    vtable: {impl FnMut<(u8,)> for test_crate::main::closure<'_0>}::{vtable}<'_0>
+}
+
+// Full name: test_crate::main::{impl Fn<(u8,)> for test_crate::main::closure<'_0>}
+impl<'_0> "impl_Fn_for_closure" Fn<(u8,)> for test_crate::main::closure<'_0> {
+    proof ImpliedClause0: (test_crate::main::closure<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure<'_0>}
+    proof ImpliedClause1: (test_crate::main::closure<'_0>: FnMut<(u8,)>) = {impl FnMut<(u8,)> for test_crate::main::closure<'_0>}<'_0>
+    proof ImpliedClause2: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause3: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
+    vtable: impl_Fn_for_closure::{vtable}<'_0>
+}
+
 // Full name: test_crate::main::closure::{impl Destruct for test_crate::main::closure<'_0>}
 impl<'_0> Destruct for test_crate::main::closure<'_0> {
     fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::closure<'_0>}::drop_glue<'_0, '_0_1>
     non-dyn-compatible
-}
-
-// Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure<'_0>}::call_once
-fn {impl FnOnce<(u8,)> for test_crate::main::closure<'_0>}::call_once<'_0>(_1: test_crate::main::closure<'_0>, _2: (u8,)) -> u8
-{
-    let _0: u8; // return
-    let _1: test_crate::main::closure<'_0>; // arg #1
-    let _2: (u8,); // arg #2
-    let _3: &'1 mut test_crate::main::closure<'_0>; // anonymous local
-
-    storage_live(_0)
-    storage_live(_3)
-    _3 = &mut _1
-    _0 = {impl FnMut<(u8,)> for test_crate::main::closure<'_0>}<'_0>::call_mut<'4>(move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::main::closure<'_0>}::drop_glue<'_0, '7>] _1
-        ↳⚡ storage_dead(_3)
-            storage_dead(_2)
-            storage_dead(_1)
-            unwind_terminate
-        storage_dead(_3)
-        storage_dead(_2)
-        storage_dead(_1)
-        unwind_continue
-    drop[{impl Destruct for test_crate::main::closure<'_0>}::drop_glue<'_0, '10>] _1
-    ↳⚡ storage_dead(_3)
-        storage_dead(_2)
-        storage_dead(_1)
-        unwind_continue
-    storage_dead(_3)
-    storage_dead(_2)
-    storage_dead(_1)
-    return
-}
-
-// Full name: test_crate::main::{impl Fn<(u8,)> for test_crate::main::closure<'_0>}::call
-fn call<'_0, '_1>(_1: &'_1 test_crate::main::closure<'_0>, tupled_args: (u8,)) -> u8
-where
-    RegionOutlives0: '_0: '_1,
-{
-    let _0: u8; // return
-    let _1: &'1 test_crate::main::closure<'_0>; // arg #1
-    let tupled_args: (u8,); // arg #2
-    let x: u8; // local
-    let _4: u8; // anonymous local
-    let _5: u8; // anonymous local
-    let _6: u8; // anonymous local
-
-    storage_live(_0)
-    storage_live(x)
-    storage_live(_6)
-    x = move tupled_args._0
-    storage_live(_4)
-    _4 = copy x
-    storage_live(_5)
-    _5 = copy (*(*_1)._0)
-    _6 = copy _4 panic.+ copy _5
-    _0 = move _6
-    storage_dead(_5)
-    storage_dead(_4)
-    storage_dead(_6)
-    storage_dead(x)
-    storage_dead(tupled_args)
-    storage_dead(_1)
-    return
 }
 
 // Full name: test_crate::main::{impl FnMut<(u8,)> for test_crate::main::closure<'_0>}::call_mut
@@ -438,6 +457,55 @@ where
     return
 }
 
+// Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure<'_0>}::call_once
+fn {impl FnOnce<(u8,)> for test_crate::main::closure<'_0>}::call_once<'_0>(_1: test_crate::main::closure<'_0>, _2: (u8,)) -> u8
+{
+    let _0: u8; // return
+    let _1: test_crate::main::closure<'_0>; // arg #1
+    let _2: (u8,); // arg #2
+    let _3: &'1 mut test_crate::main::closure<'_0>; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = {impl FnMut<(u8,)> for test_crate::main::closure<'_0>}::call_mut<'_0, '4>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::main::closure<'_0>}::drop_glue<'_0, '7>] _1
+        ↳⚡ storage_dead(_3)
+            storage_dead(_2)
+            storage_dead(_1)
+            unwind_terminate
+        storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    drop[{impl Destruct for test_crate::main::closure<'_0>}::drop_glue<'_0, '10>] _1
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure#1<'_0>}
+impl<'_0> FnOnce<(u8,)> for test_crate::main::closure#1<'_0> {
+    proof ImpliedClause0: (test_crate::main::closure#1<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure#1<'_0>}
+    proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
+    vtable: {impl FnOnce<(u8,)> for test_crate::main::closure#1<'_0>}::{vtable}<'_0>
+}
+
+// Full name: test_crate::main::{impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}
+impl<'_0> FnMut<(u8,)> for test_crate::main::closure#1<'_0> {
+    proof ImpliedClause0: (test_crate::main::closure#1<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::closure#1<'_0>}
+    proof ImpliedClause1: (test_crate::main::closure#1<'_0>: FnOnce<(u8,)>) = {impl FnOnce<(u8,)> for test_crate::main::closure#1<'_0>}<'_0>
+    proof ImpliedClause2: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause3: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
+    vtable: {impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}::{vtable}<'_0>
+}
+
 // Full name: test_crate::main::closure#1::{impl Destruct for test_crate::main::closure#1<'_0>}
 impl<'_0> Destruct for test_crate::main::closure#1<'_0> {
     fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::closure#1<'_0>}::drop_glue<'_0, '_0_1>
@@ -455,7 +523,7 @@ fn {impl FnOnce<(u8,)> for test_crate::main::closure#1<'_0>}::call_once<'_0>(_1:
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}<'_0>::call_mut<'4>(move _3, move _2)
+    _0 = {impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}::call_mut<'_0, '4>(move _3, move _2)
     ↳⚡ drop[{impl Destruct for test_crate::main::closure#1<'_0>}::drop_glue<'_0, '7>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
@@ -476,86 +544,18 @@ fn {impl FnOnce<(u8,)> for test_crate::main::closure#1<'_0>}::call_once<'_0>(_1:
     return
 }
 
-// Full name: test_crate::main::{impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}::call_mut
-fn {impl FnMut<(u8,)> for test_crate::main::closure#1<'_0>}::call_mut<'_0, '_1>(_1: &'_1 mut test_crate::main::closure#1<'_0>, tupled_args: (u8,)) -> u8
-where
-    RegionOutlives0: '_0: '_1,
-{
-    let _0: u8; // return
-    let _1: &'1 mut test_crate::main::closure#1<'_0>; // arg #1
-    let tupled_args: (u8,); // arg #2
-    let x: u8; // local
-    let _4: u8; // anonymous local
-    let _5: u8; // anonymous local
-    let _6: u8; // anonymous local
-    let _7: u8; // anonymous local
-
-    storage_live(_0)
-    storage_live(x)
-    storage_live(_4)
-    storage_live(_7)
-    x = move tupled_args._0
-    _4 = copy (*(*_1)._0) panic.+ const 1u8
-    (*(*_1)._0) = move _4
-    storage_live(_5)
-    _5 = copy x
-    storage_live(_6)
-    _6 = copy (*(*_1)._0)
-    _7 = copy _5 panic.+ copy _6
-    _0 = move _7
-    storage_dead(_6)
-    storage_dead(_5)
-    storage_dead(_7)
-    storage_dead(_4)
-    storage_dead(x)
-    storage_dead(tupled_args)
-    storage_dead(_1)
-    return
+// Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure#2}
+impl FnOnce<(u8,)> for test_crate::main::closure#2 {
+    proof ImpliedClause0: (test_crate::main::closure#2: MetaSized) = {built_in impl MetaSized for test_crate::main::closure#2}
+    proof ImpliedClause1: ((u8,): Sized) = {built_in impl Sized for (u8,)}
+    proof ImpliedClause2: ((u8,): Tuple) = {built_in impl Tuple for (u8,)}
+    vtable: {impl FnOnce<(u8,)> for test_crate::main::closure#2}::{vtable}
 }
 
 // Full name: test_crate::main::closure#2::{impl Destruct for test_crate::main::closure#2}
 impl Destruct for test_crate::main::closure#2 {
     fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::closure#2}::drop_glue<'_0_1>
     non-dyn-compatible
-}
-
-// Full name: test_crate::main::{impl FnOnce<(u8,)> for test_crate::main::closure#2}::call_once
-fn {impl FnOnce<(u8,)> for test_crate::main::closure#2}::call_once(_1: test_crate::main::closure#2, tupled_args: (u8,)) -> u8
-{
-    let _0: u8; // return
-    let _1: test_crate::main::closure#2; // arg #1
-    let tupled_args: (u8,); // arg #2
-    let x: u8; // local
-    let _4: (); // anonymous local
-    let _5: Thing; // anonymous local
-    let _6: u8; // anonymous local
-    let _7: u8; // anonymous local
-
-    storage_live(_0)
-    storage_live(x)
-    storage_live(_7)
-    x = move tupled_args._0
-    storage_live(_4)
-    storage_live(_5)
-    _5 = move _1._0
-    _4 = drop::<Thing>(move _5)
-    ↳⚡ storage_dead(_7)
-        storage_dead(x)
-        storage_dead(tupled_args)
-        storage_dead(_1)
-        unwind_continue
-    storage_dead(_5)
-    storage_dead(_4)
-    storage_live(_6)
-    _6 = copy x
-    _7 = copy _6 panic.+ const 1u8
-    _0 = move _7
-    storage_dead(_6)
-    storage_dead(_7)
-    storage_dead(x)
-    storage_dead(tupled_args)
-    storage_dead(_1)
-    return
 }
 
 

--- a/charon/tests/ui/monomorphization/fndefs-casts.out
+++ b/charon/tests/ui/monomorphization/fndefs-casts.out
@@ -1,75 +1,22 @@
 # Final LLBC before serialization:
 
-opaque type core::marker::MetaSized::{vtable}
-
-// Full name: core::marker::MetaSized
-#[fundamental]
-#[lang_item(MetaSized)]
-pub trait MetaSized<Self>
-
-// Full name: core::marker::Sized
-#[fundamental]
-#[lang_item(Sized)]
-pub trait Sized<Self>
-{
-    proof ImpliedClause0: (Self: MetaSized)
-    non-dyn-compatible
-}
-
-// Full name: core::marker::Tuple
-#[fundamental]
-#[lang_item(Tuple)]
-pub trait Tuple<Self>
-{
-    proof ImpliedClause0: (Self: MetaSized)
-    non-dyn-compatible
-}
-
-opaque type core::ops::function::Fn::{vtable}
-
-opaque type core::ops::function::FnOnce::{vtable}
-
-// Full name: core::ops::function::FnOnce
-#[fundamental]
-#[lang_item(FnOnce)]
-pub trait FnOnce<Self, Args>
-{
-    proof ImpliedClause0: (Self: MetaSized)
-    proof ImpliedClause1: (Args: Sized)
-    proof ImpliedClause2: (Args: Tuple)
-    vtable: core::ops::function::FnOnce::{vtable}
-}
-
-opaque type core::ops::function::FnMut::{vtable}
-
-// Full name: core::ops::function::FnMut
-#[fundamental]
-#[lang_item(FnMut)]
-pub trait FnMut<Self, Args>
-{
-    proof ImpliedClause0: (Self: MetaSized)
-    proof ImpliedClause1: (Self: FnOnce<Args>)
-    proof ImpliedClause2: (Args: Sized)
-    proof ImpliedClause3: (Args: Tuple)
-    vtable: core::ops::function::FnMut::{vtable}
-}
-
-// Full name: core::ops::function::Fn
-#[fundamental]
-#[lang_item(Fn)]
-pub trait Fn<Self, Args>
-{
-    proof ImpliedClause0: (Self: MetaSized)
-    proof ImpliedClause1: (Self: FnMut<Args>)
-    proof ImpliedClause2: (Args: Sized)
-    proof ImpliedClause3: (Args: Tuple)
-    vtable: core::ops::function::Fn::{vtable}
-}
-
 struct () {}
 
 struct (_,)::<&'_ u32> {
   _0: &'_ u32,
+}
+
+// Full name: test_crate::foo::<u8>
+fn foo::<u8><'a>(x: &'a u8)
+{
+    let _0: (); // return
+    let x: &'1 u8; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    storage_dead(x)
+    return
 }
 
 // Full name: test_crate::foo::<u32>
@@ -85,42 +32,21 @@ fn foo::<u32><'a>(x: &'a u32)
     return
 }
 
-// Full name: test_crate::{impl FnOnce<(&'_ u32,)> for for<'a> foo::<u32><'a>}
-impl<'a> FnOnce<(&'_ u32,)> for for<'a> foo::<u32><'a> {
-    proof ImpliedClause0: (for<'a> foo::<u32><'a>: MetaSized) = {built_in impl MetaSized for for<'a> foo::<u32><'a>}
-    proof ImpliedClause1: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
-    proof ImpliedClause2: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
-    vtable: {impl FnOnce<(&'_ u32,)> for for<'a> foo::<u32><'a>}::{vtable}::<u32><'a>
-}
-
-// Full name: test_crate::{impl FnMut<(&'_ u32,)> for for<'a> foo::<u32><'a>}
-impl<'a> FnMut<(&'_ u32,)> for for<'a> foo::<u32><'a> {
-    proof ImpliedClause0: (for<'a> foo::<u32><'a>: MetaSized) = {built_in impl MetaSized for for<'a> foo::<u32><'a>}
-    proof ImpliedClause1: (for<'a> foo::<u32><'a>: FnOnce<(&'_ u32,)>) = {impl FnOnce<(&'_ u32,)> for for<'a> foo::<u32><'a>}<'a>
-    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
-    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
-    vtable: {impl FnMut<(&'_ u32,)> for for<'a> foo::<u32><'a>}::{vtable}::<u32><'a>
-}
-
-// Full name: test_crate::{impl Fn<(&'_ u32,)> for for<'a> foo::<u32><'a>}
-impl<'a> Fn<(&'_ u32,)> for for<'a> foo::<u32><'a> {
-    proof ImpliedClause0: (for<'a> foo::<u32><'a>: MetaSized) = {built_in impl MetaSized for for<'a> foo::<u32><'a>}
-    proof ImpliedClause1: (for<'a> foo::<u32><'a>: FnMut<(&'_ u32,)>) = {impl FnMut<(&'_ u32,)> for for<'a> foo::<u32><'a>}<'a>
-    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
-    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
-    vtable: {impl Fn<(&'_ u32,)> for for<'a> foo::<u32><'a>}::{vtable}::<u32><'a>
-}
-
-// Full name: test_crate::foo::<u8>
-fn foo::<u8><'a>(x: &'a u8)
+// Full name: test_crate::{impl Fn<(&'_ u32,)> for for<'a> foo::<u32><'a>}::call::<u32>
+fn call::<u32><'a, '_1>(state: &'_1 for<'a> foo::<u32><'a>, args: (&'_ u32,))
 {
     let _0: (); // return
-    let x: &'1 u8; // arg #1
+    let state: &'_1 for<'a> foo::<u32><'a>; // arg #1
+    let args: (&'_ u32,); // arg #2
 
     storage_live(_0)
     _0 = ()
-    _0 = ()
-    storage_dead(x)
+    _0 = foo::<u32><'a>(move args._0)
+    ↳⚡ storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(args)
+    storage_dead(state)
     return
 }
 
@@ -169,7 +95,7 @@ fn takes_closure::<for<'a> foo::<u32><'a>>(c: for<'a> foo::<u32><'a>)
     _5 = &(*_6)
     _4 = &(*_5)
     _3 = (move _4,)
-    _0 = {impl Fn<(&'_ u32,)> for for<'a> foo::<u32><'a>}<'8>::call<'9>(move _2, move _3)
+    _0 = call::<u32><'7, '9>(move _2, move _3)
     ↳⚡ storage_dead(_6)
         storage_dead(c)
         unwind_continue

--- a/charon/tests/ui/monomorphization/issue-917-inline-const-with-poly-type.out
+++ b/charon/tests/ui/monomorphization/issue-917-inline-const-with-poly-type.out
@@ -95,21 +95,46 @@ unsafe fn drop_glue::<()><'_0>(_1: &'_0 mut closure::<()>)
     return
 }
 
-// Full name: test_crate::foo::{const}::{impl FnOnce<((),)> for closure::<()>}
-impl FnOnce<((),)> for closure::<()> {
-    proof ImpliedClause0: (closure::<()>: MetaSized) = {built_in impl MetaSized for closure::<()>}
-    proof ImpliedClause1: (((),): Sized) = {built_in impl Sized for ((),)}
-    proof ImpliedClause2: (((),): Tuple) = {built_in impl Tuple for ((),)}
-    vtable: {impl FnOnce<((),)> for closure::<()>}::{vtable}::<()>
+// Full name: test_crate::foo::{const}::{impl Fn<((),)> for closure::<()>}::call::<()>
+fn call::<()><'_0>(_1: &'_0 closure::<()>, tupled_args: ((),))
+{
+    let _0: (); // return
+    let _1: &'1 closure::<()>; // arg #1
+    let tupled_args: ((),); // arg #2
+    let x: (); // local
+
+    storage_live(_0)
+    storage_live(x)
+    _0 = ()
+    x = move tupled_args._0
+    _0 = ()
+    storage_dead(x)
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
 }
 
-// Full name: test_crate::foo::{const}::{impl FnMut<((),)> for closure::<()>}
-impl FnMut<((),)> for closure::<()> {
-    proof ImpliedClause0: (closure::<()>: MetaSized) = {built_in impl MetaSized for closure::<()>}
-    proof ImpliedClause1: (closure::<()>: FnOnce<((),)>) = {impl FnOnce<((),)> for closure::<()>}
-    proof ImpliedClause2: (((),): Sized) = {built_in impl Sized for ((),)}
-    proof ImpliedClause3: (((),): Tuple) = {built_in impl Tuple for ((),)}
-    vtable: {impl FnMut<((),)> for closure::<()>}::{vtable}::<()>
+// Full name: test_crate::foo::{const}::{impl FnMut<((),)> for closure::<()>}::call_mut::<()>
+fn call_mut::<()><'_0>(state: &'_0 mut closure::<()>, args: ((),))
+{
+    let _0: (); // return
+    let state: &'_0 mut closure::<()>; // arg #1
+    let args: ((),); // arg #2
+    let _3: &'0 closure::<()>; // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(_3)
+    _3 = &(*state)
+    _0 = call::<()><'2>(move _3, move args)
+    ↳⚡ storage_dead(_3)
+        storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(args)
+    storage_dead(state)
+    return
 }
 
 // Full name: test_crate::foo::{const}::{impl FnOnce<((),)> for closure::<()>}::call_once::<()>
@@ -124,8 +149,8 @@ fn call_once::<()>(_1: closure::<()>, _2: ((),))
     storage_live(_3)
     _0 = ()
     _3 = &mut _1
-    _0 = {impl FnMut<((),)> for closure::<()>}::call_mut<'2>(move _3, move _2)
-    ↳⚡ drop[drop_glue::<()><'3>] _1
+    _0 = call_mut::<()><'3>(move _3, move _2)
+    ↳⚡ drop[drop_glue::<()><'4>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -134,7 +159,7 @@ fn call_once::<()>(_1: closure::<()>, _2: ((),))
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[drop_glue::<()><'4>] _1
+    drop[drop_glue::<()><'5>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -211,6 +236,23 @@ fn foo::<()>(x: ())
     return
 }
 
+// Full name: test_crate::foo::{const}::{impl FnOnce<((),)> for closure::<()>}
+impl FnOnce<((),)> for closure::<()> {
+    proof ImpliedClause0: (closure::<()>: MetaSized) = {built_in impl MetaSized for closure::<()>}
+    proof ImpliedClause1: (((),): Sized) = {built_in impl Sized for ((),)}
+    proof ImpliedClause2: (((),): Tuple) = {built_in impl Tuple for ((),)}
+    vtable: {impl FnOnce<((),)> for closure::<()>}::{vtable}::<()>
+}
+
+// Full name: test_crate::foo::{const}::{impl FnMut<((),)> for closure::<()>}
+impl FnMut<((),)> for closure::<()> {
+    proof ImpliedClause0: (closure::<()>: MetaSized) = {built_in impl MetaSized for closure::<()>}
+    proof ImpliedClause1: (closure::<()>: FnOnce<((),)>) = {impl FnOnce<((),)> for closure::<()>}
+    proof ImpliedClause2: (((),): Sized) = {built_in impl Sized for ((),)}
+    proof ImpliedClause3: (((),): Tuple) = {built_in impl Tuple for ((),)}
+    vtable: {impl FnMut<((),)> for closure::<()>}::{vtable}::<()>
+}
+
 // Full name: test_crate::foo::{const}::{impl Fn<((),)> for closure::<()>}
 impl Fn<((),)> for closure::<()> {
     proof ImpliedClause0: (closure::<()>: MetaSized) = {built_in impl MetaSized for closure::<()>}
@@ -224,48 +266,6 @@ impl Fn<((),)> for closure::<()> {
 impl Destruct for closure::<()> {
     fn drop_glue<'_0_1> = drop_glue::<()><'_0_1>
     non-dyn-compatible
-}
-
-// Full name: test_crate::foo::{const}::{impl Fn<((),)> for closure::<()>}::call::<()>
-fn call::<()><'_0>(_1: &'_0 closure::<()>, tupled_args: ((),))
-{
-    let _0: (); // return
-    let _1: &'1 closure::<()>; // arg #1
-    let tupled_args: ((),); // arg #2
-    let x: (); // local
-
-    storage_live(_0)
-    storage_live(x)
-    _0 = ()
-    x = move tupled_args._0
-    _0 = ()
-    storage_dead(x)
-    storage_dead(tupled_args)
-    storage_dead(_1)
-    return
-}
-
-// Full name: test_crate::foo::{const}::{impl FnMut<((),)> for closure::<()>}::call_mut::<()>
-fn call_mut::<()><'_0>(state: &'_0 mut closure::<()>, args: ((),))
-{
-    let _0: (); // return
-    let state: &'_0 mut closure::<()>; // arg #1
-    let args: ((),); // arg #2
-    let _3: &'0 closure::<()>; // anonymous local
-
-    storage_live(_0)
-    _0 = ()
-    storage_live(_3)
-    _3 = &(*state)
-    _0 = call::<()><'2>(move _3, move args)
-    ↳⚡ storage_dead(_3)
-        storage_dead(args)
-        storage_dead(state)
-        unwind_continue
-    storage_dead(_3)
-    storage_dead(args)
-    storage_dead(state)
-    return
 }
 
 // Full name: test_crate::main


### PR DESCRIPTION
First commit fixes translation of `Fn*` trait calls in monomorphic code; they used to be trait methods that resolved to nothing, given in monomorphic code trait decls have no methods. I am fairly happy with this change.

Second commit translates vtables for `Fn*` traits, giving them a proper vtable with the `call` function. I am very uncertain about this change, as the implementation is a bit convoluted; but it might be okay? I tried cleaning it up to make it less bad and claude-y but i don't love it.

Third commit translates default method shims, which was left as a todo. This was straightforward :)

Fourth commit properly desugars dyn drops

Closes #1387 
Closes #1388 
Closes #1389 