### PR TITLE
Translate VTables for Fn traits 

### DIFF
--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -514,6 +514,32 @@ pub enum FullDefKind<'tcx> {
     SyntheticCoroutineBody,
 }
 
+/// If the method declared by `method_decl_id` takes `self: Self` by value, adjust the vtable
+/// signature to take the receiver via `*mut Self` instead.
+/// This mirrors what rustc does for vtable shims, which take `*mut Self` (conceptually `&own Self`).
+fn adjust_by_value_vtable_receiver<'tcx>(
+    tcx: ty::TyCtxt<'tcx>,
+    method_decl_id: RDefId,
+    sig: ty::PolyFnSig<'tcx>,
+) -> ty::PolyFnSig<'tcx> {
+    let decl_sig = tcx
+        .fn_sig(method_decl_id)
+        .instantiate_identity()
+        .skip_norm_wip();
+    let receiver_is_by_value = !decl_sig.inputs().skip_binder().is_empty()
+        && decl_sig.input(0).skip_binder().is_param(0)
+        && tcx.generics_of(method_decl_id).has_self;
+    if !receiver_is_by_value {
+        return sig;
+    }
+    sig.map_bound(|mut sig| {
+        let mut inputs_and_output = sig.inputs_and_output.to_vec();
+        inputs_and_output[0] = ty::Ty::new_mut_ptr(tcx, inputs_and_output[0]);
+        sig.inputs_and_output = tcx.mk_type_list(&inputs_and_output);
+        sig
+    })
+}
+
 fn gen_vtable_sig<'tcx>(
     // The state that owns the method DefId
     s: &impl UnderOwnerState<'tcx>,
@@ -578,6 +604,7 @@ fn gen_vtable_sig<'tcx>(
     // Instantiate and normalize the signature.
     let method_decl_sig = tcx.fn_sig(method_decl_id).instantiate(tcx, trait_args);
     let normalized_sig = normalize(tcx, s.typing_env(), method_decl_sig);
+    let normalized_sig = adjust_by_value_vtable_receiver(tcx, method_decl_id, normalized_sig);
 
     Some(normalized_sig.sinto(s))
 }
@@ -645,6 +672,11 @@ fn gen_closure_sig<'tcx>(
     // Instantiate and normalize the signature.
     let sig = sig.instantiate(tcx, trait_args);
     let sig = normalize(tcx, s.typing_env(), sig);
+    let sig = if dyn_self {
+        adjust_by_value_vtable_receiver(tcx, call_method.def_id, sig)
+    } else {
+        sig
+    };
 
     Some(sig.sinto(s))
 }

--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -582,6 +582,56 @@ fn gen_vtable_sig<'tcx>(
     Some(normalized_sig.sinto(s))
 }
 
+/// The `dyn Trait<..>` type for this trait ref, i.e. its `Self` type made existential. Same as the
+/// `dyn_self` field of a `TraitImpl`, for the virtual impls we generate ourselves.
+///
+/// Only call this for a trait ref we're building a vtable for, hence a real, dyn-compatible trait;
+/// panics otherwise.
+pub fn trait_ref_dyn_self<'tcx, S: UnderOwnerState<'tcx>>(s: &S, trait_ref: &TraitRef) -> Ty {
+    let tcx = s.base().tcx;
+    let trait_def_id = trait_ref.def_id.real_rust_def_id();
+    let trait_ref = ty::TraitRef::new_from_args(tcx, trait_def_id, trait_ref.rustc_args(s));
+    rustc_utils::dyn_self_ty(tcx, s.typing_env(), trait_ref)
+        .expect("the trait of a vtable must be dyn-compatible")
+        .sinto(s)
+}
+
+/// The signatures the methods of this trait ref must have to be stored in a vtable, i.e. with
+/// `Self` replaced by the corresponding `dyn Trait` type; `None` for the methods that aren't
+/// vtable-safe. Same as `vtable_sig` in `AssocFn`, but for the virtual impls we generate ourselves,
+/// whose methods have no `AssocFn` of their own.
+///
+/// The order matches `VirtualTraitImpl::methods`. Only call this for a trait ref that holds and is
+/// used as a `dyn Trait`: computing the `dyn Trait` type requires resolving the associated types of
+/// the trait ref.
+pub fn virtual_impl_vtable_sigs<'tcx, S: UnderOwnerState<'tcx>>(
+    s: &S,
+    trait_ref: &TraitRef,
+) -> Vec<Option<PolyFnSig>> {
+    let tcx = s.base().tcx;
+    let Some(trait_def_id) = trait_ref.def_id.as_real_def_id() else {
+        return vec![];
+    };
+    let trait_ref = ty::TraitRef::new_from_args(tcx, trait_def_id, trait_ref.rustc_args(s));
+    tcx.associated_items(trait_def_id)
+        .in_definition_order()
+        .filter(|assoc| matches!(assoc.kind, ty::AssocKind::Fn { .. }))
+        .map(|assoc| {
+            if !rustc_trait_selection::traits::is_vtable_safe_method(tcx, trait_def_id, *assoc) {
+                return None;
+            }
+            let dyn_self = rustc_utils::dyn_self_ty(tcx, s.typing_env(), trait_ref)?;
+            // `trait_ref.args[0]` is `Self`, which we replace with `dyn Trait`.
+            let mut full_args = vec![ty::GenericArg::from(dyn_self)];
+            full_args.extend(trait_ref.args[1..].iter());
+            let sig = tcx
+                .fn_sig(assoc.def_id)
+                .instantiate(tcx, tcx.mk_args(&full_args));
+            Some(normalize(tcx, s.typing_env(), sig).sinto(s))
+        })
+        .collect()
+}
+
 fn gen_closure_sig<'tcx>(
     // The state that owns the method DefId
     s: &impl UnderOwnerState<'tcx>,

--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -514,6 +514,17 @@ pub enum FullDefKind<'tcx> {
     SyntheticCoroutineBody,
 }
 
+/// Whether the trait method declared by `method_decl_id` takes `self: Self` by value.
+pub fn vtable_receiver_is_by_value<'tcx>(tcx: ty::TyCtxt<'tcx>, method_decl_id: RDefId) -> bool {
+    let decl_sig = tcx
+        .fn_sig(method_decl_id)
+        .instantiate_identity()
+        .skip_norm_wip();
+    !decl_sig.inputs().skip_binder().is_empty()
+        && decl_sig.input(0).skip_binder().is_param(0)
+        && tcx.generics_of(method_decl_id).has_self
+}
+
 /// If the method declared by `method_decl_id` takes `self: Self` by value, adjust the vtable
 /// signature to take the receiver via `*mut Self` instead.
 /// This mirrors what rustc does for vtable shims, which take `*mut Self` (conceptually `&own Self`).
@@ -522,14 +533,7 @@ fn adjust_by_value_vtable_receiver<'tcx>(
     method_decl_id: RDefId,
     sig: ty::PolyFnSig<'tcx>,
 ) -> ty::PolyFnSig<'tcx> {
-    let decl_sig = tcx
-        .fn_sig(method_decl_id)
-        .instantiate_identity()
-        .skip_norm_wip();
-    let receiver_is_by_value = !decl_sig.inputs().skip_binder().is_empty()
-        && decl_sig.input(0).skip_binder().is_param(0)
-        && tcx.generics_of(method_decl_id).has_self;
-    if !receiver_is_by_value {
+    if !vtable_receiver_is_by_value(tcx, method_decl_id) {
         return sig;
     }
     sig.map_bound(|mut sig| {

--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -585,8 +585,7 @@ fn gen_vtable_sig<'tcx>(
 /// The `dyn Trait<..>` type for this trait ref, i.e. its `Self` type made existential. Same as the
 /// `dyn_self` field of a `TraitImpl`, for the virtual impls we generate ourselves.
 ///
-/// Only call this for a trait ref we're building a vtable for, hence a real, dyn-compatible trait;
-/// panics otherwise.
+/// Panics if called on a non-dyn-compatible trait.
 pub fn trait_ref_dyn_self<'tcx, S: UnderOwnerState<'tcx>>(s: &S, trait_ref: &TraitRef) -> Ty {
     let tcx = s.base().tcx;
     let trait_def_id = trait_ref.def_id.real_rust_def_id();
@@ -596,40 +595,18 @@ pub fn trait_ref_dyn_self<'tcx, S: UnderOwnerState<'tcx>>(s: &S, trait_ref: &Tra
         .sinto(s)
 }
 
-/// The signatures the methods of this trait ref must have to be stored in a vtable, i.e. with
-/// `Self` replaced by the corresponding `dyn Trait` type; `None` for the methods that aren't
-/// vtable-safe. Same as `vtable_sig` in `AssocFn`, but for the virtual impls we generate ourselves,
-/// whose methods have no `AssocFn` of their own.
-///
-/// The order matches `VirtualTraitImpl::methods`. Only call this for a trait ref that holds and is
-/// used as a `dyn Trait`: computing the `dyn Trait` type requires resolving the associated types of
-/// the trait ref.
-pub fn virtual_impl_vtable_sigs<'tcx, S: UnderOwnerState<'tcx>>(
+/// The signature the `call*` method of this `Fn*` trait ref must have to be stored in a vtable,
+/// i.e. with `Self` replaced by the corresponding `dyn Fn*<..>` type. Same as `vtable_sig` in
+/// `AssocFn`, but for the virtual `Fn*` impls we generate ourselves, whose methods have no
+/// `AssocFn` of their own.
+pub fn fn_trait_vtable_method_sig<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     trait_ref: &TraitRef,
-) -> Vec<Option<PolyFnSig>> {
+) -> PolyFnSig {
     let tcx = s.base().tcx;
-    let Some(trait_def_id) = trait_ref.def_id.as_real_def_id() else {
-        return vec![];
-    };
+    let trait_def_id = trait_ref.def_id.real_rust_def_id();
     let trait_ref = ty::TraitRef::new_from_args(tcx, trait_def_id, trait_ref.rustc_args(s));
-    tcx.associated_items(trait_def_id)
-        .in_definition_order()
-        .filter(|assoc| matches!(assoc.kind, ty::AssocKind::Fn { .. }))
-        .map(|assoc| {
-            if !rustc_trait_selection::traits::is_vtable_safe_method(tcx, trait_def_id, *assoc) {
-                return None;
-            }
-            let dyn_self = rustc_utils::dyn_self_ty(tcx, s.typing_env(), trait_ref)?;
-            // `trait_ref.args[0]` is `Self`, which we replace with `dyn Trait`.
-            let mut full_args = vec![ty::GenericArg::from(dyn_self)];
-            full_args.extend(trait_ref.args[1..].iter());
-            let sig = tcx
-                .fn_sig(assoc.def_id)
-                .instantiate(tcx, tcx.mk_args(&full_args));
-            Some(normalize(tcx, s.typing_env(), sig).sinto(s))
-        })
-        .collect()
+    gen_closure_sig(s, Some(trait_ref), true).unwrap()
 }
 
 fn gen_closure_sig<'tcx>(

--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -525,9 +525,8 @@ pub fn vtable_receiver_is_by_value<'tcx>(tcx: ty::TyCtxt<'tcx>, method_decl_id: 
         && tcx.generics_of(method_decl_id).has_self
 }
 
-/// If the method declared by `method_decl_id` takes `self: Self` by value, adjust the vtable
-/// signature to take the receiver via `*mut Self` instead.
-/// This mirrors what rustc does for vtable shims, which take `*mut Self` (conceptually `&own Self`).
+/// If the method takes `self: Self` by value, make the vtable signature take the receiver via
+/// `*mut Self` instead, like rustc's vtable shims do.
 fn adjust_by_value_vtable_receiver<'tcx>(
     tcx: ty::TyCtxt<'tcx>,
     method_decl_id: RDefId,
@@ -615,8 +614,6 @@ fn gen_vtable_sig<'tcx>(
 
 /// The `dyn Trait<..>` type for this trait ref, i.e. its `Self` type made existential. Same as the
 /// `dyn_self` field of a `TraitImpl`, for the virtual impls we generate ourselves.
-///
-/// Panics if called on a non-dyn-compatible trait.
 pub fn trait_ref_dyn_self<'tcx, S: UnderOwnerState<'tcx>>(s: &S, trait_ref: &TraitRef) -> Ty {
     let tcx = s.base().tcx;
     let trait_def_id = trait_ref.def_id.real_rust_def_id();
@@ -627,9 +624,8 @@ pub fn trait_ref_dyn_self<'tcx, S: UnderOwnerState<'tcx>>(s: &S, trait_ref: &Tra
 }
 
 /// The signature the `call*` method of this `Fn*` trait ref must have to be stored in a vtable,
-/// i.e. with `Self` replaced by the corresponding `dyn Fn*<..>` type. Same as `vtable_sig` in
-/// `AssocFn`, but for the virtual `Fn*` impls we generate ourselves, whose methods have no
-/// `AssocFn` of their own.
+/// i.e. with `Self` replaced by `dyn Fn*<..>`. Same as `AssocFn`'s `vtable_sig`, but for the
+/// virtual `Fn*` impls we generate ourselves, whose methods have no `AssocFn` of their own.
 pub fn fn_trait_vtable_method_sig<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     trait_ref: &TraitRef,

--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -101,6 +101,34 @@ pub fn callable_virtual_impl<'a>(
         .expect("expected a callable with a Fn* impl")
 }
 
+/// Whether this proof is the builtin `Fn*` impl of a function *pointer* type (`fn(..) -> _`).
+/// Such an impl has no item behind it, so it can't go through `Callable`; the vtable method is
+/// built as an indirect call instead. See `recognize_callable_impl_proof` for the item case.
+pub fn recognize_fn_pointer_impl_proof(trait_proof: &hax::TraitProof) -> Option<ClosureKind> {
+    let hax::TraitProofKind::Builtin {
+        trait_data: hax::BuiltinTraitData::Other(lang_item),
+        ..
+    } = &trait_proof.kind
+    else {
+        return None;
+    };
+    let target_kind = match lang_item {
+        hax::SolverTraitLangItem::FnOnce => ClosureKind::FnOnce,
+        hax::SolverTraitLangItem::FnMut => ClosureKind::FnMut,
+        hax::SolverTraitLangItem::Fn => ClosureKind::Fn,
+        _ => return None,
+    };
+    let hax::GenericArg::Type(callable_ty) = trait_proof
+        .pred
+        .hax_skip_binder_ref()
+        .generic_args
+        .first()?
+    else {
+        return None;
+    };
+    matches!(callable_ty.kind(), hax::TyKind::Arrow(_)).then_some(target_kind)
+}
+
 #[derive(Clone, Copy)]
 enum Callable<'a> {
     Closure(&'a hax::ClosureArgs),

--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -57,11 +57,11 @@ pub fn translate_closure_kind(kind: &hax::ClosureKind) -> ClosureKind {
     }
 }
 
-/// If this trait proof is the built-in impl of a `Fn*` trait for a closure or function item,
-/// return the callable item and the kind of the implemented trait.
-pub fn recognize_callable_impl_proof(
+/// If this trait proof is a built-in impl of a `Fn*` trait, return the `Self` type it is
+/// implemented for and the kind of the implemented trait.
+pub fn recognize_fn_trait_impl_proof(
     trait_proof: &hax::TraitProof,
-) -> Option<(&hax::ItemRef, ClosureKind)> {
+) -> Option<(&hax::Ty, ClosureKind)> {
     let hax::TraitProofKind::Builtin {
         trait_data: hax::BuiltinTraitData::Other(lang_item),
         ..
@@ -75,20 +75,12 @@ pub fn recognize_callable_impl_proof(
         hax::SolverTraitLangItem::Fn => ClosureKind::Fn,
         _ => return None,
     };
-    let hax::GenericArg::Type(callable_ty) = trait_proof
-        .pred
-        .hax_skip_binder_ref()
-        .generic_args
-        .first()?
+    let Some(hax::GenericArg::Type(self_ty)) =
+        trait_proof.pred.hax_skip_binder_ref().generic_args.first()
     else {
-        return None;
+        unreachable!("no Self type arg on Fn trait?");
     };
-    let item = match callable_ty.kind() {
-        hax::TyKind::Closure(closure_args) => &closure_args.item,
-        hax::TyKind::FnDef { item, .. } => item,
-        _ => return None,
-    };
-    Some((item, target_kind))
+    Some((self_ty, target_kind))
 }
 
 /// The built-in `Fn*` impl of the given kind that we generate for this closure or function item.
@@ -99,34 +91,6 @@ pub fn callable_virtual_impl<'a>(
     CallableFnImpls::from_def(def)
         .and_then(|impls| impls.vimpl(target_kind))
         .expect("expected a callable with a Fn* impl")
-}
-
-/// Whether this proof is the builtin `Fn*` impl of a function *pointer* type (`fn(..) -> _`).
-/// Such an impl has no item behind it, so it can't go through `Callable`; the vtable method is
-/// built as an indirect call instead. See `recognize_callable_impl_proof` for the item case.
-pub fn recognize_fn_pointer_impl_proof(trait_proof: &hax::TraitProof) -> Option<ClosureKind> {
-    let hax::TraitProofKind::Builtin {
-        trait_data: hax::BuiltinTraitData::Other(lang_item),
-        ..
-    } = &trait_proof.kind
-    else {
-        return None;
-    };
-    let target_kind = match lang_item {
-        hax::SolverTraitLangItem::FnOnce => ClosureKind::FnOnce,
-        hax::SolverTraitLangItem::FnMut => ClosureKind::FnMut,
-        hax::SolverTraitLangItem::Fn => ClosureKind::Fn,
-        _ => return None,
-    };
-    let hax::GenericArg::Type(callable_ty) = trait_proof
-        .pred
-        .hax_skip_binder_ref()
-        .generic_args
-        .first()?
-    else {
-        return None;
-    };
-    matches!(callable_ty.kind(), hax::TyKind::Arrow(_)).then_some(target_kind)
 }
 
 #[derive(Clone, Copy)]

--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -57,6 +57,50 @@ pub fn translate_closure_kind(kind: &hax::ClosureKind) -> ClosureKind {
     }
 }
 
+/// If this trait proof is the built-in impl of a `Fn*` trait for a closure or function item,
+/// return the callable item and the kind of the implemented trait.
+pub fn recognize_callable_impl_proof(
+    trait_proof: &hax::TraitProof,
+) -> Option<(&hax::ItemRef, ClosureKind)> {
+    let hax::TraitProofKind::Builtin {
+        trait_data: hax::BuiltinTraitData::Other(lang_item),
+        ..
+    } = &trait_proof.kind
+    else {
+        return None;
+    };
+    let target_kind = match lang_item {
+        hax::SolverTraitLangItem::FnOnce => ClosureKind::FnOnce,
+        hax::SolverTraitLangItem::FnMut => ClosureKind::FnMut,
+        hax::SolverTraitLangItem::Fn => ClosureKind::Fn,
+        _ => return None,
+    };
+    let hax::GenericArg::Type(callable_ty) = trait_proof
+        .pred
+        .hax_skip_binder_ref()
+        .generic_args
+        .first()?
+    else {
+        return None;
+    };
+    let item = match callable_ty.kind() {
+        hax::TyKind::Closure(closure_args) => &closure_args.item,
+        hax::TyKind::FnDef { item, .. } => item,
+        _ => return None,
+    };
+    Some((item, target_kind))
+}
+
+/// The built-in `Fn*` impl of the given kind that we generate for this closure or function item.
+pub fn callable_virtual_impl<'a>(
+    def: &'a hax::FullDef<'_>,
+    target_kind: ClosureKind,
+) -> &'a hax::VirtualTraitImpl {
+    CallableFnImpls::from_def(def)
+        .and_then(|impls| impls.vimpl(target_kind))
+        .expect("expected a callable with a Fn* impl")
+}
+
 #[derive(Clone, Copy)]
 enum Callable<'a> {
     Closure(&'a hax::ClosureArgs),
@@ -392,6 +436,29 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             fn_mut_impl,
             fn_impl,
             signature,
+        })
+    }
+
+    /// The type of the `self` argument of the `call_*` method of the `Fn*` impl of this callable,
+    /// i.e. `&closure`, `&mut closure` or `closure` depending on the trait.
+    pub(crate) fn translate_callable_method_receiver_ty(
+        &mut self,
+        span: Span,
+        def: &hax::FullDef<'tcx>,
+        target_kind: ClosureKind,
+    ) -> Result<Ty, Error> {
+        let callable = CallableFnImpls::from_def(def)
+            .expect("callable expected")
+            .callable;
+        let state_ty = self.get_callable_state_ty(span, callable)?;
+        Ok(match target_kind {
+            ClosureKind::FnOnce => state_ty,
+            ClosureKind::Fn | ClosureKind::FnMut => {
+                let rid = self.the_only_binder().closure_call_method_region.unwrap();
+                let region = Region::Var(DeBruijnVar::new_at_zero(rid));
+                let mutability = RefKind::mutable(target_kind == ClosureKind::FnMut);
+                TyKind::Ref(region, state_ty, mutability).into_ty()
+            }
         })
     }
 

--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -69,7 +69,7 @@ pub fn recognize_fn_trait_impl_proof(
     else {
         return None;
     };
-    let target_kind = match lang_item {
+    let kind = match lang_item {
         hax::SolverTraitLangItem::FnOnce => ClosureKind::FnOnce,
         hax::SolverTraitLangItem::FnMut => ClosureKind::FnMut,
         hax::SolverTraitLangItem::Fn => ClosureKind::Fn,
@@ -78,9 +78,9 @@ pub fn recognize_fn_trait_impl_proof(
     let Some(hax::GenericArg::Type(self_ty)) =
         trait_proof.pred.hax_skip_binder_ref().generic_args.first()
     else {
-        unreachable!("no Self type arg on Fn trait?");
+        unreachable!("no `Self` type arg on a `Fn*` trait ref")
     };
-    Some((self_ty, target_kind))
+    Some((self_ty, kind))
 }
 
 /// The built-in `Fn*` impl of the given kind that we generate for this closure or function item.

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -97,6 +97,10 @@ pub enum TransImplSource {
     TraitAlias,
     /// An impl of the appropriate `Fn*` trait for a closure or function item.
     Callable(ClosureKind),
+    /// The builtin impl of the appropriate `Fn*` trait for a function pointer type. Unlike
+    /// `Callable`, there is no item to hang this off: the `DefId` is that of the trait, and the
+    /// concrete `Self` (the `fn(..)` type) comes from the trait ref's generics.
+    FnPointer(ClosureKind),
     /// A fictitious `impl Destruct for T` that contains the drop glue code for the given ADT or
     /// closure. The `DefId` is that of the ADT or closure.
     ImplicitDestruct,
@@ -171,12 +175,18 @@ impl TransItemSource {
                 TransItemSourceKind::TraitImpl(TransImplSource::Callable(kind))
             }
             TransItemSourceKind::VTableMethod(..) => return None,
-            TransItemSourceKind::DropGlueMethod(TransImplSource::Marker)
-            | TransItemSourceKind::VTableInstance(TransImplSource::Marker)
-            | TransItemSourceKind::VTableInstanceInitializer(TransImplSource::Marker)
-            | TransItemSourceKind::VTableDropShim(TransImplSource::Marker) => {
-                TransItemSourceKind::TraitDecl
-            }
+            TransItemSourceKind::DropGlueMethod(
+                TransImplSource::Marker | TransImplSource::FnPointer(..),
+            )
+            | TransItemSourceKind::VTableInstance(
+                TransImplSource::Marker | TransImplSource::FnPointer(..),
+            )
+            | TransItemSourceKind::VTableInstanceInitializer(
+                TransImplSource::Marker | TransImplSource::FnPointer(..),
+            )
+            | TransItemSourceKind::VTableDropShim(
+                TransImplSource::Marker | TransImplSource::FnPointer(..),
+            ) => TransItemSourceKind::TraitDecl,
             TransItemSourceKind::DropGlueMethod(impl_kind)
             | TransItemSourceKind::VTableInstance(impl_kind)
             | TransItemSourceKind::VTableInstanceInitializer(impl_kind)

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -174,25 +174,15 @@ impl TransItemSource {
             | TransItemSourceKind::VTableMethod(TransImplSource::Callable(kind)) => {
                 TransItemSourceKind::TraitImpl(TransImplSource::Callable(kind))
             }
-            TransItemSourceKind::VTableMethod(..) => return None,
-            TransItemSourceKind::DropGlueMethod(
-                TransImplSource::Marker | TransImplSource::FnPointer(..),
-            )
-            | TransItemSourceKind::VTableInstance(
-                TransImplSource::Marker | TransImplSource::FnPointer(..),
-            )
-            | TransItemSourceKind::VTableInstanceInitializer(
-                TransImplSource::Marker | TransImplSource::FnPointer(..),
-            )
-            | TransItemSourceKind::VTableDropShim(
-                TransImplSource::Marker | TransImplSource::FnPointer(..),
-            ) => TransItemSourceKind::TraitDecl,
             TransItemSourceKind::DropGlueMethod(impl_kind)
             | TransItemSourceKind::VTableInstance(impl_kind)
             | TransItemSourceKind::VTableInstanceInitializer(impl_kind)
-            | TransItemSourceKind::VTableDropShim(impl_kind) => {
-                TransItemSourceKind::TraitImpl(impl_kind)
-            }
+            | TransItemSourceKind::VTableDropShim(impl_kind) => match impl_kind {
+                TransImplSource::Marker | TransImplSource::FnPointer(..) => {
+                    TransItemSourceKind::TraitDecl
+                }
+                _ => TransItemSourceKind::TraitImpl(impl_kind),
+            },
             _ => return None,
         };
         Some(self.with_kind(parent_kind))

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -80,9 +80,10 @@ pub enum TransItemSourceKind {
     /// The initializer function of the `VTableInstance`.
     VTableInstanceInitializer(TransImplSource),
     /// Shim function to store a method in a vtable; give a method with `self: Ptr<Self>` argument,
-    /// this takes a `Ptr<dyn Trait>` and forwards to the method. The `DefId` refers to the method
-    /// implementation.
-    VTableMethod,
+    /// this takes a `Ptr<dyn Trait>` and forwards to the method. For a `Normal` impl the `DefId`
+    /// refers to the method implementation; for a `Callable` one it refers to the closure or fn
+    /// item, whose `call_*` method has no `DefId` of its own.
+    VTableMethod(TransImplSource),
     /// The drop shim function to be used in the vtable as a field.
     VTableDropShim(TransImplSource),
 }
@@ -165,9 +166,11 @@ impl TransItemSource {
     /// not attempt to generally compute the parent of an item. Used to compute names.
     pub(crate) fn parent(&self) -> Option<Self> {
         let parent_kind = match self.kind {
-            TransItemSourceKind::CallableMethod(kind) => {
+            TransItemSourceKind::CallableMethod(kind)
+            | TransItemSourceKind::VTableMethod(TransImplSource::Callable(kind)) => {
                 TransItemSourceKind::TraitImpl(TransImplSource::Callable(kind))
             }
+            TransItemSourceKind::VTableMethod(..) => return None,
             TransItemSourceKind::DropGlueMethod(TransImplSource::Marker)
             | TransItemSourceKind::VTableInstance(TransImplSource::Marker)
             | TransItemSourceKind::VTableInstanceInitializer(TransImplSource::Marker)
@@ -427,7 +430,7 @@ impl<'tcx> TranslateCtx<'tcx> {
                     | ClosureAsFnCast
                     | DropGlueMethod(..)
                     | VTableInstanceInitializer(..)
-                    | VTableMethod
+                    | VTableMethod(..)
                     | VTableDropShim(..) => ItemId::Fun(self.translated.fun_decls.reserve_slot()),
                     InherentImpl | Module => return None,
                 };
@@ -824,6 +827,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                     )
                     | TransItemSourceKind::VTableDropShim(TransImplSource::Callable(..))
                     | TransItemSourceKind::CallableMethod(..)
+                    | TransItemSourceKind::VTableMethod(TransImplSource::Callable(..))
                     | TransItemSourceKind::ClosureAsFnCast = kind
                     {
                         generics.regions.extend(
@@ -836,7 +840,10 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                 }
                 _ => {}
             }
-            if let TransItemSourceKind::CallableMethod(ClosureKind::FnMut | ClosureKind::Fn) = kind
+            if let TransItemSourceKind::CallableMethod(ClosureKind::FnMut | ClosureKind::Fn)
+            | TransItemSourceKind::VTableMethod(TransImplSource::Callable(
+                ClosureKind::FnMut | ClosureKind::Fn,
+            )) = kind
             {
                 generics.regions.push(self.translate_erased_region());
             }

--- a/charon/src/bin/charon-driver/translate/translate_generics.rs
+++ b/charon/src/bin/charon-driver/translate/translate_generics.rs
@@ -528,6 +528,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
             | TransItemSourceKind::VTableInstanceInitializer(TransImplSource::Callable(..))
             | TransItemSourceKind::VTableDropShim(TransImplSource::Callable(..))
             | TransItemSourceKind::CallableMethod(..)
+            | TransItemSourceKind::VTableMethod(TransImplSource::Callable(..))
             | TransItemSourceKind::ClosureAsFnCast = kind
             {
                 self.the_only_binder_mut()
@@ -539,7 +540,9 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         | hax::FullDefKind::AssocFn { .. }
         | hax::FullDefKind::Closure { .. }
         | hax::FullDefKind::Ctor { .. } = def.kind()
-            && let TransItemSourceKind::CallableMethod(ClosureKind::Fn | ClosureKind::FnMut) = kind
+            && let TransItemSourceKind::CallableMethod(closure)
+            | TransItemSourceKind::VTableMethod(TransImplSource::Callable(closure)) = kind
+            && matches!(closure, ClosureKind::Fn | ClosureKind::FnMut)
         {
             // Add the lifetime generics coming from the method itself.
             let rid = self

--- a/charon/src/bin/charon-driver/translate/translate_generics.rs
+++ b/charon/src/bin/charon-driver/translate/translate_generics.rs
@@ -540,9 +540,10 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         | hax::FullDefKind::AssocFn { .. }
         | hax::FullDefKind::Closure { .. }
         | hax::FullDefKind::Ctor { .. } = def.kind()
-            && let TransItemSourceKind::CallableMethod(closure)
-            | TransItemSourceKind::VTableMethod(TransImplSource::Callable(closure)) = kind
-            && matches!(closure, ClosureKind::Fn | ClosureKind::FnMut)
+            && let TransItemSourceKind::CallableMethod(ClosureKind::Fn | ClosureKind::FnMut)
+            | TransItemSourceKind::VTableMethod(TransImplSource::Callable(
+                ClosureKind::Fn | ClosureKind::FnMut,
+            )) = kind
         {
             // Add the lifetime generics coming from the method itself.
             let rid = self

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -165,7 +165,7 @@ impl<'tcx> TranslateCtx<'tcx> {
                         bt_ctx.translate_implicit_destruct_impl(id, item_meta, &def)?
                     }
                     TransImplSource::Marker | TransImplSource::FnPointer(..) => {
-                        unreachable!("marker impls are only used as vtable item sources")
+                        unreachable!("these impls are only used as vtable item sources")
                     }
                 };
                 self.translated.trait_impls.set_slot(id, trait_impl);
@@ -219,11 +219,11 @@ impl<'tcx> TranslateCtx<'tcx> {
                     unreachable!()
                 };
                 let fun_decl = match impl_kind {
-                    TransImplSource::Callable(target_kind) => {
-                        bt_ctx.translate_callable_vtable_shim(id, item_meta, &def, target_kind)?
+                    TransImplSource::Callable(kind) => {
+                        bt_ctx.translate_callable_vtable_shim(id, item_meta, &def, kind)?
                     }
-                    TransImplSource::FnPointer(target_kind) => {
-                        bt_ctx.translate_fn_pointer_vtable_shim(id, item_meta, &def, target_kind)?
+                    TransImplSource::FnPointer(kind) => {
+                        bt_ctx.translate_fn_pointer_vtable_shim(id, item_meta, &def, kind)?
                     }
                     _ => bt_ctx.translate_vtable_shim(id, item_meta, &def)?,
                 };

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -164,7 +164,7 @@ impl<'tcx> TranslateCtx<'tcx> {
                     TransImplSource::ImplicitDestruct => {
                         bt_ctx.translate_implicit_destruct_impl(id, item_meta, &def)?
                     }
-                    TransImplSource::Marker => {
+                    TransImplSource::Marker | TransImplSource::FnPointer(..) => {
                         unreachable!("marker impls are only used as vtable item sources")
                     }
                 };
@@ -218,10 +218,14 @@ impl<'tcx> TranslateCtx<'tcx> {
                 let Some(ItemId::Fun(id)) = trans_id else {
                     unreachable!()
                 };
-                let fun_decl = if let TransImplSource::Callable(target_kind) = impl_kind {
-                    bt_ctx.translate_callable_vtable_shim(id, item_meta, &def, target_kind)?
-                } else {
-                    bt_ctx.translate_vtable_shim(id, item_meta, &def)?
+                let fun_decl = match impl_kind {
+                    TransImplSource::Callable(target_kind) => {
+                        bt_ctx.translate_callable_vtable_shim(id, item_meta, &def, target_kind)?
+                    }
+                    TransImplSource::FnPointer(target_kind) => {
+                        bt_ctx.translate_fn_pointer_vtable_shim(id, item_meta, &def, target_kind)?
+                    }
+                    _ => bt_ctx.translate_vtable_shim(id, item_meta, &def)?,
                 };
                 self.translated.fun_decls.set_slot(id, fun_decl);
             }

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -214,11 +214,15 @@ impl<'tcx> TranslateCtx<'tcx> {
                     bt_ctx.translate_vtable_instance_init(id, item_meta, &def, impl_kind)?;
                 self.translated.fun_decls.set_slot(id, fun_decl);
             }
-            TransItemSourceKind::VTableMethod => {
+            &TransItemSourceKind::VTableMethod(impl_kind) => {
                 let Some(ItemId::Fun(id)) = trans_id else {
                     unreachable!()
                 };
-                let fun_decl = bt_ctx.translate_vtable_shim(id, item_meta, &def)?;
+                let fun_decl = if let TransImplSource::Callable(target_kind) = impl_kind {
+                    bt_ctx.translate_callable_vtable_shim(id, item_meta, &def, target_kind)?
+                } else {
+                    bt_ctx.translate_vtable_shim(id, item_meta, &def)?
+                };
                 self.translated.fun_decls.set_slot(id, fun_decl);
             }
             &TransItemSourceKind::VTableDropShim(impl_kind) => {

--- a/charon/src/bin/charon-driver/translate/translate_meta.rs
+++ b/charon/src/bin/charon-driver/translate/translate_meta.rs
@@ -416,7 +416,7 @@ impl<'tcx> TranslateCtx<'tcx> {
             TransItemSourceKind::TraitImpl(
                 TransImplSource::Marker | TransImplSource::FnPointer(..),
             ) => {
-                unreachable!("marker impls are only used as vtable item sources")
+                unreachable!("these impls are only used as vtable item sources")
             }
             TransItemSourceKind::CallableMethod(kind) => {
                 let fn_name = kind.method_name().to_string();

--- a/charon/src/bin/charon-driver/translate/translate_meta.rs
+++ b/charon/src/bin/charon-driver/translate/translate_meta.rs
@@ -413,7 +413,9 @@ impl<'tcx> TranslateCtx<'tcx> {
                 let impl_id = self.register_and_enqueue(&None, src.clone()).unwrap();
                 name.name.push(PathElem::Impl(ImplElem::Trait(impl_id)));
             }
-            TransItemSourceKind::TraitImpl(TransImplSource::Marker) => {
+            TransItemSourceKind::TraitImpl(
+                TransImplSource::Marker | TransImplSource::FnPointer(..),
+            ) => {
                 unreachable!("marker impls are only used as vtable item sources")
             }
             TransItemSourceKind::CallableMethod(kind) => {

--- a/charon/src/bin/charon-driver/translate/translate_meta.rs
+++ b/charon/src/bin/charon-driver/translate/translate_meta.rs
@@ -441,7 +441,7 @@ impl<'tcx> TranslateCtx<'tcx> {
                     Disambiguator::ZERO,
                 ));
             }
-            TransItemSourceKind::VTableMethod => {
+            TransItemSourceKind::VTableMethod(..) => {
                 name.name.push(PathElem::Builtin(
                     BuiltinPathElem::VTableMethod,
                     Disambiguator::ZERO,

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -407,11 +407,23 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                             }
                             type_map
                         };
+
+                        let impl_kind =
+                            match super::translate_closures::recognize_fn_trait_impl_proof(
+                                impl_source,
+                            ) {
+                                Some((self_ty, kind))
+                                    if matches!(self_ty.kind(), hax::TyKind::Arrow(_)) =>
+                                {
+                                    TransImplSource::FnPointer(kind)
+                                }
+                                _ => TransImplSource::Marker,
+                            };
                         let vtable = self.translate_vtable_instance_ref_no_enqueue(
                             span,
                             tref.hax_skip_binder_ref(),
                             tref.hax_skip_binder_ref(),
-                            TransImplSource::Marker,
+                            impl_kind,
                         )?;
                         TraitRefKind::BuiltinOrAuto {
                             builtin_data,

--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -419,12 +419,12 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                                 }
                                 _ => TransImplSource::Marker,
                             };
-                        let vtable = self.translate_vtable_instance_ref_no_enqueue(
-                            span,
-                            tref.hax_skip_binder_ref(),
-                            tref.hax_skip_binder_ref(),
-                            impl_kind,
-                        )?;
+                        let vtable = self.translate_region_binder(span, tref, |ctx, tref| {
+                            ctx.translate_vtable_instance_ref_no_enqueue(
+                                span, tref, tref, impl_kind,
+                            )
+                        })?;
+                        let vtable = self.erase_region_binder(vtable);
                         TraitRefKind::BuiltinOrAuto {
                             builtin_data,
                             parent_trait_refs,

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -187,6 +187,19 @@ pub struct VTableData {
     pub supertrait_map: IndexVec<TraitClauseId, Option<FieldId>>,
 }
 
+/// What we need to know about an impl to fill in its vtable.
+struct VTableInstanceData<'a> {
+    implemented_trait_ref: hax::TraitRef,
+    implied_trait_proofs: &'a [hax::TraitProof],
+    methods: VTableMethodSource<'a>,
+}
+
+/// Where the shims stored in a vtable's method fields come from.
+enum VTableMethodSource<'a> {
+    ImplItems(std::slice::Iter<'a, hax::ImplAssocItem>),
+    Callable(&'a hax::ItemRef, ClosureKind),
+}
+
 /// Generate the vtable struct.
 impl<'tcx> ItemTransCtx<'tcx, '_> {
     /// Query whether a trait is dyn compatible.
@@ -631,27 +644,22 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         };
         let ty = TyKind::Ref(Region::Static, vtbl_ty.clone(), RefKind::Shared).into_ty();
 
+        // If this is the built-in `Fn*` impl of a closure or function item, the vtable belongs to
+        // the virtual impl we generate for it, like the impl's own `vtable` field.
+        let callable_impl = super::translate_closures::recognize_callable_impl_proof(trait_proof);
+
         let kind = match &trait_proof.kind {
-            // The marker trait vtable translation pipeline would give incorrect results for these
-            // traits.
-            // FIXME(dyn): translate vtables for the closure traits
-            hax::TraitProofKind::Builtin {
-                trait_data:
-                    hax::BuiltinTraitData::Other(
-                        hax::SolverTraitLangItem::FnOnce
-                        | hax::SolverTraitLangItem::FnMut
-                        | hax::SolverTraitLangItem::Fn,
-                    ),
-                ..
-            } => ConstantExprKind::VTableRef(self.translate_trait_proof(span, trait_proof)?),
             hax::TraitProofKind::Concrete { .. } | hax::TraitProofKind::Builtin { .. } => {
                 // We could return `VTableRef` but we need to enqueue the translation of the static
                 // so may as well reuse that to normalize a bit.
                 let vtable_instance =
                     self.translate_region_binder(span, &trait_proof.pred, |ctx, tref| {
-                        let (impl_item, impl_kind) = match &trait_proof.kind {
-                            hax::TraitProofKind::Concrete(impl_item) => {
+                        let (impl_item, impl_kind) = match (&trait_proof.kind, callable_impl) {
+                            (hax::TraitProofKind::Concrete(impl_item), _) => {
                                 (impl_item, TransImplSource::Normal)
+                            }
+                            (_, Some((item, closure_kind))) => {
+                                (item, TransImplSource::Callable(closure_kind))
                             }
                             _ => (tref, TransImplSource::Marker),
                         };
@@ -734,14 +742,18 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         impl_def: &hax::FullDef<'tcx>,
         impl_kind: TransImplSource,
     ) -> Result<(Option<TraitImplRef>, TypeDeclRef), Error> {
-        let implemented_trait = match impl_def.kind() {
-            hax::FullDefKind::TraitImpl { trait_pred, .. } => {
+        let implemented_trait = match (impl_def.kind(), impl_kind) {
+            (hax::FullDefKind::TraitImpl { trait_pred, .. }, _) => {
                 assert_ne!(impl_kind, TransImplSource::Marker);
                 &trait_pred.trait_ref
             }
-            hax::FullDefKind::Trait { self_predicate, .. } => {
+            (hax::FullDefKind::Trait { self_predicate, .. }, _) => {
                 assert_eq!(impl_kind, TransImplSource::Marker);
                 &self_predicate.trait_ref
+            }
+            (_, TransImplSource::Callable(target_kind)) => {
+                let vimpl = super::translate_closures::callable_virtual_impl(impl_def, target_kind);
+                &vimpl.trait_pred.trait_ref
             }
             _ => unreachable!(),
         };
@@ -815,6 +827,97 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         })
     }
 
+    /// Gather what we need to fill in the vtable of this impl. See `VTableInstanceData`.
+    fn vtable_instance_data<'a>(
+        impl_def: &'a hax::FullDef<'tcx>,
+        impl_kind: TransImplSource,
+    ) -> VTableInstanceData<'a> {
+        if let TransImplSource::Callable(target_kind) = impl_kind {
+            let vimpl = super::translate_closures::callable_virtual_impl(impl_def, target_kind);
+            let callable = impl_def.this();
+            return VTableInstanceData {
+                implemented_trait_ref: vimpl.trait_pred.trait_ref.clone(),
+                implied_trait_proofs: &vimpl.implied_trait_proofs,
+                methods: VTableMethodSource::Callable(callable, target_kind),
+            };
+        }
+        match impl_def.kind() {
+            hax::FullDefKind::TraitImpl {
+                trait_pred,
+                items,
+                implied_trait_proofs,
+                ..
+            } => {
+                assert_ne!(impl_kind, TransImplSource::Marker);
+                VTableInstanceData {
+                    implemented_trait_ref: trait_pred.trait_ref.clone(),
+                    implied_trait_proofs,
+                    methods: VTableMethodSource::ImplItems(items.iter()),
+                }
+            }
+            hax::FullDefKind::Trait {
+                self_predicate,
+                implied_trait_proofs,
+                ..
+            } => {
+                assert_eq!(impl_kind, TransImplSource::Marker);
+                VTableInstanceData {
+                    implemented_trait_ref: self_predicate.trait_ref.clone(),
+                    implied_trait_proofs,
+                    methods: VTableMethodSource::ImplItems([].iter()),
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    /// The shim to store in the next method field of a vtable.
+    fn vtable_method_value(
+        &mut self,
+        span: Span,
+        trait_id: TraitDeclId,
+        method_id: TraitMethodId,
+        implemented_trait: &hax::TraitRef,
+        methods: &mut VTableMethodSource<'_>,
+    ) -> Result<VtableMethodValue, Error> {
+        match methods {
+            VTableMethodSource::ImplItems(items) => {
+                // Bit of a hack: we know the methods are in the right order. This is easier
+                // than trying to index into the items list by name.
+                for item in items.by_ref() {
+                    if let Some(value) =
+                        self.add_method_to_vtable_value(span, trait_id, implemented_trait, item)?
+                    {
+                        return Ok(value);
+                    }
+                }
+                unreachable!("no impl item left for vtable method {method_id:?}")
+            }
+            &mut VTableMethodSource::Callable(callable, target_kind) => {
+                let shim = self.translate_fn_ptr(
+                    span,
+                    callable,
+                    TransItemSourceKind::VTableMethod(TransImplSource::Callable(target_kind)),
+                )?;
+                if !self.monomorphize() {
+                    return Ok(VtableMethodValue::Const(ConstantExprKind::FnPtr(shim)));
+                }
+                // In mono mode the vtable field is an erased pointer, so we must compute the real
+                // type of the shim to cast from.
+                let vtable_sig = self.callable_vtable_method_sig(implemented_trait)?;
+                let bound_sig = self.translate_region_binder(span, &vtable_sig, |ctx, sig| {
+                    ctx.translate_fun_sig(span, sig)
+                })?;
+                let method_ty = TyKind::FnPtr(bound_sig).into_ty();
+                let method_name = self
+                    .translated
+                    .assoc_item_name(trait_id, method_id)
+                    .to_string();
+                Ok(VtableMethodValue::Cast((method_name, method_ty, shim)))
+            }
+        }
+    }
+
     fn add_method_to_vtable_value(
         &mut self,
         span: Span,
@@ -846,7 +949,11 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                 )
             }
         };
-        let shim_ref = self.translate_fn_ptr(span, &item_ref, TransItemSourceKind::VTableMethod)?;
+        let shim_ref = self.translate_fn_ptr(
+            span,
+            &item_ref,
+            TransItemSourceKind::VTableMethod(TransImplSource::Normal),
+        )?;
         // In mono mode, we cannot get real types of shim functions by looking up the ones in
         // `struct vtable` because they are erased function pointers.
         // Therefore, below we compute real types that are used for casting.
@@ -857,7 +964,11 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             assert!(self.binding_levels.len() == 1);
             let orginal_binding = self.binding_levels.pop();
             let assoc_fun_def = self.hax_def(&item_ref)?;
-            self.translate_item_generics(span, &assoc_fun_def, &TransItemSourceKind::VTableMethod)?;
+            self.translate_item_generics(
+                span,
+                &assoc_fun_def,
+                &TransItemSourceKind::VTableMethod(TransImplSource::Normal),
+            )?;
             let vtable_sig = match assoc_fun_def.kind() {
                 hax::FullDefKind::AssocFn {
                     vtable_sig: Some(vtable_sig),
@@ -903,19 +1014,11 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         vtable_struct_ref: TypeDeclRef,
         impl_kind: TransImplSource,
     ) -> Result<Body, Error> {
-        let (implemented_trait_ref, impl_items) = match impl_def.kind() {
-            hax::FullDefKind::TraitImpl {
-                trait_pred, items, ..
-            } => {
-                assert_ne!(impl_kind, TransImplSource::Marker);
-                (trait_pred.trait_ref.clone(), items.as_slice())
-            }
-            hax::FullDefKind::Trait { self_predicate, .. } => {
-                assert_eq!(impl_kind, TransImplSource::Marker);
-                (self_predicate.trait_ref.clone(), &[] as &[_])
-            }
-            _ => unreachable!(),
-        };
+        let VTableInstanceData {
+            implemented_trait_ref,
+            implied_trait_proofs,
+            mut methods,
+        } = Self::vtable_instance_data(impl_def, impl_kind);
 
         let trait_def = self.hax_def(&implemented_trait_ref)?;
         // We use `poly_trait_def` to fetch `implied_preds`, which is used to fetch supertrait in `prepare_vtable_fields`.
@@ -962,7 +1065,6 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
         // Construct a list with one operand per vtable field.
         let mut aggregate_fields = vec![];
-        let mut items_iter = impl_items.iter();
         for (field, ty) in vtable_data.fields.into_iter().zip(field_tys) {
             // In poly mode, all fields of vtables can be filled with const values.
             let mk_const = |kind| Operand::Const(ConstantExpr::new(kind, ty.clone()));
@@ -1065,39 +1167,21 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                         mk_const(ConstantExprKind::FnPtr(drop_shim))
                     }
                 }
-                TrVTableField::Method(..) => 'a: {
-                    // Bit of a hack: we know the methods are in the right order. This is easier
-                    // than trying to index into the items list by name.
-                    for item in items_iter.by_ref() {
-                        if let Some(kind) = self.add_method_to_vtable_value(
-                            span,
-                            trait_id,
-                            &implemented_trait_ref,
-                            item,
-                        )? {
-                            match kind {
-                                VtableMethodValue::Const(const_kind) => {
-                                    break 'a mk_const(const_kind);
-                                }
-                                VtableMethodValue::Cast(method) => break 'a mk_cast(method),
-                            }
-                        }
+                TrVTableField::Method(method_id, _) => {
+                    let value = self.vtable_method_value(
+                        span,
+                        trait_id,
+                        method_id,
+                        &implemented_trait_ref,
+                        &mut methods,
+                    )?;
+                    match value {
+                        VtableMethodValue::Const(const_kind) => mk_const(const_kind),
+                        VtableMethodValue::Cast(method) => mk_cast(method),
                     }
-                    unreachable!()
                 }
                 TrVTableField::SuperTrait(clause_id, _) => {
-                    let supertrait_proofs = match impl_def.kind() {
-                        hax::FullDefKind::TraitImpl {
-                            implied_trait_proofs,
-                            ..
-                        }
-                        | hax::FullDefKind::Trait {
-                            implied_trait_proofs,
-                            ..
-                        } => implied_trait_proofs,
-                        _ => unreachable!(),
-                    };
-                    let trait_proof = &supertrait_proofs[clause_id.index()];
+                    let trait_proof = &implied_trait_proofs[clause_id.index()];
                     Operand::Const(self.translate_vtable_instance_const(span, trait_proof)?)
                 }
             };
@@ -1148,7 +1232,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
         let body = match impl_kind {
             _ if item_meta.opacity.with_private_contents().is_opaque() => Body::Opaque,
-            TransImplSource::Marker | TransImplSource::Normal => {
+            TransImplSource::Marker | TransImplSource::Normal | TransImplSource::Callable(..) => {
                 self.gen_vtable_instance_init_body(span, impl_def, vtable_struct_ref, impl_kind)?
             }
             _ => {
@@ -1192,7 +1276,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         span: Span,
         target_receiver: &Ty,
         shim_signature: &FunSig,
-        impl_func_def: &hax::FullDef,
+        target_fn: FnPtr,
     ) -> Result<Body, Error> {
         let mut builder = BodyBuilder::new(span, shim_signature.inputs.len());
 
@@ -1219,10 +1303,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         );
         builder.push_statement(StatementKind::Assign(target_self.clone(), rval));
 
-        let fun_id = self.register_item(span, impl_func_def.this(), TransItemSourceKind::Fun);
-        let generics = self.outermost_binder().params.identity_args();
         builder.call(Call {
-            func: FnOperand::Regular(FnPtr::new(FnPtrKind::Fun(fun_id), generics)),
+            func: FnOperand::Regular(target_fn),
             args: method_args.into_iter().map(Operand::Move).collect(),
             dest: ret_place,
         });
@@ -1284,22 +1366,39 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
     ) -> Result<FunDecl, Error> {
         let span = item_meta.span;
 
-        let (dyn_self, trait_pred) = match impl_def.kind() {
-            hax::FullDefKind::TraitImpl {
-                dyn_self: Some(dyn_self),
-                trait_pred,
-                ..
-            } => {
+        // For a callable the def is the closure or fn item, whose virtual `Fn*` impl has no
+        // `dyn_self` field; we ask rustc for the `dyn Fn*<..>` type of the implemented trait ref.
+        let callable_dyn_self;
+        let (dyn_self, trait_pred) = match (impl_def.kind(), impl_kind) {
+            (
+                hax::FullDefKind::TraitImpl {
+                    dyn_self: Some(dyn_self),
+                    trait_pred,
+                    ..
+                },
+                _,
+            ) => {
                 assert_ne!(impl_kind, TransImplSource::Marker);
                 (dyn_self, trait_pred)
             }
-            hax::FullDefKind::Trait {
-                dyn_self: Some(dyn_self),
-                self_predicate,
-                ..
-            } => {
+            (
+                hax::FullDefKind::Trait {
+                    dyn_self: Some(dyn_self),
+                    self_predicate,
+                    ..
+                },
+                _,
+            ) => {
                 assert_eq!(impl_kind, TransImplSource::Marker);
                 (dyn_self, self_predicate)
+            }
+            (_, TransImplSource::Callable(target_kind)) => {
+                let trait_pred =
+                    &super::translate_closures::callable_virtual_impl(impl_def, target_kind)
+                        .trait_pred;
+                callable_dyn_self =
+                    hax::trait_ref_dyn_self(self.hax_state_with_id(), &trait_pred.trait_ref);
+                (&callable_dyn_self, trait_pred)
             }
             _ => {
                 raise_error!(
@@ -1378,7 +1477,78 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         let body = if item_meta.opacity.with_private_contents().is_opaque() {
             Body::Opaque
         } else {
-            self.translate_vtable_shim_body(span, &target_receiver, &signature, impl_func_def)?
+            let fun_id = self.register_item(span, impl_func_def.this(), TransItemSourceKind::Fun);
+            let target_fn = FnPtr::new(
+                FnPtrKind::Fun(fun_id),
+                self.outermost_binder().params.identity_args(),
+            );
+            self.translate_vtable_shim_body(span, &target_receiver, &signature, target_fn)?
+        };
+
+        Ok(FunDecl {
+            def_id: fun_id,
+            item_meta,
+            generics: self.into_generics(),
+            signature: Box::new(signature),
+            src: FunSource::VTableShim,
+            body,
+        })
+    }
+
+    /// The signature the `call`/`call_mut`/`call_once` shim of this `Fn*` trait ref must have,
+    /// i.e. with `Self` replaced by `dyn Fn*<..>`.
+    fn callable_vtable_method_sig(
+        &mut self,
+        trait_ref: &hax::TraitRef,
+    ) -> Result<hax::PolyFnSig, Error> {
+        let sigs = hax::virtual_impl_vtable_sigs(self.hax_state_with_id(), trait_ref);
+        Ok(sigs.into_iter().exactly_one()?.unwrap())
+    }
+
+    /// Same as `translate_vtable_shim`, for the `call`/`call_mut`/`call_once` method of the `Fn*`
+    /// impl we generate for a closure or fn item.
+    pub(crate) fn translate_callable_vtable_shim(
+        mut self,
+        fun_id: FunDeclId,
+        item_meta: ItemMeta,
+        def: &hax::FullDef<'tcx>,
+        target_kind: ClosureKind,
+    ) -> Result<FunDecl, Error> {
+        let span = item_meta.span;
+
+        let vimpl = super::translate_closures::callable_virtual_impl(def, target_kind);
+        let vtable_sig = self.callable_vtable_method_sig(&vimpl.trait_pred.trait_ref)?;
+
+        // The signature of the shim function. Its only late-bound region is the one of the
+        // `call`/`call_mut` method, for which we have a dedicated parameter.
+        let signature = {
+            let bound_sig = self.translate_region_binder(span, &vtable_sig, |ctx, sig| {
+                ctx.translate_fun_sig(span, sig)
+            })?;
+            bound_sig.apply(
+                self.the_only_binder()
+                    .closure_call_method_region
+                    .iter()
+                    .map(|r| Region::Var(DeBruijnVar::new_at_zero(*r)))
+                    .collect(),
+            )
+        };
+        // The concrete receiver we will cast to.
+        let target_receiver = self.translate_callable_method_receiver_ty(span, def, target_kind)?;
+
+        let body = if item_meta.opacity.with_private_contents().is_opaque() {
+            Body::Opaque
+        } else {
+            let fun_id = self.register_item(
+                span,
+                def.this(),
+                TransItemSourceKind::CallableMethod(target_kind),
+            );
+            let target_fn = FnPtr::new(
+                FnPtrKind::Fun(fun_id),
+                self.outermost_binder().params.identity_args(),
+            );
+            self.translate_vtable_shim_body(span, &target_receiver, &signature, target_fn)?
         };
 
         Ok(FunDecl {

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -413,12 +413,22 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                                 .insert(hax::GenericPredicateId::TraitSelf, TraitClauseId::ZERO);
                             ctx.translate_poly_fun_sig(span, sig)
                         })?;
-                        let sig = bound_sig.apply(&{
+                        // A `self: Self` receiver would be unsized once `Self` becomes `dyn Trait`,
+                        // so takes it via `*mut Self` instead (like rustc)
+                        let receiver_is_by_value = matches!(
+                            sig.value.inputs[0].kind(),
+                            hax::TyKind::Param(param) if param.index == 0
+                        );
+                        let mut sig = bound_sig.apply(&{
                             let mut generics = GenericArgs::empty();
                             // Provide the `Self` clause.
                             generics.trait_refs.push(self_trait_ref.clone());
                             generics
                         });
+                        if receiver_is_by_value {
+                            let receiver = &mut sig.skip_binder.inputs[0];
+                            *receiver = TyKind::RawPtr(receiver.clone(), RefKind::Mut).into_ty();
+                        }
                         let ty = TyKind::FnPtr(sig).into_ty();
                         (field_name, ty)
                     }
@@ -1290,6 +1300,13 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
     /// // call the impl function and assign the result to ret@0
     /// ret@0 := impl_func(target_self@(N+1), arg1@2, ..., argN@N);
     /// ```
+    ///
+    /// For a method that takes `self: Self` by value, the shim receiver is `*mut dyn Trait`, so
+    /// we concretize the pointer and move out of it:
+    /// ```ignore
+    /// target_self@(N+1) := concretize_cast<*mut dyn Trait, *mut TargetReceiverTy>(shim_self@1);
+    /// ret@0 := impl_func(move (*target_self@(N+1)), arg1@2, ..., argN@N);
+    /// ```
     fn translate_vtable_shim_body(
         &mut self,
         span: Span,
@@ -1305,10 +1322,25 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             .iter()
             .map(|ty| builder.new_var(None, ty.clone()))
             .collect_vec();
-        let target_self = builder.new_var(None, target_receiver.clone());
+
+        // The target function takes the receiver by value but the shim receives it via `*mut Self`;
+        // concretize the pointer and dereference it to call the target.
+        let receiver_is_by_value = matches!(shim_signature.inputs[0].kind(), TyKind::RawPtr(..))
+            && !matches!(target_receiver.kind(), TyKind::RawPtr(..));
+        let cast_target_ty = if receiver_is_by_value {
+            TyKind::RawPtr(target_receiver.clone(), RefKind::Mut).into_ty()
+        } else {
+            target_receiver.clone()
+        };
+        let target_self = builder.new_var(None, cast_target_ty);
 
         // Replace the `dyn Trait` receiver with the concrete one.
-        let shim_self = mem::replace(&mut method_args[0], target_self.clone());
+        let receiver_arg = if receiver_is_by_value {
+            target_self.clone().deref()
+        } else {
+            target_self.clone()
+        };
+        let shim_self = mem::replace(&mut method_args[0], receiver_arg);
 
         // Perform the core concretization cast.
         // FIXME: need to unpack & re-pack the structure for cases like `Rc`, `Arc`, `Pin` and
@@ -1551,8 +1583,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             TyKind::Ref(region, _, mutability) => {
                 TyKind::Ref(*region, fn_ptr_ty, *mutability).into_ty()
             }
-            // `FnOnce` takes the receiver by value, so it is the bare `dyn Trait`.
-            TyKind::DynTrait(_) => fn_ptr_ty,
+            // `FnOnce`'s shim receives `Self` as `*mut dyn Trait`
+            TyKind::RawPtr(..) => fn_ptr_ty,
             _ => unreachable!(),
         };
 
@@ -1621,7 +1653,11 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         );
         let tupled_args_ty = &shim_signature.inputs[1];
         let tupled_args = builder.new_var(Some("args".to_string()), tupled_args_ty.clone());
-        let target_self = builder.new_var(Some("target_self".to_string()), target_receiver.clone());
+        let cast_target_ty = match target_kind {
+            ClosureKind::Fn | ClosureKind::FnMut => target_receiver.clone(),
+            ClosureKind::FnOnce => TyKind::RawPtr(target_receiver.clone(), RefKind::Mut).into_ty(),
+        };
+        let target_self = builder.new_var(Some("target_self".to_string()), cast_target_ty);
 
         // Replace the `dyn Trait` receiver with the concrete `fn(..)` one.
         let rval = Rvalue::UnaryOp(
@@ -1649,11 +1685,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             })
             .collect();
 
-        // `FnOnce` takes the fn pointer by value; the others through a reference.
-        let callee = match target_kind {
-            ClosureKind::FnOnce => target_self,
-            ClosureKind::Fn | ClosureKind::FnMut => target_self.deref(),
-        };
+        // Dereference the pointer/reference to get the fn pointer to call.
+        let callee = target_self.deref();
         builder.call(Call {
             func: FnOperand::Dynamic(Operand::Copy(callee)),
             args,

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use rustc_span::kw;
-use std::{assert_matches, mem};
+use std::mem;
 
 use super::{
     translate_crate::TransItemSourceKind, translate_ctx::*, translate_generics::BindingLevel,
@@ -189,7 +189,7 @@ pub struct VTableData {
 
 /// What we need to know about an impl to fill in its vtable.
 struct VTableInstanceData<'a> {
-    implemented_trait_ref: hax::TraitRef,
+    implemented_trait_ref: &'a hax::TraitRef,
     implied_trait_proofs: &'a [hax::TraitProof],
     methods: VTableMethodSource<'a>,
 }
@@ -197,8 +197,8 @@ struct VTableInstanceData<'a> {
 /// Where the shims stored in a vtable's method fields come from.
 enum VTableMethodSource<'a> {
     ImplItems(std::slice::Iter<'a, hax::ImplAssocItem>),
-    Callable(&'a hax::ItemRef, ClosureKind),
-    FnPointer(&'a hax::ItemRef, ClosureKind),
+    /// The `call*` shim of a builtin `Fn*` impl; the source is `Callable(..)` or `FnPointer(..)`.
+    FnTraitShim(&'a hax::ItemRef, TransImplSource),
 }
 
 /// Generate the vtable struct.
@@ -647,29 +647,34 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
         let kind = match &trait_proof.kind {
             hax::TraitProofKind::Concrete { .. } | hax::TraitProofKind::Builtin { .. } => {
-                let callable_impl =
-                    super::translate_closures::recognize_callable_impl_proof(trait_proof);
-                let fn_pointer_impl =
-                    super::translate_closures::recognize_fn_pointer_impl_proof(trait_proof);
-
                 // We could return `VTableRef` but we need to enqueue the translation of the static
                 // so may as well reuse that to normalize a bit.
                 let vtable_instance =
                     self.translate_region_binder(span, &trait_proof.pred, |ctx, tref| {
-                        let (impl_item, impl_kind) =
-                            match (&trait_proof.kind, callable_impl, fn_pointer_impl) {
-                                (hax::TraitProofKind::Concrete(impl_item), _, _) => {
-                                    (impl_item, TransImplSource::Normal)
+                        let fn_trait_impl =
+                            super::translate_closures::recognize_fn_trait_impl_proof(trait_proof);
+                        let (impl_item, impl_kind) = match (&trait_proof.kind, fn_trait_impl) {
+                            (hax::TraitProofKind::Concrete(impl_item), _) => {
+                                (impl_item, TransImplSource::Normal)
+                            }
+                            (_, Some((self_ty, closure_kind))) => match self_ty.kind() {
+                                // Key the `Fn*` impls of closures and fn items on the item
+                                hax::TyKind::Closure(args) => {
+                                    (&args.item, TransImplSource::Callable(closure_kind))
                                 }
-                                (_, Some((item, closure_kind)), _) => {
+                                hax::TyKind::FnDef { item, .. } => {
                                     (item, TransImplSource::Callable(closure_kind))
                                 }
-
-                                (_, _, Some(closure_kind)) => {
+                                // Function pointers don't have an item so put them on the trait
+                                hax::TyKind::Arrow(_) => {
                                     (tref, TransImplSource::FnPointer(closure_kind))
                                 }
-                                (_, None, None) => (tref, TransImplSource::Marker),
-                            };
+                                _ => unreachable!(
+                                    "builtin `Fn*` impl for unexpected type {self_ty:?}"
+                                ),
+                            },
+                            (_, None) => (tref, TransImplSource::Marker),
+                        };
                         ctx.translate_vtable_instance_ref(span, tref, impl_item, impl_kind)
                     })?;
                 let vtable_instance = self.erase_region_binder(vtable_instance);
@@ -749,24 +754,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         impl_def: &hax::FullDef<'tcx>,
         impl_kind: TransImplSource,
     ) -> Result<(Option<TraitImplRef>, TypeDeclRef), Error> {
-        let implemented_trait = match (impl_def.kind(), impl_kind) {
-            (hax::FullDefKind::TraitImpl { trait_pred, .. }, _) => {
-                assert_ne!(impl_kind, TransImplSource::Marker);
-                &trait_pred.trait_ref
-            }
-            (hax::FullDefKind::Trait { self_predicate, .. }, _) => {
-                assert_matches!(
-                    impl_kind,
-                    TransImplSource::Marker | TransImplSource::FnPointer(..)
-                );
-                &self_predicate.trait_ref
-            }
-            (_, TransImplSource::Callable(target_kind)) => {
-                let vimpl = super::translate_closures::callable_virtual_impl(impl_def, target_kind);
-                &vimpl.trait_pred.trait_ref
-            }
-            _ => unreachable!(),
-        };
+        let implemented_trait =
+            Self::vtable_instance_data(impl_def, impl_kind).implemented_trait_ref;
         let vtable_struct_ref = self.translate_vtable_struct_ref(span, implemented_trait)?;
         let impl_ref = if matches!(
             impl_kind,
@@ -846,57 +835,54 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         impl_def: &'a hax::FullDef<'tcx>,
         impl_kind: TransImplSource,
     ) -> VTableInstanceData<'a> {
-        if let TransImplSource::FnPointer(target_kind) = impl_kind {
-            // `impl_def` is the trait itself; the concrete `Self` lives in the trait ref.
-            let hax::FullDefKind::Trait {
-                self_predicate,
-                implied_trait_proofs,
-                ..
-            } = impl_def.kind()
-            else {
-                unreachable!("a fn-pointer vtable is registered against its trait")
-            };
-            return VTableInstanceData {
-                implemented_trait_ref: self_predicate.trait_ref.clone(),
-                implied_trait_proofs,
-                methods: VTableMethodSource::FnPointer(impl_def.this(), target_kind),
-            };
-        }
-        if let TransImplSource::Callable(target_kind) = impl_kind {
-            let vimpl = super::translate_closures::callable_virtual_impl(impl_def, target_kind);
-            let callable = impl_def.this();
-            return VTableInstanceData {
-                implemented_trait_ref: vimpl.trait_pred.trait_ref.clone(),
-                implied_trait_proofs: &vimpl.implied_trait_proofs,
-                methods: VTableMethodSource::Callable(callable, target_kind),
-            };
-        }
-        match impl_def.kind() {
-            hax::FullDefKind::TraitImpl {
-                trait_pred,
-                items,
-                implied_trait_proofs,
-                ..
-            } => {
-                assert_ne!(impl_kind, TransImplSource::Marker);
+        match (impl_kind, impl_def.kind()) {
+            // The def is the closure or fn item; the impl is one of its virtual `Fn*` impls.
+            (TransImplSource::Callable(target_kind), _) => {
+                let vimpl = super::translate_closures::callable_virtual_impl(impl_def, target_kind);
                 VTableInstanceData {
-                    implemented_trait_ref: trait_pred.trait_ref.clone(),
-                    implied_trait_proofs,
-                    methods: VTableMethodSource::ImplItems(items.iter()),
+                    implemented_trait_ref: &vimpl.trait_pred.trait_ref,
+                    implied_trait_proofs: &vimpl.implied_trait_proofs,
+                    methods: VTableMethodSource::FnTraitShim(impl_def.this(), impl_kind),
                 }
             }
-            hax::FullDefKind::Trait {
-                self_predicate,
-                implied_trait_proofs,
-                ..
-            } => {
-                assert_eq!(impl_kind, TransImplSource::Marker);
-                VTableInstanceData {
-                    implemented_trait_ref: self_predicate.trait_ref.clone(),
+            // The def is the `Fn*` trait itself; the concrete `Self` lives in the trait ref.
+            (
+                TransImplSource::FnPointer(..),
+                hax::FullDefKind::Trait {
+                    self_predicate,
                     implied_trait_proofs,
-                    methods: VTableMethodSource::ImplItems([].iter()),
-                }
-            }
+                    ..
+                },
+            ) => VTableInstanceData {
+                implemented_trait_ref: &self_predicate.trait_ref,
+                implied_trait_proofs,
+                methods: VTableMethodSource::FnTraitShim(impl_def.this(), impl_kind),
+            },
+            (
+                TransImplSource::Normal,
+                hax::FullDefKind::TraitImpl {
+                    trait_pred,
+                    items,
+                    implied_trait_proofs,
+                    ..
+                },
+            ) => VTableInstanceData {
+                implemented_trait_ref: &trait_pred.trait_ref,
+                implied_trait_proofs,
+                methods: VTableMethodSource::ImplItems(items.iter()),
+            },
+            (
+                TransImplSource::Marker,
+                hax::FullDefKind::Trait {
+                    self_predicate,
+                    implied_trait_proofs,
+                    ..
+                },
+            ) => VTableInstanceData {
+                implemented_trait_ref: &self_predicate.trait_ref,
+                implied_trait_proofs,
+                methods: VTableMethodSource::ImplItems([].iter()),
+            },
             _ => unreachable!(),
         }
     }
@@ -923,38 +909,18 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                 }
                 unreachable!("no impl item left for vtable method {method_id:?}")
             }
-            &mut VTableMethodSource::FnPointer(item, target_kind) => {
+            &mut VTableMethodSource::FnTraitShim(item, impl_source) => {
                 let shim = self.translate_fn_ptr(
                     span,
                     item,
-                    TransItemSourceKind::VTableMethod(TransImplSource::FnPointer(target_kind)),
-                )?;
-                if !self.monomorphize() {
-                    return Ok(VtableMethodValue::Const(ConstantExprKind::FnPtr(shim)));
-                }
-                let vtable_sig = self.callable_vtable_method_sig(implemented_trait)?;
-                let bound_sig = self.translate_region_binder(span, &vtable_sig, |ctx, sig| {
-                    ctx.translate_fun_sig(span, sig)
-                })?;
-                let method_ty = TyKind::FnPtr(bound_sig).into_ty();
-                let method_name = self
-                    .translated
-                    .assoc_item_name(trait_id, method_id)
-                    .to_string();
-                Ok(VtableMethodValue::Cast((method_name, method_ty, shim)))
-            }
-            &mut VTableMethodSource::Callable(callable, target_kind) => {
-                let shim = self.translate_fn_ptr(
-                    span,
-                    callable,
-                    TransItemSourceKind::VTableMethod(TransImplSource::Callable(target_kind)),
+                    TransItemSourceKind::VTableMethod(impl_source),
                 )?;
                 if !self.monomorphize() {
                     return Ok(VtableMethodValue::Const(ConstantExprKind::FnPtr(shim)));
                 }
                 // In mono mode the vtable field is an erased pointer, so we must compute the real
                 // type of the shim to cast from.
-                let vtable_sig = self.callable_vtable_method_sig(implemented_trait)?;
+                let vtable_sig = self.callable_vtable_method_sig(implemented_trait);
                 let bound_sig = self.translate_region_binder(span, &vtable_sig, |ctx, sig| {
                     ctx.translate_fun_sig(span, sig)
                 })?;
@@ -1070,7 +1036,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             mut methods,
         } = Self::vtable_instance_data(impl_def, impl_kind);
 
-        let trait_def = self.hax_def(&implemented_trait_ref)?;
+        let trait_def = self.hax_def(implemented_trait_ref)?;
         // We use `poly_trait_def` to fetch `implied_preds`, which is used to fetch supertrait in `prepare_vtable_fields`.
         let poly_trait_def = self.poly_hax_def(&implemented_trait_ref.def_id)?;
         let hax::FullDefKind::Trait {
@@ -1081,7 +1047,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             unreachable!()
         };
 
-        let implemented_trait = self.translate_trait_decl_ref(span, &implemented_trait_ref)?;
+        let implemented_trait = self.translate_trait_decl_ref(span, implemented_trait_ref)?;
         let trait_id = implemented_trait.id;
         // The type this impl is for.
         let self_ty = &implemented_trait.generics.types[0];
@@ -1222,7 +1188,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                         span,
                         trait_id,
                         method_id,
-                        &implemented_trait_ref,
+                        implemented_trait_ref,
                         &mut methods,
                     )?;
                     match value {
@@ -1422,46 +1388,40 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         // For a callable the def is the closure or fn item, whose virtual `Fn*` impl has no
         // `dyn_self` field; we ask rustc for the `dyn Fn*<..>` type of the implemented trait ref.
         let callable_dyn_self;
-        let (dyn_self, trait_pred) = match (impl_def.kind(), impl_kind) {
-            (
+        let (dyn_self, trait_pred) = if let TransImplSource::Callable(target_kind) = impl_kind {
+            let trait_pred =
+                &super::translate_closures::callable_virtual_impl(impl_def, target_kind).trait_pred;
+            callable_dyn_self =
+                hax::trait_ref_dyn_self(self.hax_state_with_id(), &trait_pred.trait_ref);
+            (&callable_dyn_self, trait_pred)
+        } else {
+            match impl_def.kind() {
                 hax::FullDefKind::TraitImpl {
                     dyn_self: Some(dyn_self),
                     trait_pred,
                     ..
-                },
-                _,
-            ) => {
-                assert_ne!(impl_kind, TransImplSource::Marker);
-                (dyn_self, trait_pred)
-            }
-            (
+                } => {
+                    assert_eq!(impl_kind, TransImplSource::Normal);
+                    (dyn_self, trait_pred)
+                }
                 hax::FullDefKind::Trait {
                     dyn_self: Some(dyn_self),
                     self_predicate,
                     ..
-                },
-                _,
-            ) => {
-                assert_matches!(
-                    impl_kind,
-                    TransImplSource::Marker | TransImplSource::FnPointer(..)
-                );
-                (dyn_self, self_predicate)
-            }
-            (_, TransImplSource::Callable(target_kind)) => {
-                let trait_pred =
-                    &super::translate_closures::callable_virtual_impl(impl_def, target_kind)
-                        .trait_pred;
-                callable_dyn_self =
-                    hax::trait_ref_dyn_self(self.hax_state_with_id(), &trait_pred.trait_ref);
-                (&callable_dyn_self, trait_pred)
-            }
-            _ => {
-                raise_error!(
-                    self,
-                    span,
-                    "Trying to generate a vtable drop shim for a non-dyn-compatible trait"
-                );
+                } => {
+                    assert!(matches!(
+                        impl_kind,
+                        TransImplSource::Marker | TransImplSource::FnPointer(..)
+                    ));
+                    (dyn_self, self_predicate)
+                }
+                _ => {
+                    raise_error!(
+                        self,
+                        span,
+                        "Trying to generate a vtable drop shim for a non-dyn-compatible trait"
+                    );
+                }
             }
         };
 
@@ -1553,12 +1513,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
     /// The signature the `call`/`call_mut`/`call_once` shim of this `Fn*` trait ref must have,
     /// i.e. with `Self` replaced by `dyn Fn*<..>`.
-    fn callable_vtable_method_sig(
-        &mut self,
-        trait_ref: &hax::TraitRef,
-    ) -> Result<hax::PolyFnSig, Error> {
-        let sigs = hax::virtual_impl_vtable_sigs(self.hax_state_with_id(), trait_ref);
-        Ok(sigs.into_iter().exactly_one()?.unwrap())
+    fn callable_vtable_method_sig(&mut self, trait_ref: &hax::TraitRef) -> hax::PolyFnSig {
+        hax::fn_trait_vtable_method_sig(self.hax_state_with_id(), trait_ref)
     }
 
     /// Same as `translate_callable_vtable_shim`, for the builtin `Fn*` impl of a function *pointer*.
@@ -1579,7 +1535,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         else {
             unreachable!("a fn-pointer vtable shim is registered against its trait")
         };
-        let vtable_sig = self.callable_vtable_method_sig(&self_predicate.trait_ref)?;
+        let vtable_sig = self.callable_vtable_method_sig(&self_predicate.trait_ref);
         let signature = {
             let bound_sig = self.translate_region_binder(span, &vtable_sig, |ctx, sig| {
                 ctx.translate_fun_sig(span, sig)
@@ -1595,9 +1551,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             TyKind::Ref(region, _, mutability) => {
                 TyKind::Ref(*region, fn_ptr_ty, *mutability).into_ty()
             }
-            TyKind::RawPtr(_, mutability) => TyKind::RawPtr(fn_ptr_ty, *mutability).into_ty(),
             // `FnOnce` takes the receiver by value, so it is the bare `dyn Trait`.
-            TyKind::FnPtr(_) | TyKind::DynTrait(_) => fn_ptr_ty,
+            TyKind::DynTrait(_) => fn_ptr_ty,
             _ => unreachable!(),
         };
 
@@ -1611,11 +1566,10 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                 target_kind,
             )?
         } else {
-            // In polymorphic mode the shim is keyed on the trait, so `Self` and `Args` are still
-            // generic: we can neither see that the receiver is a function pointer nor untuple
-            // `Args` to call it directly. Instead we forward to `<Self as Fn*<Args>>::call*` via
-            // the `Self: Fn*<Args>` clause, passing the tupled args along unchanged; the clause
-            // resolves to the builtin fn-pointer impl at instantiation time.
+            // The shim is keyed on the trait, so `Self` and `Args` are still generic and we
+            // can't call the fn pointer directly. Instead we forward to
+            // `<Self as Fn*<Args>>::call*` via the `Self: Fn*<Args>` clause, which resolves to
+            // the builtin fn-pointer impl at instantiation time.
             let method_item = items
                 .iter()
                 .find(|item| matches!(item.kind, hax::AssocKind::Fn { .. }))
@@ -1679,18 +1633,10 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         );
         builder.push_statement(StatementKind::Assign(target_self.clone(), rval));
 
-        // Untupling the arguments needs the concrete tuple, so this only works once the
-        // arguments are known; with generic `Args` there is no arity to unpack.
-        let Some(tuple_ref) = tupled_args_ty.as_adt() else {
-            raise_error!(
-                self,
-                span,
-                "vtable shims for function pointers need monomorphized arguments, got `{}`",
-                tupled_args_ty.with_ctx(&self.into_fmt())
-            )
-        };
-        let tuple_id = tuple_ref.id;
-        let _ = self.get_or_translate(ItemId::Type(tuple_id))?;
+        // We only get here in mono mode, so the tupled argument type is a concrete tuple whose
+        // fields we can untuple to call the function pointer directly.
+        let tuple_ref = tupled_args_ty.as_adt().expect("args must be a tuple");
+        let _ = self.get_or_translate(ItemId::Type(tuple_ref.id))?;
         let arg_tys = tupled_args_ty.as_tuple_fields(&self.t_ctx.translated);
         let args = arg_tys
             .into_iter()
@@ -1729,7 +1675,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         let span = item_meta.span;
 
         let vimpl = super::translate_closures::callable_virtual_impl(def, target_kind);
-        let vtable_sig = self.callable_vtable_method_sig(&vimpl.trait_pred.trait_ref)?;
+        let vtable_sig = self.callable_vtable_method_sig(&vimpl.trait_pred.trait_ref);
 
         // The signature of the shim function. Its only late-bound region is the one of the
         // `call`/`call_mut` method, for which we have a dedicated parameter.

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -1571,7 +1571,12 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
     ) -> Result<FunDecl, Error> {
         let span = item_meta.span;
 
-        let hax::FullDefKind::Trait { self_predicate, .. } = def.kind() else {
+        let hax::FullDefKind::Trait {
+            self_predicate,
+            items,
+            ..
+        } = def.kind()
+        else {
             unreachable!("a fn-pointer vtable shim is registered against its trait")
         };
         let vtable_sig = self.callable_vtable_method_sig(&self_predicate.trait_ref)?;
@@ -1598,13 +1603,34 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
         let body = if item_meta.opacity.with_private_contents().is_opaque() {
             Body::Opaque
-        } else {
+        } else if self.monomorphize() {
             self.translate_fn_pointer_vtable_shim_body(
                 span,
                 &target_receiver,
                 &signature,
                 target_kind,
             )?
+        } else {
+            // In polymorphic mode the shim is keyed on the trait, so `Self` and `Args` are still
+            // generic: we can neither see that the receiver is a function pointer nor untuple
+            // `Args` to call it directly. Instead we forward to `<Self as Fn*<Args>>::call*` via
+            // the `Self: Fn*<Args>` clause, passing the tupled args along unchanged; the clause
+            // resolves to the builtin fn-pointer impl at instantiation time.
+            let method_item = items
+                .iter()
+                .find(|item| matches!(item.kind, hax::AssocKind::Fn { .. }))
+                .expect("the `Fn*` traits each have a method");
+            let trait_decl_ref =
+                RegionBinder::empty(self.translate_trait_predicate(span, self_predicate)?);
+            let tref = TraitRef::new(TraitRefKind::SelfId, trait_decl_ref);
+            let method_id = self.translate_trait_method_id(tref.trait_id(), &method_item.def_id)?;
+            let mut generics = GenericArgs::empty();
+            if matches!(target_kind, ClosureKind::Fn | ClosureKind::FnMut) {
+                // `call`/`call_mut` have a late-bound region for the `&self`/`&mut self` receiver.
+                generics.regions.push(self.translate_erased_region());
+            }
+            let target_fn = FnPtr::new(FnPtrKind::Trait(tref, method_id), generics);
+            self.translate_vtable_shim_body(span, &target_receiver, &signature, target_fn)?
         };
 
         Ok(FunDecl {

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -414,7 +414,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                             ctx.translate_poly_fun_sig(span, sig)
                         })?;
                         // A `self: Self` receiver would be unsized once `Self` becomes `dyn Trait`,
-                        // so takes it via `*mut Self` instead (like rustc)
+                        // so we take it via `*mut Self` instead (like rustc)
                         let receiver_is_by_value = matches!(
                             sig.value.inputs[0].kind(),
                             hax::TyKind::Param(param) if param.index == 0
@@ -1312,6 +1312,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         span: Span,
         target_receiver: &Ty,
         shim_signature: &FunSig,
+        receiver_is_by_value: bool,
         target_fn: FnPtr,
     ) -> Result<Body, Error> {
         let mut builder = BodyBuilder::new(span, shim_signature.inputs.len());
@@ -1323,10 +1324,6 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             .map(|ty| builder.new_var(None, ty.clone()))
             .collect_vec();
 
-        // The target function takes the receiver by value but the shim receives it via `*mut Self`;
-        // concretize the pointer and dereference it to call the target.
-        let receiver_is_by_value = matches!(shim_signature.inputs[0].kind(), TyKind::RawPtr(..))
-            && !matches!(target_receiver.kind(), TyKind::RawPtr(..));
         let cast_target_ty = if receiver_is_by_value {
             TyKind::RawPtr(target_receiver.clone(), RefKind::Mut).into_ty()
         } else {
@@ -1502,6 +1499,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         let hax::FullDefKind::AssocFn {
             vtable_sig: Some(vtable_sig),
             sig: target_signature,
+            associated_item,
             ..
         } = impl_func_def.kind()
         else {
@@ -1516,6 +1514,12 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         let signature = self.translate_fun_sig(span, &vtable_sig.value)?;
         // The concrete receiver we will cast to.
         let target_receiver = self.translate_ty(span, &target_signature.value.inputs[0])?;
+        let receiver_is_by_value = hax::vtable_receiver_is_by_value(
+            self.tcx,
+            associated_item
+                .implemented_trait_item_id()
+                .real_rust_def_id(),
+        );
 
         trace!(
             "[VtableShim] Obtained dyn signature with receiver type: {}",
@@ -1530,7 +1534,13 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                 FnPtrKind::Fun(fun_id),
                 self.outermost_binder().params.identity_args(),
             );
-            self.translate_vtable_shim_body(span, &target_receiver, &signature, target_fn)?
+            self.translate_vtable_shim_body(
+                span,
+                &target_receiver,
+                &signature,
+                receiver_is_by_value,
+                target_fn,
+            )?
         };
 
         Ok(FunDecl {
@@ -1616,7 +1626,13 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                 generics.regions.push(self.translate_erased_region());
             }
             let target_fn = FnPtr::new(FnPtrKind::Trait(tref, method_id), generics);
-            self.translate_vtable_shim_body(span, &target_receiver, &signature, target_fn)?
+            self.translate_vtable_shim_body(
+                span,
+                &target_receiver,
+                &signature,
+                target_kind == ClosureKind::FnOnce,
+                target_fn,
+            )?
         };
 
         Ok(FunDecl {
@@ -1739,7 +1755,13 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                 FnPtrKind::Fun(fun_id),
                 self.outermost_binder().params.identity_args(),
             );
-            self.translate_vtable_shim_body(span, &target_receiver, &signature, target_fn)?
+            self.translate_vtable_shim_body(
+                span,
+                &target_receiver,
+                &signature,
+                target_kind == ClosureKind::FnOnce,
+                target_fn,
+            )?
         };
 
         Ok(FunDecl {

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use rustc_span::kw;
-use std::mem;
+use std::{assert_matches, mem};
 
 use super::{
     translate_crate::TransItemSourceKind, translate_ctx::*, translate_generics::BindingLevel,
@@ -198,6 +198,7 @@ struct VTableInstanceData<'a> {
 enum VTableMethodSource<'a> {
     ImplItems(std::slice::Iter<'a, hax::ImplAssocItem>),
     Callable(&'a hax::ItemRef, ClosureKind),
+    FnPointer(&'a hax::ItemRef, ClosureKind),
 }
 
 /// Generate the vtable struct.
@@ -644,25 +645,31 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         };
         let ty = TyKind::Ref(Region::Static, vtbl_ty.clone(), RefKind::Shared).into_ty();
 
-        // If this is the built-in `Fn*` impl of a closure or function item, the vtable belongs to
-        // the virtual impl we generate for it, like the impl's own `vtable` field.
-        let callable_impl = super::translate_closures::recognize_callable_impl_proof(trait_proof);
-
         let kind = match &trait_proof.kind {
             hax::TraitProofKind::Concrete { .. } | hax::TraitProofKind::Builtin { .. } => {
+                let callable_impl =
+                    super::translate_closures::recognize_callable_impl_proof(trait_proof);
+                let fn_pointer_impl =
+                    super::translate_closures::recognize_fn_pointer_impl_proof(trait_proof);
+
                 // We could return `VTableRef` but we need to enqueue the translation of the static
                 // so may as well reuse that to normalize a bit.
                 let vtable_instance =
                     self.translate_region_binder(span, &trait_proof.pred, |ctx, tref| {
-                        let (impl_item, impl_kind) = match (&trait_proof.kind, callable_impl) {
-                            (hax::TraitProofKind::Concrete(impl_item), _) => {
-                                (impl_item, TransImplSource::Normal)
-                            }
-                            (_, Some((item, closure_kind))) => {
-                                (item, TransImplSource::Callable(closure_kind))
-                            }
-                            _ => (tref, TransImplSource::Marker),
-                        };
+                        let (impl_item, impl_kind) =
+                            match (&trait_proof.kind, callable_impl, fn_pointer_impl) {
+                                (hax::TraitProofKind::Concrete(impl_item), _, _) => {
+                                    (impl_item, TransImplSource::Normal)
+                                }
+                                (_, Some((item, closure_kind)), _) => {
+                                    (item, TransImplSource::Callable(closure_kind))
+                                }
+
+                                (_, _, Some(closure_kind)) => {
+                                    (tref, TransImplSource::FnPointer(closure_kind))
+                                }
+                                (_, None, None) => (tref, TransImplSource::Marker),
+                            };
                         ctx.translate_vtable_instance_ref(span, tref, impl_item, impl_kind)
                     })?;
                 let vtable_instance = self.erase_region_binder(vtable_instance);
@@ -748,7 +755,10 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                 &trait_pred.trait_ref
             }
             (hax::FullDefKind::Trait { self_predicate, .. }, _) => {
-                assert_eq!(impl_kind, TransImplSource::Marker);
+                assert_matches!(
+                    impl_kind,
+                    TransImplSource::Marker | TransImplSource::FnPointer(..)
+                );
                 &self_predicate.trait_ref
             }
             (_, TransImplSource::Callable(target_kind)) => {
@@ -758,7 +768,11 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             _ => unreachable!(),
         };
         let vtable_struct_ref = self.translate_vtable_struct_ref(span, implemented_trait)?;
-        let impl_ref = if impl_kind == TransImplSource::Marker || self.monomorphize() {
+        let impl_ref = if matches!(
+            impl_kind,
+            TransImplSource::Marker | TransImplSource::FnPointer(..)
+        ) || self.monomorphize()
+        {
             None
         } else {
             Some(self.translate_item(
@@ -832,6 +846,22 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         impl_def: &'a hax::FullDef<'tcx>,
         impl_kind: TransImplSource,
     ) -> VTableInstanceData<'a> {
+        if let TransImplSource::FnPointer(target_kind) = impl_kind {
+            // `impl_def` is the trait itself; the concrete `Self` lives in the trait ref.
+            let hax::FullDefKind::Trait {
+                self_predicate,
+                implied_trait_proofs,
+                ..
+            } = impl_def.kind()
+            else {
+                unreachable!("a fn-pointer vtable is registered against its trait")
+            };
+            return VTableInstanceData {
+                implemented_trait_ref: self_predicate.trait_ref.clone(),
+                implied_trait_proofs,
+                methods: VTableMethodSource::FnPointer(impl_def.this(), target_kind),
+            };
+        }
         if let TransImplSource::Callable(target_kind) = impl_kind {
             let vimpl = super::translate_closures::callable_virtual_impl(impl_def, target_kind);
             let callable = impl_def.this();
@@ -892,6 +922,26 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                     }
                 }
                 unreachable!("no impl item left for vtable method {method_id:?}")
+            }
+            &mut VTableMethodSource::FnPointer(item, target_kind) => {
+                let shim = self.translate_fn_ptr(
+                    span,
+                    item,
+                    TransItemSourceKind::VTableMethod(TransImplSource::FnPointer(target_kind)),
+                )?;
+                if !self.monomorphize() {
+                    return Ok(VtableMethodValue::Const(ConstantExprKind::FnPtr(shim)));
+                }
+                let vtable_sig = self.callable_vtable_method_sig(implemented_trait)?;
+                let bound_sig = self.translate_region_binder(span, &vtable_sig, |ctx, sig| {
+                    ctx.translate_fun_sig(span, sig)
+                })?;
+                let method_ty = TyKind::FnPtr(bound_sig).into_ty();
+                let method_name = self
+                    .translated
+                    .assoc_item_name(trait_id, method_id)
+                    .to_string();
+                Ok(VtableMethodValue::Cast((method_name, method_ty, shim)))
             }
             &mut VTableMethodSource::Callable(callable, target_kind) => {
                 let shim = self.translate_fn_ptr(
@@ -1232,7 +1282,10 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
         let body = match impl_kind {
             _ if item_meta.opacity.with_private_contents().is_opaque() => Body::Opaque,
-            TransImplSource::Marker | TransImplSource::Normal | TransImplSource::Callable(..) => {
+            TransImplSource::Marker
+            | TransImplSource::Normal
+            | TransImplSource::Callable(..)
+            | TransImplSource::FnPointer(..) => {
                 self.gen_vtable_instance_init_body(span, impl_def, vtable_struct_ref, impl_kind)?
             }
             _ => {
@@ -1389,7 +1442,10 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                 },
                 _,
             ) => {
-                assert_eq!(impl_kind, TransImplSource::Marker);
+                assert_matches!(
+                    impl_kind,
+                    TransImplSource::Marker | TransImplSource::FnPointer(..)
+                );
                 (dyn_self, self_predicate)
             }
             (_, TransImplSource::Callable(target_kind)) => {
@@ -1503,6 +1559,136 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
     ) -> Result<hax::PolyFnSig, Error> {
         let sigs = hax::virtual_impl_vtable_sigs(self.hax_state_with_id(), trait_ref);
         Ok(sigs.into_iter().exactly_one()?.unwrap())
+    }
+
+    /// Same as `translate_callable_vtable_shim`, for the builtin `Fn*` impl of a function *pointer*.
+    pub(crate) fn translate_fn_pointer_vtable_shim(
+        mut self,
+        fun_id: FunDeclId,
+        item_meta: ItemMeta,
+        def: &hax::FullDef<'tcx>,
+        target_kind: ClosureKind,
+    ) -> Result<FunDecl, Error> {
+        let span = item_meta.span;
+
+        let hax::FullDefKind::Trait { self_predicate, .. } = def.kind() else {
+            unreachable!("a fn-pointer vtable shim is registered against its trait")
+        };
+        let vtable_sig = self.callable_vtable_method_sig(&self_predicate.trait_ref)?;
+        let signature = {
+            let bound_sig = self.translate_region_binder(span, &vtable_sig, |ctx, sig| {
+                ctx.translate_fun_sig(span, sig)
+            })?;
+            self.erase_region_binder(bound_sig)
+        };
+
+        let Some(hax::GenericArg::Type(self_ty)) = def.this().generic_args.first() else {
+            unreachable!("the `Fn*` trait ref has a `Self` type argument")
+        };
+        let fn_ptr_ty = self.translate_ty(span, self_ty)?;
+        let target_receiver = match signature.inputs[0].kind() {
+            TyKind::Ref(region, _, mutability) => {
+                TyKind::Ref(*region, fn_ptr_ty, *mutability).into_ty()
+            }
+            TyKind::RawPtr(_, mutability) => TyKind::RawPtr(fn_ptr_ty, *mutability).into_ty(),
+            // `FnOnce` takes the receiver by value, so it is the bare `dyn Trait`.
+            TyKind::FnPtr(_) | TyKind::DynTrait(_) => fn_ptr_ty,
+            _ => unreachable!(),
+        };
+
+        let body = if item_meta.opacity.with_private_contents().is_opaque() {
+            Body::Opaque
+        } else {
+            self.translate_fn_pointer_vtable_shim_body(
+                span,
+                &target_receiver,
+                &signature,
+                target_kind,
+            )?
+        };
+
+        Ok(FunDecl {
+            def_id: fun_id,
+            item_meta,
+            generics: self.into_generics(),
+            signature: Box::new(signature),
+            src: FunSource::VTableShim,
+            body,
+        })
+    }
+
+    /// ```ignore
+    /// local ret@0 : Output;
+    /// local shim_self@1 : &dyn Fn<Args>;
+    /// local args@2 : Args;
+    /// local target_self@3 : &fn(..) -> Output;
+    /// target_self@3 := concretize_cast<&dyn Fn<Args>, &fn(..) -> Output>(shim_self@1);
+    /// ret@0 := (*target_self@3)(move args@2.0, move args@2.1, ..);
+    /// ```
+    fn translate_fn_pointer_vtable_shim_body(
+        &mut self,
+        span: Span,
+        target_receiver: &Ty,
+        shim_signature: &FunSig,
+        target_kind: ClosureKind,
+    ) -> Result<Body, Error> {
+        let mut builder = BodyBuilder::new(span, shim_signature.inputs.len());
+
+        let ret_place = builder.new_var(None, shim_signature.output.clone());
+        let shim_self = builder.new_var(
+            Some("shim_self".to_string()),
+            shim_signature.inputs[0].clone(),
+        );
+        let tupled_args_ty = &shim_signature.inputs[1];
+        let tupled_args = builder.new_var(Some("args".to_string()), tupled_args_ty.clone());
+        let target_self = builder.new_var(Some("target_self".to_string()), target_receiver.clone());
+
+        // Replace the `dyn Trait` receiver with the concrete `fn(..)` one.
+        let rval = Rvalue::UnaryOp(
+            UnOp::Cast(CastKind::Concretize(
+                shim_self.ty().clone(),
+                target_self.ty().clone(),
+            )),
+            Operand::Move(shim_self),
+        );
+        builder.push_statement(StatementKind::Assign(target_self.clone(), rval));
+
+        // Untupling the arguments needs the concrete tuple, so this only works once the
+        // arguments are known; with generic `Args` there is no arity to unpack.
+        let Some(tuple_ref) = tupled_args_ty.as_adt() else {
+            raise_error!(
+                self,
+                span,
+                "vtable shims for function pointers need monomorphized arguments, got `{}`",
+                tupled_args_ty.with_ctx(&self.into_fmt())
+            )
+        };
+        let tuple_id = tuple_ref.id;
+        let _ = self.get_or_translate(ItemId::Type(tuple_id))?;
+        let arg_tys = tupled_args_ty.as_tuple_fields(&self.t_ctx.translated);
+        let args = arg_tys
+            .into_iter()
+            .enumerate()
+            .map(|(i, ty)| {
+                let nth_field = tupled_args
+                    .clone()
+                    .project(ProjectionElem::Field(None, FieldId::new(i)), ty);
+                Operand::Move(nth_field)
+            })
+            .collect();
+
+        // `FnOnce` takes the fn pointer by value; the others through a reference.
+        let callee = match target_kind {
+            ClosureKind::FnOnce => target_self,
+            ClosureKind::Fn | ClosureKind::FnMut => target_self.deref(),
+        };
+        builder.call(Call {
+            func: FnOperand::Dynamic(Operand::Copy(callee)),
+            args,
+            dest: ret_place,
+        });
+
+        Ok(Body::Unstructured(builder.build()))
     }
 
     /// Same as `translate_vtable_shim`, for the `call`/`call_mut`/`call_once` method of the `Fn*`

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -3,7 +3,10 @@ use rustc_span::kw;
 use std::mem;
 
 use super::{
-    translate_crate::TransItemSourceKind, translate_ctx::*, translate_generics::BindingLevel,
+    translate_closures::{callable_virtual_impl, recognize_fn_trait_impl_proof},
+    translate_crate::TransItemSourceKind,
+    translate_ctx::*,
+    translate_generics::BindingLevel,
 };
 use crate::hax;
 use crate::hax::TraitPredicate;
@@ -413,23 +416,23 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                                 .insert(hax::GenericPredicateId::TraitSelf, TraitClauseId::ZERO);
                             ctx.translate_poly_fun_sig(span, sig)
                         })?;
-                        // A `self: Self` receiver would be unsized once `Self` becomes `dyn Trait`,
-                        // so we take it via `*mut Self` instead (like rustc)
-                        let receiver_is_by_value = matches!(
+                        // A `self: Self` receiver would be unsized once `Self` becomes
+                        // `dyn Trait`, so we take it via `*mut Self` instead (like rustc).
+                        let by_value_receiver = matches!(
                             sig.value.inputs[0].kind(),
-                            hax::TyKind::Param(param) if param.index == 0
+                            hax::TyKind::Param(p) if p.index == 0
                         );
-                        let mut sig = bound_sig.apply(&{
+                        let mut fn_sig = bound_sig.apply(&{
                             let mut generics = GenericArgs::empty();
                             // Provide the `Self` clause.
                             generics.trait_refs.push(self_trait_ref.clone());
                             generics
                         });
-                        if receiver_is_by_value {
-                            let receiver = &mut sig.skip_binder.inputs[0];
+                        if by_value_receiver {
+                            let receiver = &mut fn_sig.skip_binder.inputs[0];
                             *receiver = TyKind::RawPtr(receiver.clone(), RefKind::Mut).into_ty();
                         }
-                        let ty = TyKind::FnPtr(sig).into_ty();
+                        let ty = TyKind::FnPtr(fn_sig).into_ty();
                         (field_name, ty)
                     }
                 }
@@ -659,29 +662,24 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             hax::TraitProofKind::Concrete { .. } | hax::TraitProofKind::Builtin { .. } => {
                 // We could return `VTableRef` but we need to enqueue the translation of the static
                 // so may as well reuse that to normalize a bit.
+                let fn_trait_impl = recognize_fn_trait_impl_proof(trait_proof);
                 let vtable_instance =
                     self.translate_region_binder(span, &trait_proof.pred, |ctx, tref| {
-                        let fn_trait_impl =
-                            super::translate_closures::recognize_fn_trait_impl_proof(trait_proof);
                         let (impl_item, impl_kind) = match (&trait_proof.kind, fn_trait_impl) {
                             (hax::TraitProofKind::Concrete(impl_item), _) => {
                                 (impl_item, TransImplSource::Normal)
                             }
-                            (_, Some((self_ty, closure_kind))) => match self_ty.kind() {
-                                // Key the `Fn*` impls of closures and fn items on the item
+                            // Key the `Fn*` impls of closures and fn items on the item; function
+                            // pointers have no item so we key them on the trait.
+                            (_, Some((self_ty, kind))) => match self_ty.kind() {
                                 hax::TyKind::Closure(args) => {
-                                    (&args.item, TransImplSource::Callable(closure_kind))
+                                    (&args.item, TransImplSource::Callable(kind))
                                 }
                                 hax::TyKind::FnDef { item, .. } => {
-                                    (item, TransImplSource::Callable(closure_kind))
+                                    (item, TransImplSource::Callable(kind))
                                 }
-                                // Function pointers don't have an item so put them on the trait
-                                hax::TyKind::Arrow(_) => {
-                                    (tref, TransImplSource::FnPointer(closure_kind))
-                                }
-                                _ => unreachable!(
-                                    "builtin `Fn*` impl for unexpected type {self_ty:?}"
-                                ),
+                                hax::TyKind::Arrow(_) => (tref, TransImplSource::FnPointer(kind)),
+                                _ => unreachable!("builtin `Fn*` impl for {self_ty:?}"),
                             },
                             (_, None) => (tref, TransImplSource::Marker),
                         };
@@ -840,7 +838,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         })
     }
 
-    /// Gather what we need to fill in the vtable of this impl. See `VTableInstanceData`.
+    /// Gather what we need to fill in the vtable of this impl.
     fn vtable_instance_data<'a>(
         impl_def: &'a hax::FullDef<'tcx>,
         impl_kind: TransImplSource,
@@ -848,7 +846,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         match (impl_kind, impl_def.kind()) {
             // The def is the closure or fn item; the impl is one of its virtual `Fn*` impls.
             (TransImplSource::Callable(target_kind), _) => {
-                let vimpl = super::translate_closures::callable_virtual_impl(impl_def, target_kind);
+                let vimpl = callable_virtual_impl(impl_def, target_kind);
                 VTableInstanceData {
                     implemented_trait_ref: &vimpl.trait_pred.trait_ref,
                     implied_trait_proofs: &vimpl.implied_trait_proofs,
@@ -1418,8 +1416,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         // `dyn_self` field; we ask rustc for the `dyn Fn*<..>` type of the implemented trait ref.
         let callable_dyn_self;
         let (dyn_self, trait_pred) = if let TransImplSource::Callable(target_kind) = impl_kind {
-            let trait_pred =
-                &super::translate_closures::callable_virtual_impl(impl_def, target_kind).trait_pred;
+            let trait_pred = &callable_virtual_impl(impl_def, target_kind).trait_pred;
             callable_dyn_self =
                 hax::trait_ref_dyn_self(self.hax_state_with_id(), &trait_pred.trait_ref);
             (&callable_dyn_self, trait_pred)
@@ -1663,17 +1660,14 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         let mut builder = BodyBuilder::new(span, shim_signature.inputs.len());
 
         let ret_place = builder.new_var(None, shim_signature.output.clone());
-        let shim_self = builder.new_var(
-            Some("shim_self".to_string()),
-            shim_signature.inputs[0].clone(),
-        );
+        let shim_self = builder.new_var(Some("shim_self".into()), shim_signature.inputs[0].clone());
         let tupled_args_ty = &shim_signature.inputs[1];
-        let tupled_args = builder.new_var(Some("args".to_string()), tupled_args_ty.clone());
+        let tupled_args = builder.new_var(Some("args".into()), tupled_args_ty.clone());
         let cast_target_ty = match target_kind {
             ClosureKind::Fn | ClosureKind::FnMut => target_receiver.clone(),
             ClosureKind::FnOnce => TyKind::RawPtr(target_receiver.clone(), RefKind::Mut).into_ty(),
         };
-        let target_self = builder.new_var(Some("target_self".to_string()), cast_target_ty);
+        let target_self = builder.new_var(Some("target_self".into()), cast_target_ty);
 
         // Replace the `dyn Trait` receiver with the concrete `fn(..)` one.
         let rval = Rvalue::UnaryOp(
@@ -1688,23 +1682,20 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         // We only get here in mono mode, so the tupled argument type is a concrete tuple whose
         // fields we can untuple to call the function pointer directly.
         let tuple_ref = tupled_args_ty.as_adt().expect("args must be a tuple");
-        let _ = self.get_or_translate(ItemId::Type(tuple_ref.id))?;
-        let arg_tys = tupled_args_ty.as_tuple_fields(&self.t_ctx.translated);
-        let args = arg_tys
+        self.get_or_translate(ItemId::Type(tuple_ref.id))?;
+        let args = tupled_args_ty
+            .as_tuple_fields(&self.t_ctx.translated)
             .into_iter()
             .enumerate()
             .map(|(i, ty)| {
-                let nth_field = tupled_args
-                    .clone()
-                    .project(ProjectionElem::Field(None, FieldId::new(i)), ty);
-                Operand::Move(nth_field)
+                let field = ProjectionElem::Field(None, FieldId::new(i));
+                Operand::Move(tupled_args.clone().project(field, ty))
             })
             .collect();
 
-        // Dereference the pointer/reference to get the fn pointer to call.
-        let callee = target_self.deref();
         builder.call(Call {
-            func: FnOperand::Dynamic(Operand::Copy(callee)),
+            // Dereference the pointer/reference to get the fn pointer to call.
+            func: FnOperand::Dynamic(Operand::Copy(target_self.deref())),
             args,
             dest: ret_place,
         });
@@ -1723,7 +1714,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
     ) -> Result<FunDecl, Error> {
         let span = item_meta.span;
 
-        let vimpl = super::translate_closures::callable_virtual_impl(def, target_kind);
+        let vimpl = callable_virtual_impl(def, target_kind);
         let vtable_sig = self.callable_vtable_method_sig(&vimpl.trait_pred.trait_ref);
 
         // The signature of the shim function. Its only late-bound region is the one of the

--- a/charon/src/transform/normalize/transform_dyn_trait_calls.rs
+++ b/charon/src/transform/normalize/transform_dyn_trait_calls.rs
@@ -141,6 +141,13 @@ fn transform_dyn_trait_call(
             "Dyn trait receiver does not have vtable metadata"
         );
     };
+
+    // this is the the (wide) pointer that has the vtable metadata. by-value receivers (e.g. Box<dyn FnOnce>)
+    // are passed as *p, but it's p that has the vtable, so we need to get that!
+    let dyn_trait_place = match dyn_trait_place.as_projection() {
+        Some((ptr, ProjectionElem::Deref)) => ptr,
+        _ => dyn_trait_place,
+    };
     let receiver_vtable_ty = TyKind::Adt(receiver_vtable_ref).into_ty();
     let ptr_to_vtable_ty = Ty::new(TyKind::RawPtr(receiver_vtable_ty.clone(), RefKind::Shared));
     let mut method_vtable_place = dyn_trait_place

--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -216,8 +216,8 @@ impl TypeCheckVisitor<'_> {
             }
             // Can happen with `Box`, where the RHS is `Box`. FIXME(#1163): check for Box here.
             (TyKind::DynTrait(..), TyKind::Adt(..)) => {}
-            // The vtable shim of the `Fn*` impl of a function item concretizes to the function item type.
-            (TyKind::DynTrait(..), TyKind::FnDef(..)) => {}
+            // The vtable shim of the `Fn*` impl of a function item/pointer concretizes to that type.
+            (TyKind::DynTrait(..), TyKind::FnDef(..) | TyKind::FnPtr(..)) => {}
             _ => {
                 let fmt = &self.ctx.into_fmt();
                 self.error(format!(

--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -216,6 +216,8 @@ impl TypeCheckVisitor<'_> {
             }
             // Can happen with `Box`, where the RHS is `Box`. FIXME(#1163): check for Box here.
             (TyKind::DynTrait(..), TyKind::Adt(..)) => {}
+            // The vtable shim of the `Fn*` impl of a function item concretizes to the function item type.
+            (TyKind::DynTrait(..), TyKind::FnDef(..)) => {}
             _ => {
                 let fmt = &self.ctx.into_fmt();
                 self.error(format!(

--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -218,6 +218,9 @@ impl TypeCheckVisitor<'_> {
             (TyKind::DynTrait(..), TyKind::Adt(..)) => {}
             // The vtable shim of the `Fn*` impl of a function item/pointer concretizes to that type.
             (TyKind::DynTrait(..), TyKind::FnDef(..) | TyKind::FnPtr(..)) => {}
+            // In polymorphic mode, the vtable shim for the `Fn*` impl of a function pointer is
+            // keyed on the trait, so it concretizes `dyn Fn*<Args>` to the generic `Self`.
+            (TyKind::DynTrait(..), TyKind::TypeVar(..)) => {}
             _ => {
                 let fmt = &self.ctx.into_fmt();
                 self.error(format!(

--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -214,13 +214,6 @@ impl TypeCheckVisitor<'_> {
                     assert_eq!(instantiated_from(src.id), instantiated_from(tar.id));
                 }
             }
-            // Can happen with `Box`, where the RHS is `Box`. FIXME(#1163): check for Box here.
-            (TyKind::DynTrait(..), TyKind::Adt(..)) => {}
-            // The vtable shim of the `Fn*` impl of a function item/pointer concretizes to that type.
-            (TyKind::DynTrait(..), TyKind::FnDef(..) | TyKind::FnPtr(..)) => {}
-            // In polymorphic mode, the vtable shim for the `Fn*` impl of a function pointer is
-            // keyed on the trait, so it concretizes `dyn Fn*<Args>` to the generic `Self`.
-            (TyKind::DynTrait(..), TyKind::TypeVar(..)) => {}
             _ => {
                 let fmt = &self.ctx.into_fmt();
                 self.error(format!(

--- a/charon/tests/cargo/dependencies.out
+++ b/charon/tests/cargo/dependencies.out
@@ -154,24 +154,24 @@ fn main()
     let _2: (); // anonymous local
     let _3: &'1 mut u32; // anonymous local
     let _4: &'2 mut u32; // anonymous local
-    let _5: (&'11 u32, &'12 u32); // anonymous local
-    let _6: &'16 u32; // anonymous local
-    let _7: &'17 u32; // anonymous local
-    let left_val: &'18 u32; // local
-    let right_val: &'19 u32; // local
+    let _5: (&'12 u32, &'13 u32); // anonymous local
+    let _6: &'17 u32; // anonymous local
+    let _7: &'18 u32; // anonymous local
+    let left_val: &'19 u32; // local
+    let right_val: &'20 u32; // local
     let _10: bool; // anonymous local
     let _11: u32; // anonymous local
     let _12: u32; // anonymous local
     let kind: AssertKind; // local
     let _14: AssertKind; // anonymous local
-    let _15: &'20 u32; // anonymous local
-    let _16: &'21 u32; // anonymous local
-    let _17: &'22 u32; // anonymous local
-    let _18: &'23 u32; // anonymous local
-    let _19: Option<Arguments<'31>>[{built_in impl Sized for Arguments<'31>}]; // anonymous local
-    let _20: &'35 u32; // anonymous local
-    let _21: &'38 u32; // anonymous local
-    let _22: &'52 u32; // anonymous local
+    let _15: &'21 u32; // anonymous local
+    let _16: &'22 u32; // anonymous local
+    let _17: &'23 u32; // anonymous local
+    let _18: &'24 u32; // anonymous local
+    let _19: Option<Arguments<'33>>[{built_in impl Sized for Arguments<'33>}]; // anonymous local
+    let _20: &'37 u32; // anonymous local
+    let _21: &'40 u32; // anonymous local
+    let _22: &'55 u32; // anonymous local
     let _23: u32; // anonymous local
 
     storage_live(_0)
@@ -185,7 +185,7 @@ fn main()
     storage_live(_4)
     _4 = &mut x
     _3 = &two-phase-mut (*_4)
-    _2 = silly_incr<'37>(move _3)
+    _2 = silly_incr<'39>(move _3)
     ↳⚡ unwind_continue
     storage_live(_21)
     storage_live(_22)

--- a/charon/tests/cargo/issue-396-lib-bin.out
+++ b/charon/tests/cargo/issue-396-lib-bin.out
@@ -117,15 +117,15 @@ fn main()
     let args_3: (&'4 u32,); // local
     let _4: &'5 u32; // anonymous local
     let _5: u32; // anonymous local
-    let args_6: [Argument<'13>; 1usize]; // local
-    let _7: Argument<'17>; // anonymous local
-    let _8: &'18 u32; // anonymous local
-    let _9: &'20 [u8; 4usize]; // anonymous local
-    let _10: &'21 [u8; 4usize]; // anonymous local
-    let _11: &'27 [Argument<'28>; 1usize]; // anonymous local
-    let _12: &'32 [Argument<'33>; 1usize]; // anonymous local
+    let args_6: [Argument<'14>; 1usize]; // local
+    let _7: Argument<'18>; // anonymous local
+    let _8: &'19 u32; // anonymous local
+    let _9: &'21 [u8; 4usize]; // anonymous local
+    let _10: &'22 [u8; 4usize]; // anonymous local
+    let _11: &'28 [Argument<'29>; 1usize]; // anonymous local
+    let _12: &'33 [Argument<'34>; 1usize]; // anonymous local
     let _13: [u8; 4usize]; // anonymous local
-    let _14: &'43 [u8; 4usize]; // anonymous local
+    let _14: &'44 [u8; 4usize]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -144,7 +144,7 @@ fn main()
     storage_live(_7)
     storage_live(_8)
     _8 = &(*args_3._0)
-    _7 = new_display<'39, '41, u32>[{built_in impl Sized for u32}, impl_Display_for_u32](move _8)
+    _7 = new_display<'40, '42, u32>[{built_in impl Sized for u32}, impl_Display_for_u32](move _8)
     ↳⚡ unwind_continue
     storage_dead(_8)
     args_6 = [move _7]
@@ -162,13 +162,13 @@ fn main()
     storage_live(_12)
     _12 = &args_6
     _11 = &(*_12)
-    _2 = new<'48, 4usize, 1usize>(move _9, move _11)
+    _2 = new<'49, 4usize, 1usize>(move _9, move _11)
     ↳⚡ unwind_continue
     storage_dead(_12)
     storage_dead(_11)
     storage_dead(_10)
     storage_dead(_9)
-    _1 = _print<'50>(move _2)
+    _1 = _print<'51>(move _2)
     ↳⚡ unwind_continue
     storage_dead(_2)
     storage_dead(args_6)

--- a/charon/tests/cargo/issue-412-dup-deps.out
+++ b/charon/tests/cargo/issue-412-dup-deps.out
@@ -70,28 +70,28 @@ fn main()
     let _0: (); // return
     let a: u32; // local
     let b: u32; // local
-    let _3: (&'8 u32, &'9 u32); // anonymous local
-    let _4: &'13 u32; // anonymous local
+    let _3: (&'9 u32, &'10 u32); // anonymous local
+    let _4: &'14 u32; // anonymous local
     let _5: u32; // anonymous local
     let _6: u32; // anonymous local
     let _7: u32; // anonymous local
     let _8: (u32, bool); // anonymous local
-    let _9: &'14 u32; // anonymous local
-    let left_val: &'15 u32; // local
-    let right_val: &'16 u32; // local
+    let _9: &'15 u32; // anonymous local
+    let left_val: &'16 u32; // local
+    let right_val: &'17 u32; // local
     let _12: bool; // anonymous local
     let _13: u32; // anonymous local
     let _14: u32; // anonymous local
     let kind: AssertKind; // local
     let _16: AssertKind; // anonymous local
-    let _17: &'17 u32; // anonymous local
-    let _18: &'18 u32; // anonymous local
-    let _19: &'19 u32; // anonymous local
-    let _20: &'20 u32; // anonymous local
-    let _21: Option<Arguments<'28>>[{built_in impl Sized for Arguments<'28>}]; // anonymous local
-    let _22: &'32 u32; // anonymous local
-    let _23: &'33 u32; // anonymous local
-    let _24: &'47 u32; // anonymous local
+    let _17: &'18 u32; // anonymous local
+    let _18: &'19 u32; // anonymous local
+    let _19: &'20 u32; // anonymous local
+    let _20: &'21 u32; // anonymous local
+    let _21: Option<Arguments<'30>>[{built_in impl Sized for Arguments<'30>}]; // anonymous local
+    let _22: &'34 u32; // anonymous local
+    let _23: &'35 u32; // anonymous local
+    let _24: &'50 u32; // anonymous local
     let _25: u32; // anonymous local
 
     storage_live(_0)

--- a/charon/tests/cargo/test-attributes.out
+++ b/charon/tests/cargo/test-attributes.out
@@ -457,7 +457,7 @@ pub fn test_attributes::tests::test_ignore() -> TestDescAndFn
     let _0: TestDescAndFn; // return
     let _1: TestDesc; // anonymous local
     let _2: TestName; // anonymous local
-    let _3: Option<&'7 str>[{built_in impl Sized for &'7 str}]; // anonymous local
+    let _3: Option<&'8 str>[{built_in impl Sized for &'8 str}]; // anonymous local
     let _4: ShouldPanic; // anonymous local
     let _5: TestType; // anonymous local
     let _6: TestFn; // anonymous local
@@ -478,8 +478,8 @@ pub fn test_attributes::tests::test_ignore() -> TestDescAndFn
     storage_dead(_5)
     storage_dead(_4)
     storage_dead(_3)
-    conditional_drop[impl_Destruct_for_TestName::drop_glue<'19>] _2
-    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'21>] _1
+    conditional_drop[impl_Destruct_for_TestName::drop_glue<'21>] _2
+    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'23>] _1
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_2)
@@ -492,12 +492,12 @@ pub fn test_attributes::tests::test_ignore() -> TestDescAndFn
     _6 = TestFn::StaticTestFn { _0: move _7 }
     storage_dead(_7)
     _0 = TestDescAndFn { desc: move _1, testfn: move _6 }
-    conditional_drop[impl_Destruct_for_TestFn::drop_glue<'20>] _6
-    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'21>] _1
+    conditional_drop[impl_Destruct_for_TestFn::drop_glue<'22>] _6
+    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'23>] _1
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_6)
-    conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'22>] _1
+    conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'24>] _1
     ↳⚡ unwind_continue
     storage_dead(_1)
     return
@@ -608,7 +608,7 @@ pub fn test_attributes::tests::test_should_panic() -> TestDescAndFn
     let _0: TestDescAndFn; // return
     let _1: TestDesc; // anonymous local
     let _2: TestName; // anonymous local
-    let _3: Option<&'7 str>[{built_in impl Sized for &'7 str}]; // anonymous local
+    let _3: Option<&'8 str>[{built_in impl Sized for &'8 str}]; // anonymous local
     let _4: ShouldPanic; // anonymous local
     let _5: TestType; // anonymous local
     let _6: TestFn; // anonymous local
@@ -629,8 +629,8 @@ pub fn test_attributes::tests::test_should_panic() -> TestDescAndFn
     storage_dead(_5)
     storage_dead(_4)
     storage_dead(_3)
-    conditional_drop[impl_Destruct_for_TestName::drop_glue<'19>] _2
-    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'21>] _1
+    conditional_drop[impl_Destruct_for_TestName::drop_glue<'21>] _2
+    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'23>] _1
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_2)
@@ -643,12 +643,12 @@ pub fn test_attributes::tests::test_should_panic() -> TestDescAndFn
     _6 = TestFn::StaticTestFn { _0: move _7 }
     storage_dead(_7)
     _0 = TestDescAndFn { desc: move _1, testfn: move _6 }
-    conditional_drop[impl_Destruct_for_TestFn::drop_glue<'20>] _6
-    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'21>] _1
+    conditional_drop[impl_Destruct_for_TestFn::drop_glue<'22>] _6
+    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'23>] _1
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_6)
-    conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'22>] _1
+    conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'24>] _1
     ↳⚡ unwind_continue
     storage_dead(_1)
     return
@@ -760,7 +760,7 @@ pub fn test_attributes::tests::test_foo() -> TestDescAndFn
     let _0: TestDescAndFn; // return
     let _1: TestDesc; // anonymous local
     let _2: TestName; // anonymous local
-    let _3: Option<&'7 str>[{built_in impl Sized for &'7 str}]; // anonymous local
+    let _3: Option<&'8 str>[{built_in impl Sized for &'8 str}]; // anonymous local
     let _4: ShouldPanic; // anonymous local
     let _5: TestType; // anonymous local
     let _6: TestFn; // anonymous local
@@ -781,8 +781,8 @@ pub fn test_attributes::tests::test_foo() -> TestDescAndFn
     storage_dead(_5)
     storage_dead(_4)
     storage_dead(_3)
-    conditional_drop[impl_Destruct_for_TestName::drop_glue<'19>] _2
-    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'21>] _1
+    conditional_drop[impl_Destruct_for_TestName::drop_glue<'21>] _2
+    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'23>] _1
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_2)
@@ -795,12 +795,12 @@ pub fn test_attributes::tests::test_foo() -> TestDescAndFn
     _6 = TestFn::StaticTestFn { _0: move _7 }
     storage_dead(_7)
     _0 = TestDescAndFn { desc: move _1, testfn: move _6 }
-    conditional_drop[impl_Destruct_for_TestFn::drop_glue<'20>] _6
-    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'21>] _1
+    conditional_drop[impl_Destruct_for_TestFn::drop_glue<'22>] _6
+    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'23>] _1
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_6)
-    conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'22>] _1
+    conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'24>] _1
     ↳⚡ unwind_continue
     storage_dead(_1)
     return
@@ -812,21 +812,21 @@ pub const test_attributes::tests::test_foo: TestDescAndFn = test_attributes::tes
 pub fn main()
 {
     let _0: (); // return
-    let _1: &'12 [&'13 TestDescAndFn]; // anonymous local
-    let _2: &'28 [&'29 TestDescAndFn; 3usize]; // anonymous local
-    let _3: &'33 [&'34 TestDescAndFn; 3usize]; // anonymous local
-    let _4: &'48 [&'49 TestDescAndFn; 3usize]; // anonymous local
-    let _5: &'53 [&'54 TestDescAndFn; 3usize]; // anonymous local
-    let _6: &'75 [&'76 TestDescAndFn; 3usize]; // anonymous local
-    let _7: [&'80 TestDescAndFn; 3usize]; // anonymous local
-    let _8: &'84 TestDescAndFn; // anonymous local
-    let _9: &'85 TestDescAndFn; // anonymous local
+    let _1: &'13 [&'14 TestDescAndFn]; // anonymous local
+    let _2: &'30 [&'31 TestDescAndFn; 3usize]; // anonymous local
+    let _3: &'35 [&'36 TestDescAndFn; 3usize]; // anonymous local
+    let _4: &'50 [&'51 TestDescAndFn; 3usize]; // anonymous local
+    let _5: &'55 [&'56 TestDescAndFn; 3usize]; // anonymous local
+    let _6: &'77 [&'78 TestDescAndFn; 3usize]; // anonymous local
+    let _7: [&'82 TestDescAndFn; 3usize]; // anonymous local
+    let _8: &'86 TestDescAndFn; // anonymous local
+    let _9: &'87 TestDescAndFn; // anonymous local
     let _10: TestDescAndFn; // anonymous local
-    let _11: &'86 TestDescAndFn; // anonymous local
-    let _12: &'87 TestDescAndFn; // anonymous local
+    let _11: &'88 TestDescAndFn; // anonymous local
+    let _12: &'89 TestDescAndFn; // anonymous local
     let _13: TestDescAndFn; // anonymous local
-    let _14: &'88 TestDescAndFn; // anonymous local
-    let _15: &'89 TestDescAndFn; // anonymous local
+    let _14: &'90 TestDescAndFn; // anonymous local
+    let _15: &'91 TestDescAndFn; // anonymous local
     let _16: TestDescAndFn; // anonymous local
 
     storage_live(_5)
@@ -862,9 +862,9 @@ pub fn main()
     _4 = move _5
     _3 = &(*_4)
     _2 = &(*_3)
-    _1 = unsize_cast<&'28 [&'29 TestDescAndFn; 3usize], &'66 [&'67 TestDescAndFn], 3usize>(move _2)
+    _1 = unsize_cast<&'30 [&'31 TestDescAndFn; 3usize], &'68 [&'69 TestDescAndFn], 3usize>(move _2)
     storage_dead(_2)
-    _0 = test_main_static<'73, '74>(move _1)
+    _0 = test_main_static<'75, '76>(move _1)
     ↳⚡ unwind_continue
     storage_dead(_1)
     storage_dead(_3)

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -2872,16 +2872,16 @@ where
     TypeOutlives0: T: '_0,
 {
     let _0: (); // return
-    let x: [&'6 mut T; 3usize]; // arg #1
-    let _a: &'10 mut T; // local
-    let _b: &'11 mut T; // local
-    let _c: &'12 mut T; // local
-    let _5: &'_ mut [&'6 mut T; 3usize]; // anonymous local
-    let _6: &'_ mut &'6 mut T; // anonymous local
-    let _7: &'_ mut [&'6 mut T; 3usize]; // anonymous local
-    let _8: &'_ mut &'6 mut T; // anonymous local
-    let _9: &'_ mut [&'6 mut T; 3usize]; // anonymous local
-    let _10: &'_ mut &'6 mut T; // anonymous local
+    let x: [&'8 mut T; 3usize]; // arg #1
+    let _a: &'12 mut T; // local
+    let _b: &'13 mut T; // local
+    let _c: &'14 mut T; // local
+    let _5: &'_ mut [&'8 mut T; 3usize]; // anonymous local
+    let _6: &'_ mut &'8 mut T; // anonymous local
+    let _7: &'_ mut [&'8 mut T; 3usize]; // anonymous local
+    let _8: &'_ mut &'8 mut T; // anonymous local
+    let _9: &'_ mut [&'8 mut T; 3usize]; // anonymous local
+    let _10: &'_ mut &'8 mut T; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -2889,21 +2889,21 @@ where
     storage_live(_5)
     _5 = &mut x
     storage_live(_6)
-    _6 = impl_IndexMut_for_array::index_mut<'_, &'6 mut T, usize, &'6 mut T, 3usize>[{built_in impl Sized for &'6 mut T}, {built_in impl Sized for usize}, impl_IndexMut_for_slice<&'6 mut T, usize, &'6 mut T>[{built_in impl Sized for &'6 mut T}, {built_in impl Sized for usize}, impl_SliceIndex_slice_for_usize<&'6 mut T>[{built_in impl Sized for &'6 mut T}]]](move _5, const 0usize)
+    _6 = impl_IndexMut_for_array::index_mut<'_, &'8 mut T, usize, &'8 mut T, 3usize>[{built_in impl Sized for &'8 mut T}, {built_in impl Sized for usize}, impl_IndexMut_for_slice<&'8 mut T, usize, &'8 mut T>[{built_in impl Sized for &'8 mut T}, {built_in impl Sized for usize}, impl_SliceIndex_slice_for_usize<&'8 mut T>[{built_in impl Sized for &'8 mut T}]]](move _5, const 0usize)
     ↳⚡ undefined_behavior
     _a = move (*_6)
     storage_live(_b)
     storage_live(_7)
     _7 = &mut x
     storage_live(_8)
-    _8 = impl_IndexMut_for_array::index_mut<'_, &'6 mut T, usize, &'6 mut T, 3usize>[{built_in impl Sized for &'6 mut T}, {built_in impl Sized for usize}, impl_IndexMut_for_slice<&'6 mut T, usize, &'6 mut T>[{built_in impl Sized for &'6 mut T}, {built_in impl Sized for usize}, impl_SliceIndex_slice_for_usize<&'6 mut T>[{built_in impl Sized for &'6 mut T}]]](move _7, const 1usize)
+    _8 = impl_IndexMut_for_array::index_mut<'_, &'8 mut T, usize, &'8 mut T, 3usize>[{built_in impl Sized for &'8 mut T}, {built_in impl Sized for usize}, impl_IndexMut_for_slice<&'8 mut T, usize, &'8 mut T>[{built_in impl Sized for &'8 mut T}, {built_in impl Sized for usize}, impl_SliceIndex_slice_for_usize<&'8 mut T>[{built_in impl Sized for &'8 mut T}]]](move _7, const 1usize)
     ↳⚡ undefined_behavior
     _b = move (*_8)
     storage_live(_c)
     storage_live(_9)
     _9 = &mut x
     storage_live(_10)
-    _10 = impl_IndexMut_for_array::index_mut<'_, &'6 mut T, usize, &'6 mut T, 3usize>[{built_in impl Sized for &'6 mut T}, {built_in impl Sized for usize}, impl_IndexMut_for_slice<&'6 mut T, usize, &'6 mut T>[{built_in impl Sized for &'6 mut T}, {built_in impl Sized for usize}, impl_SliceIndex_slice_for_usize<&'6 mut T>[{built_in impl Sized for &'6 mut T}]]](move _9, const 2usize)
+    _10 = impl_IndexMut_for_array::index_mut<'_, &'8 mut T, usize, &'8 mut T, 3usize>[{built_in impl Sized for &'8 mut T}, {built_in impl Sized for usize}, impl_IndexMut_for_slice<&'8 mut T, usize, &'8 mut T>[{built_in impl Sized for &'8 mut T}, {built_in impl Sized for usize}, impl_SliceIndex_slice_for_usize<&'8 mut T>[{built_in impl Sized for &'8 mut T}]]](move _9, const 2usize)
     ↳⚡ undefined_behavior
     _c = move (*_10)
     _0 = ()

--- a/charon/tests/ui/associated_types/associated-types.out
+++ b/charon/tests/ui/associated_types/associated-types.out
@@ -177,8 +177,8 @@ where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: 'a,
 {
-    let _0: Option<&'6 T>[{built_in impl Sized for &'6 T}]; // return
-    let x: Option<&'10 T>[{built_in impl Sized for &'10 T}]; // arg #1
+    let _0: Option<&'8 T>[{built_in impl Sized for &'8 T}]; // return
+    let x: Option<&'12 T>[{built_in impl Sized for &'12 T}]; // arg #1
 
     storage_live(_0)
     _0 = copy x
@@ -302,15 +302,15 @@ where
 fn call_fn()
 {
     let _0: (); // return
-    let _1: Option<&'7 bool>[{built_in impl Sized for &'7 bool}]; // anonymous local
-    let _2: Option<&'11 bool>[{built_in impl Sized for &'11 bool}]; // anonymous local
+    let _1: Option<&'8 bool>[{built_in impl Sized for &'8 bool}]; // anonymous local
+    let _2: Option<&'12 bool>[{built_in impl Sized for &'12 bool}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
     storage_live(_1)
     storage_live(_2)
     _2 = Option::None {  }
-    _1 = external_use_item<'23, &'23 bool, Option<&'23 bool>[{built_in impl Sized for &'23 bool}], &'23 bool>[{built_in impl Sized for &'23 bool}, {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T}<'23, bool>[{built_in impl Sized for bool}], impl_Foo_for_Option<'23, &'23 bool>[{built_in impl Sized for &'23 bool}, {impl Copy for &'_0 T}<'23, bool>]](move _2)
+    _1 = external_use_item<'25, &'25 bool, Option<&'25 bool>[{built_in impl Sized for &'25 bool}], &'25 bool>[{built_in impl Sized for &'25 bool}, {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T}<'25, bool>[{built_in impl Sized for bool}], impl_Foo_for_Option<'25, &'25 bool>[{built_in impl Sized for &'25 bool}, {impl Copy for &'_0 T}<'25, bool>]](move _2)
     ↳⚡ unwind_continue
     storage_dead(_2)
     storage_dead(_1)

--- a/charon/tests/ui/associated_types/mem-discriminant-from-derive.out
+++ b/charon/tests/ui/associated_types/mem-discriminant-from-derive.out
@@ -91,13 +91,13 @@ pub fn impl_PartialEq_Enum_for_Enum::eq<'_0, '_1>(self: &'_0 Enum, other: &'_1 E
     let _7: bool; // anonymous local
     let _8: isize; // anonymous local
     let _9: isize; // anonymous local
-    let _10: (&'12 Enum, &'13 Enum); // anonymous local
-    let _11: &'17 Enum; // anonymous local
-    let _12: &'18 Enum; // anonymous local
-    let __self_0: &'20 u8; // local
-    let __arg1_0: &'21 u8; // local
-    let _15: &'24 &'25 u8; // anonymous local
-    let _16: &'26 &'27 u8; // anonymous local
+    let _10: (&'13 Enum, &'14 Enum); // anonymous local
+    let _11: &'18 Enum; // anonymous local
+    let _12: &'19 Enum; // anonymous local
+    let __self_0: &'21 u8; // local
+    let __arg1_0: &'22 u8; // local
+    let _15: &'25 &'26 u8; // anonymous local
+    let _16: &'27 &'28 u8; // anonymous local
 
     storage_live(_0)
     storage_live(__self_discr)
@@ -152,7 +152,7 @@ pub fn impl_PartialEq_Enum_for_Enum::eq<'_0, '_1>(self: &'_0 Enum, other: &'_1 E
                     _15 = &__self_0
                     storage_live(_16)
                     _16 = &__arg1_0
-                    _0 = {impl PartialEq<&'_0 B> for &'_1 A}::eq<'41, '42, '45, '46, u8, u8>[impl_PartialEq_u8_for_u8](move _15, move _16)
+                    _0 = {impl PartialEq<&'_0 B> for &'_1 A}::eq<'42, '43, '46, '47, u8, u8>[impl_PartialEq_u8_for_u8](move _15, move _16)
                     ↳⚡ storage_dead(other)
                         storage_dead(self)
                         unwind_continue

--- a/charon/tests/ui/borrowck-statements.out
+++ b/charon/tests/ui/borrowck-statements.out
@@ -507,10 +507,10 @@ where
     storage_live(value_2)
     value_2 = copy value_1
     fake_read(value_2)
-    set_type(typeof(value_2) == &'12 u32)
+    set_type(typeof(value_2) == &'13 u32)
     predicate_holds({built_in impl Sized for &'4 u32})
-    predicate_holds({impl Copy for &'_0 T}<'10, u32>)
-    set_outlives(&'11 u32, 'b)
+    predicate_holds({impl Copy for &'_0 T}<'11, u32>)
+    set_outlives(&'12 u32, 'b)
     _0 = ()
     storage_dead(value_2)
     storage_dead(value_1)

--- a/charon/tests/ui/comments.out
+++ b/charon/tests/ui/comments.out
@@ -518,25 +518,25 @@ fn foo()
     let _13: u32; // anonymous local
     let _14: u32; // anonymous local
     let a: [u32; 10usize]; // local
-    let _16: (&'8 u32, &'9 u32); // anonymous local
-    let _17: &'13 u32; // anonymous local
+    let _16: (&'9 u32, &'10 u32); // anonymous local
+    let _17: &'14 u32; // anonymous local
     let _18: usize; // anonymous local
-    let _19: &'14 u32; // anonymous local
-    let left_val: &'15 u32; // local
-    let right_val: &'16 u32; // local
+    let _19: &'15 u32; // anonymous local
+    let left_val: &'16 u32; // local
+    let right_val: &'17 u32; // local
     let _22: bool; // anonymous local
     let _23: u32; // anonymous local
     let _24: u32; // anonymous local
     let kind: AssertKind; // local
     let _26: AssertKind; // anonymous local
-    let _27: &'17 u32; // anonymous local
-    let _28: &'18 u32; // anonymous local
-    let _29: &'19 u32; // anonymous local
-    let _30: &'20 u32; // anonymous local
-    let _31: Option<Arguments<'28>>[{built_in impl Sized for Arguments<'28>}]; // anonymous local
-    let _32: &'32 u32; // anonymous local
-    let _33: &'33 u32; // anonymous local
-    let _34: &'47 u32; // anonymous local
+    let _27: &'18 u32; // anonymous local
+    let _28: &'19 u32; // anonymous local
+    let _29: &'20 u32; // anonymous local
+    let _30: &'21 u32; // anonymous local
+    let _31: Option<Arguments<'30>>[{built_in impl Sized for Arguments<'30>}]; // anonymous local
+    let _32: &'34 u32; // anonymous local
+    let _33: &'35 u32; // anonymous local
+    let _34: &'50 u32; // anonymous local
     let _35: u32; // anonymous local
     let _36: &'_ [u32; 10usize]; // anonymous local
     let _37: &'_ u32; // anonymous local

--- a/charon/tests/ui/control-flow/issue-297-cfg.out
+++ b/charon/tests/ui/control-flow/issue-297-cfg.out
@@ -212,10 +212,10 @@ fn f2<'_0, '_1>(a: &'_0 [u8], result: &'_1 mut [i16]) -> usize
     let _5: Chunks<'6, u8>[{built_in impl Sized for u8}]; // anonymous local
     let _6: &'7 [u8]; // anonymous local
     let iter: Chunks<'8, u8>[{built_in impl Sized for u8}]; // local
-    let _8: Option<&'15 [u8]>[{built_in impl Sized for &'15 [u8]}]; // anonymous local
-    let _9: &'21 mut Chunks<'22, u8>[{built_in impl Sized for u8}]; // anonymous local
-    let _10: &'23 mut Chunks<'24, u8>[{built_in impl Sized for u8}]; // anonymous local
-    let bytes: &'25 [u8]; // local
+    let _8: Option<&'16 [u8]>[{built_in impl Sized for &'16 [u8]}]; // anonymous local
+    let _9: &'22 mut Chunks<'23, u8>[{built_in impl Sized for u8}]; // anonymous local
+    let _10: &'24 mut Chunks<'25, u8>[{built_in impl Sized for u8}]; // anonymous local
+    let bytes: &'26 [u8]; // local
     let b1: i16; // local
     let _13: u8; // anonymous local
     let _14: usize; // anonymous local
@@ -270,14 +270,14 @@ fn f2<'_0, '_1>(a: &'_0 [u8], result: &'_1 mut [i16]) -> usize
     storage_live(_5)
     storage_live(_6)
     _6 = &(*a) with_metadata(copy a.metadata)
-    _5 = chunks<'27, u8>[{built_in impl Sized for u8}](move _6, const 3usize)
+    _5 = chunks<'28, u8>[{built_in impl Sized for u8}](move _6, const 3usize)
     ↳⚡ storage_dead(_44)
         storage_dead(_37)
         storage_dead(result)
         storage_dead(a)
         unwind_continue
     storage_dead(_6)
-    _4 = into_iter<Chunks<'29, u8>[{built_in impl Sized for u8}]>[{built_in impl Sized for Chunks<'29, u8>[{built_in impl Sized for u8}]}, impl_Iterator_for_Chunks<'29, u8>[{built_in impl Sized for u8}]](move _5)
+    _4 = into_iter<Chunks<'30, u8>[{built_in impl Sized for u8}]>[{built_in impl Sized for Chunks<'30, u8>[{built_in impl Sized for u8}]}, impl_Iterator_for_Chunks<'30, u8>[{built_in impl Sized for u8}]](move _5)
     ↳⚡ storage_dead(_44)
         storage_dead(_37)
         storage_dead(result)
@@ -292,7 +292,7 @@ fn f2<'_0, '_1>(a: &'_0 [u8], result: &'_1 mut [i16]) -> usize
         storage_live(_10)
         _10 = &mut iter
         _9 = &two-phase-mut (*_10)
-        _8 = next<'39, '41, u8>[{built_in impl Sized for u8}](move _9)
+        _8 = next<'41, '43, u8>[{built_in impl Sized for u8}](move _9)
         ↳⚡ storage_dead(_44)
             storage_dead(_37)
             storage_dead(result)

--- a/charon/tests/ui/copy_nonoverlapping.out
+++ b/charon/tests/ui/copy_nonoverlapping.out
@@ -515,8 +515,8 @@ pub fn panic_nounwind_fmt<'_0>(fmt: Arguments<'_0>, force_no_backtrace: bool) ->
     let _0: !; // return
     let fmt: Arguments<'1>; // arg #1
     let force_no_backtrace: bool; // arg #2
-    let _3: (Arguments<'8>, bool); // anonymous local
-    let _4: Arguments<'12>; // anonymous local
+    let _3: (Arguments<'9>, bool); // anonymous local
+    let _4: Arguments<'13>; // anonymous local
     let _5: bool; // anonymous local
 
     storage_live(_0)
@@ -528,7 +528,7 @@ pub fn panic_nounwind_fmt<'_0>(fmt: Arguments<'_0>, force_no_backtrace: bool) ->
     _3 = (move _4, move _5)
     storage_dead(_5)
     storage_dead(_4)
-    _0 = core::panicking::panic_nounwind_fmt::runtime<'18>(move _3._0, move _3._1)
+    _0 = core::panicking::panic_nounwind_fmt::runtime<'19>(move _3._0, move _3._1)
     ↳⚡ storage_dead(_3)
         storage_dead(force_no_backtrace)
         storage_dead(fmt)

--- a/charon/tests/ui/dyn/box-dyn-fnonce-raw.out
+++ b/charon/tests/ui/dyn/box-dyn-fnonce-raw.out
@@ -192,7 +192,7 @@ struct core::ops::function::FnOnce::{vtable}<Args, Ty0> {
   size: usize,
   align: usize,
   drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Ty0>)),
-  method_call_once: extern "rust-call" fn((dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
+  method_call_once: extern "rust-call" fn(*mut (dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
   super_trait_0: &'static core::marker::MetaSized::{vtable},
 }
 
@@ -573,7 +573,7 @@ where
 }
 
 // Full name: alloc::boxed::{impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}::call_once::{vtable_method}
-extern "rust-call" fn {vtable_method}<Args, F, A>(_1: (dyn FnOnce<Args, Output = TraitClause4::Output>), _2: Args) -> TraitClause4::Output
+extern "rust-call" fn {vtable_method}<Args, F, A>(_1: *mut (dyn FnOnce<Args, Output = TraitClause4::Output>), _2: Args) -> TraitClause4::Output
 where
     TraitClause0: (Args: Sized),
     TraitClause1: (F: MetaSized),
@@ -583,14 +583,14 @@ where
     TraitClause5: (A: Allocator),
 {
     let _0: TraitClause4::Output; // return
-    let _1: (dyn FnOnce<Args, Output = TraitClause4::Output> + '0); // arg #1
+    let _1: *mut (dyn FnOnce<Args, Output = TraitClause4::Output> + '0); // arg #1
     let _2: Args; // arg #2
-    let _3: Box<F, A>[TraitClause1, TraitClause2, TraitClause5]; // anonymous local
+    let _3: *mut Box<F, A>[TraitClause1, TraitClause2, TraitClause5]; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
-    _3 = concretize<(dyn FnOnce<Args, Output = TraitClause4::Output> + '1), Box<F, A>[TraitClause1, TraitClause2, TraitClause5]>(move _1)
-    _0 = call_once<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5](move _3, move _2)
+    _3 = concretize<*mut (dyn FnOnce<Args, Output = TraitClause4::Output> + '1), *mut Box<F, A>[TraitClause1, TraitClause2, TraitClause5]>(move _1)
+    _0 = call_once<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5](move (*_3), move _2)
     ↳⚡ unwind_continue
     return
 }
@@ -635,7 +635,7 @@ where
     let size: usize; // local
     let align: usize; // local
     let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = TraitClause4::Output> + '1)); // anonymous local
-    let _4: extern "rust-call" fn((dyn FnOnce<Args, Output = TraitClause4::Output> + '2), Args) -> TraitClause4::Output; // anonymous local
+    let _4: extern "rust-call" fn(*mut (dyn FnOnce<Args, Output = TraitClause4::Output> + '2), Args) -> TraitClause4::Output; // anonymous local
     let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
 
     storage_live(ret)
@@ -646,7 +646,7 @@ where
     storage_live(_3)
     _3 = cast<for<'_0_1> {vtable_drop_shim}<'0, Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5], unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = TraitClause4::Output> + '1))>(const {vtable_drop_shim}<'0, Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5])
     storage_live(_4)
-    _4 = cast<{vtable_method}<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5], extern "rust-call" fn((dyn FnOnce<Args, Output = TraitClause4::Output> + '2), Args) -> TraitClause4::Output>(const {vtable_method}<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5])
+    _4 = cast<{vtable_method}<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5], extern "rust-call" fn(*mut (dyn FnOnce<Args, Output = TraitClause4::Output> + '2), Args) -> TraitClause4::Output>(const {vtable_method}<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5])
     storage_live(_5)
     _5 = &core::marker::MetaSized::{vtable}<Box<F, A>[TraitClause1, TraitClause2, TraitClause5]>
     ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: move _5 }

--- a/charon/tests/ui/dyn/box-dyn-fnonce-raw.out
+++ b/charon/tests/ui/dyn/box-dyn-fnonce-raw.out
@@ -686,39 +686,39 @@ where
 // Full name: test_crate::box_box
 pub fn box_box(f: Box<(dyn FnOnce<(), Output = ()> + 'static), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + 'static)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]) -> Box<(dyn FnOnce<(), Output = ()> + 'static), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + 'static)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]
 {
-    let _0: Box<(dyn FnOnce<(), Output = ()> + '5), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '7)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // return
-    let f: Box<(dyn FnOnce<(), Output = ()> + '8), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '10)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // arg #1
-    let _2: Box<(dyn FnOnce<(), Output = ()> + '11), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '13)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // anonymous local
-    let _3: Box<Box<(dyn FnOnce<(), Output = ()> + '28), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '30)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '34), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '36)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // anonymous local
-    let _4: Box<(dyn FnOnce<(), Output = ()> + '37), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '39)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // anonymous local
+    let _0: Box<(dyn FnOnce<(), Output = ()> + '6), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '8)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // return
+    let f: Box<(dyn FnOnce<(), Output = ()> + '9), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '11)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // arg #1
+    let _2: Box<(dyn FnOnce<(), Output = ()> + '12), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '14)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // anonymous local
+    let _3: Box<Box<(dyn FnOnce<(), Output = ()> + '36), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '38)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '42), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '44)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // anonymous local
+    let _4: Box<(dyn FnOnce<(), Output = ()> + '45), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '47)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // anonymous local
 
     storage_live(_0)
     storage_live(_2)
     storage_live(_3)
     storage_live(_4)
     _4 = move f
-    _3 = new<Box<(dyn FnOnce<(), Output = ()> + '45), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '47)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]>[{built_in impl Sized for Box<(dyn FnOnce<(), Output = ()> + '53), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '55)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}](move _4)
-    ↳⚡ conditional_drop[drop_glue<'79, (dyn FnOnce<(), Output = ()> + '75), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '75)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _4
+    _3 = new<Box<(dyn FnOnce<(), Output = ()> + '54), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '56)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]>[{built_in impl Sized for Box<(dyn FnOnce<(), Output = ()> + '63), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '65)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}](move _4)
+    ↳⚡ conditional_drop[drop_glue<'98, (dyn FnOnce<(), Output = ()> + '93), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '93)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _4
         ↳⚡ unwind_terminate
-        conditional_drop[drop_glue<'167, (dyn FnOnce<(), Output = ()> + '163), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '163)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
+        conditional_drop[drop_glue<'207, (dyn FnOnce<(), Output = ()> + '202), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '202)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
         ↳⚡ unwind_terminate
         unwind_continue
-    _2 = unsize_cast<Box<Box<(dyn FnOnce<(), Output = ()> + '28), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '30)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '34), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '36)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Box<(dyn FnOnce<(), Output = ()> + '80), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '82)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], &impl_FnOnce_for_Box::{vtable}<(), (dyn FnOnce<(), Output = ()> + '106), Global>[{built_in impl Sized for ()}, {built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '108)}, {built_in impl Sized for Global}, {built_in impl Tuple for ()}, FnOnce<(dyn FnOnce<(), Output = ()> + '111), ()>, impl_Allocator_for_Global]>(move _3)
-    conditional_drop[drop_glue<'154, Box<(dyn FnOnce<(), Output = ()> + '140), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '142)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '140), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '142)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _3
-    ↳⚡ conditional_drop[drop_glue<'79, (dyn FnOnce<(), Output = ()> + '75), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '75)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _4
+    _2 = unsize_cast<Box<Box<(dyn FnOnce<(), Output = ()> + '36), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '38)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '42), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '44)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Box<(dyn FnOnce<(), Output = ()> + '99), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '101)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], &impl_FnOnce_for_Box::{vtable}<(), (dyn FnOnce<(), Output = ()> + '128), Global>[{built_in impl Sized for ()}, {built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '130)}, {built_in impl Sized for Global}, {built_in impl Tuple for ()}, FnOnce<(dyn FnOnce<(), Output = ()> + '134), ()>, impl_Allocator_for_Global]>(move _3)
+    conditional_drop[drop_glue<'192, Box<(dyn FnOnce<(), Output = ()> + '171), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '173)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '171), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '173)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _3
+    ↳⚡ conditional_drop[drop_glue<'98, (dyn FnOnce<(), Output = ()> + '93), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '93)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _4
         ↳⚡ unwind_terminate
-        conditional_drop[drop_glue<'167, (dyn FnOnce<(), Output = ()> + '163), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '163)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
+        conditional_drop[drop_glue<'207, (dyn FnOnce<(), Output = ()> + '202), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '202)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_4)
     storage_dead(_3)
-    _0 = unsize_cast<Box<(dyn FnOnce<(), Output = ()> + '11), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '13)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Box<(dyn FnOnce<(), Output = ()> + '168), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '170)}, {built_in impl Sized for Global}, impl_Allocator_for_Global],  at []>(move _2)
-    conditional_drop[drop_glue<'183, (dyn FnOnce<(), Output = ()> + '179), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '179)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _2
-    ↳⚡ conditional_drop[drop_glue<'167, (dyn FnOnce<(), Output = ()> + '163), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '163)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
+    _0 = unsize_cast<Box<(dyn FnOnce<(), Output = ()> + '12), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '14)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Box<(dyn FnOnce<(), Output = ()> + '208), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '210)}, {built_in impl Sized for Global}, impl_Allocator_for_Global],  at []>(move _2)
+    conditional_drop[drop_glue<'225, (dyn FnOnce<(), Output = ()> + '220), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '220)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _2
+    ↳⚡ conditional_drop[drop_glue<'207, (dyn FnOnce<(), Output = ()> + '202), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '202)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_2)
-    conditional_drop[drop_glue<'196, (dyn FnOnce<(), Output = ()> + '192), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '192)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
+    conditional_drop[drop_glue<'240, (dyn FnOnce<(), Output = ()> + '235), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '235)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
     ↳⚡ unwind_continue
     return
 }

--- a/charon/tests/ui/dyn/builtin-vtables.out
+++ b/charon/tests/ui/dyn/builtin-vtables.out
@@ -44,7 +44,7 @@ struct core::ops::function::FnOnce::{vtable}<Args, Ty0> {
   size: usize,
   align: usize,
   drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Ty0>)),
-  method_call_once: extern "rust-call" fn((dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
+  method_call_once: extern "rust-call" fn(*mut (dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
   super_trait_0: &'static core::marker::MetaSized::{vtable},
 }
 
@@ -153,17 +153,17 @@ fn {impl FnOnce<(u32,)> for some_fn}::call_once(state: some_fn, args: (u32,)) ->
 }
 
 // Full name: test_crate::{impl FnOnce<(u32,)> for some_fn}::{vtable_method}
-extern "rust-call" fn {impl FnOnce<(u32,)> for some_fn}::{vtable_method}(_1: (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
+extern "rust-call" fn {impl FnOnce<(u32,)> for some_fn}::{vtable_method}(_1: *mut (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
 {
     let _0: u32; // return
-    let _1: (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
+    let _1: *mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
     let _2: (u32,); // arg #2
-    let _3: some_fn; // anonymous local
+    let _3: *mut some_fn; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
-    _3 = concretize<(dyn FnOnce<(u32,), Output = u32> + '1), some_fn>(move _1)
-    _0 = {impl FnOnce<(u32,)> for some_fn}::call_once(move _3, move _2)
+    _3 = concretize<*mut (dyn FnOnce<(u32,), Output = u32> + '1), *mut some_fn>(move _1)
+    _0 = {impl FnOnce<(u32,)> for some_fn}::call_once(move (*_3), move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -197,7 +197,7 @@ fn {impl FnOnce<(u32,)> for some_fn}::{vtable}() -> core::ops::function::FnOnce:
     let size: usize; // local
     let align: usize; // local
     let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(u32,), Output = u32> + '1)); // anonymous local
-    let _4: extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32; // anonymous local
+    let _4: extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32; // anonymous local
     let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
 
     storage_live(ret)
@@ -208,7 +208,7 @@ fn {impl FnOnce<(u32,)> for some_fn}::{vtable}() -> core::ops::function::FnOnce:
     storage_live(_3)
     _3 = cast<for<'_0_1> {impl FnOnce<(u32,)> for some_fn}::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(u32,), Output = u32> + '1))>(const {impl FnOnce<(u32,)> for some_fn}::{vtable_drop_shim}<'0>)
     storage_live(_4)
-    _4 = cast<{impl FnOnce<(u32,)> for some_fn}::{vtable_method}, extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32>(const {impl FnOnce<(u32,)> for some_fn}::{vtable_method})
+    _4 = cast<{impl FnOnce<(u32,)> for some_fn}::{vtable_method}, extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32>(const {impl FnOnce<(u32,)> for some_fn}::{vtable_method})
     storage_live(_5)
     _5 = &core::marker::MetaSized::{vtable}<some_fn>
     ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: move _5 }
@@ -509,17 +509,17 @@ fn impl_FnOnce_tuple_for_closure::call_once(_1: {closure}, _2: (u32,)) -> u32
 }
 
 // Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::{vtable_method}
-extern "rust-call" fn impl_FnOnce_tuple_for_closure::{vtable_method}(_1: (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
+extern "rust-call" fn impl_FnOnce_tuple_for_closure::{vtable_method}(_1: *mut (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
 {
     let _0: u32; // return
-    let _1: (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
+    let _1: *mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
     let _2: (u32,); // arg #2
-    let _3: {closure}; // anonymous local
+    let _3: *mut {closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
-    _3 = concretize<(dyn FnOnce<(u32,), Output = u32> + '1), {closure}>(move _1)
-    _0 = impl_FnOnce_tuple_for_closure::call_once(move _3, move _2)
+    _3 = concretize<*mut (dyn FnOnce<(u32,), Output = u32> + '1), *mut {closure}>(move _1)
+    _0 = impl_FnOnce_tuple_for_closure::call_once(move (*_3), move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -557,7 +557,7 @@ fn impl_FnOnce_tuple_for_closure::{vtable}() -> core::ops::function::FnOnce::{vt
     let size: usize; // local
     let align: usize; // local
     let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(u32,), Output = u32> + '1)); // anonymous local
-    let _4: extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32; // anonymous local
+    let _4: extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32; // anonymous local
     let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
 
     storage_live(ret)
@@ -568,7 +568,7 @@ fn impl_FnOnce_tuple_for_closure::{vtable}() -> core::ops::function::FnOnce::{vt
     storage_live(_3)
     _3 = cast<for<'_0_1> impl_FnOnce_tuple_for_closure::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(u32,), Output = u32> + '1))>(const impl_FnOnce_tuple_for_closure::{vtable_drop_shim}<'0>)
     storage_live(_4)
-    _4 = cast<impl_FnOnce_tuple_for_closure::{vtable_method}, extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32>(const impl_FnOnce_tuple_for_closure::{vtable_method})
+    _4 = cast<impl_FnOnce_tuple_for_closure::{vtable_method}, extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32>(const impl_FnOnce_tuple_for_closure::{vtable_method})
     storage_live(_5)
     _5 = &core::marker::MetaSized::{vtable}<{closure}>
     ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: move _5 }

--- a/charon/tests/ui/dyn/builtin-vtables.out
+++ b/charon/tests/ui/dyn/builtin-vtables.out
@@ -421,6 +421,358 @@ impl Fn<(u32,)> for some_fn {
     vtable: {impl Fn<(u32,)> for some_fn}::{vtable}
 }
 
+// Full name: test_crate::generic_fn
+fn generic_fn<T>(x: T) -> T
+where
+    TraitClause0: (T: Sized),
+{
+    let _0: T; // return
+    let x: T; // arg #1
+
+    storage_live(_0)
+    _0 = move x
+    conditional_drop[{built_in impl Destruct for T}::drop_glue<'0>] x
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    storage_dead(x)
+    return
+}
+
+// Full name: test_crate::{impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::call_once
+fn {impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::call_once<T>(state: generic_fn<T>[TraitClause0], args: (T,)) -> T
+where
+    TraitClause0: (T: Sized),
+{
+    let _0: T; // return
+    let state: generic_fn<T>[TraitClause0]; // arg #1
+    let args: (T,); // arg #2
+
+    storage_live(_0)
+    _0 = generic_fn<T>[TraitClause0](move args._0)
+    ↳⚡ storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::{impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_method}
+extern "rust-call" fn {impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_method}<T>(_1: *mut (dyn FnOnce<(T,), Output = T>), _2: (T,)) -> T
+where
+    TraitClause0: (T: Sized),
+{
+    let _0: T; // return
+    let _1: *mut (dyn FnOnce<(T,), Output = T> + '0); // arg #1
+    let _2: (T,); // arg #2
+    let _3: *mut generic_fn<T>[TraitClause0]; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<*mut (dyn FnOnce<(T,), Output = T> + '1), *mut generic_fn<T>[TraitClause0]>(move _1)
+    _0 = {impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::call_once<T>[TraitClause0](move (*_3), move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_drop_shim}
+unsafe fn {impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_drop_shim}<'_0, T>(dyn_self: &'_0 mut (dyn FnOnce<(T,), Output = T>))
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: '_0,
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnOnce<(T,), Output = T> + '0); // arg #1
+    let target_self: &'_0 mut generic_fn<T>[TraitClause0]; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnOnce<(T,), Output = T> + '1), &'_0 mut generic_fn<T>[TraitClause0]>(move dyn_self)
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}
+fn {impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}<T>() -> core::ops::function::FnOnce::{vtable}<(T,), T>
+where
+    TraitClause0: (T: Sized),
+{
+    let ret: core::ops::function::FnOnce::{vtable}<(T,), T>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(T,), Output = T> + '1)); // anonymous local
+    let _4: extern "rust-call" fn(*mut (dyn FnOnce<(T,), Output = T> + '2), (T,)) -> T; // anonymous local
+    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<generic_fn<T>[TraitClause0]>
+    storage_live(align)
+    align = align_of<generic_fn<T>[TraitClause0]>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_drop_shim}<'0, T>[TraitClause0], unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(T,), Output = T> + '1))>(const {impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_drop_shim}<'0, T>[TraitClause0])
+    storage_live(_4)
+    _4 = cast<{impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_method}<T>[TraitClause0], extern "rust-call" fn(*mut (dyn FnOnce<(T,), Output = T> + '2), (T,)) -> T>(const {impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_method}<T>[TraitClause0])
+    storage_live(_5)
+    _5 = &core::marker::MetaSized::{vtable}<generic_fn<T>[TraitClause0]>
+    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: move _5 }
+    return
+}
+
+// Full name: test_crate::{impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}
+static {impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}<T>: core::ops::function::FnOnce::{vtable}<(T,), T>
+where
+    TraitClause0: (T: Sized),
+ = {impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}<T>[TraitClause0]()
+
+// Full name: test_crate::{impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::call_mut
+fn {impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::call_mut<'_0, T>(state: &'_0 mut generic_fn<T>[TraitClause0], args: (T,)) -> T
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: '_0,
+{
+    let _0: T; // return
+    let state: &'_0 mut generic_fn<T>[TraitClause0]; // arg #1
+    let args: (T,); // arg #2
+
+    storage_live(_0)
+    _0 = generic_fn<T>[TraitClause0](move args._0)
+    ↳⚡ storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::{impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_method}
+extern "rust-call" fn {impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_method}<'_0, T>(_1: &'_0 mut (dyn FnMut<(T,), ImpliedClause1::Output = T>), _2: (T,)) -> T
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: '_0,
+{
+    let _0: T; // return
+    let _1: &'_0 mut (dyn FnMut<(T,), ImpliedClause1::Output = T> + '0); // arg #1
+    let _2: (T,); // arg #2
+    let _3: &'_0 mut generic_fn<T>[TraitClause0]; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_0 mut (dyn FnMut<(T,), ImpliedClause1::Output = T> + '1), &'_0 mut generic_fn<T>[TraitClause0]>(move _1)
+    _0 = {impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::call_mut<'_0, T>[TraitClause0](move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_drop_shim}
+unsafe fn {impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_drop_shim}<'_0, T>(dyn_self: &'_0 mut (dyn FnMut<(T,), ImpliedClause1::Output = T>))
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: '_0,
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnMut<(T,), ImpliedClause1::Output = T> + '0); // arg #1
+    let target_self: &'_0 mut generic_fn<T>[TraitClause0]; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnMut<(T,), ImpliedClause1::Output = T> + '1), &'_0 mut generic_fn<T>[TraitClause0]>(move dyn_self)
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}
+fn {impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}<T>() -> core::ops::function::FnMut::{vtable}<(T,), T>
+where
+    TraitClause0: (T: Sized),
+{
+    let ret: core::ops::function::FnMut::{vtable}<(T,), T>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<(T,), ImpliedClause1::Output = T> + '1)); // anonymous local
+    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(T,), ImpliedClause1::Output = T> + '3), (T,)) -> T; // anonymous local
+    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _6: &'static core::ops::function::FnOnce::{vtable}<(T,), T>; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<generic_fn<T>[TraitClause0]>
+    storage_live(align)
+    align = align_of<generic_fn<T>[TraitClause0]>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_drop_shim}<'0, T>[TraitClause0], unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<(T,), ImpliedClause1::Output = T> + '1))>(const {impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_drop_shim}<'0, T>[TraitClause0])
+    storage_live(_4)
+    _4 = cast<for<'_0_1> {impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_method}<'2, T>[TraitClause0], extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(T,), ImpliedClause1::Output = T> + '3), (T,)) -> T>(const {impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_method}<'2, T>[TraitClause0])
+    storage_live(_5)
+    _5 = &core::marker::MetaSized::{vtable}<generic_fn<T>[TraitClause0]>
+    storage_live(_6)
+    _6 = &{impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}<T>[TraitClause0]
+    ret = core::ops::function::FnMut::{vtable} { size: move size, align: move align, drop: move _3, method_call_mut: move _4, super_trait_0: move _5, super_trait_1: move _6 }
+    return
+}
+
+// Full name: test_crate::{impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}
+static {impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}<T>: core::ops::function::FnMut::{vtable}<(T,), T>
+where
+    TraitClause0: (T: Sized),
+ = {impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}<T>[TraitClause0]()
+
+// Full name: test_crate::{impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::call
+fn {impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::call<'_0, T>(state: &'_0 generic_fn<T>[TraitClause0], args: (T,)) -> T
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: '_0,
+{
+    let _0: T; // return
+    let state: &'_0 generic_fn<T>[TraitClause0]; // arg #1
+    let args: (T,); // arg #2
+
+    storage_live(_0)
+    _0 = generic_fn<T>[TraitClause0](move args._0)
+    ↳⚡ storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::{impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_method}
+extern "rust-call" fn {impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_method}<'_0, T>(_1: &'_0 (dyn Fn<(T,), ImpliedClause1::ImpliedClause1::Output = T>), _2: (T,)) -> T
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: '_0,
+{
+    let _0: T; // return
+    let _1: &'_0 (dyn Fn<(T,), ImpliedClause1::ImpliedClause1::Output = T> + '0); // arg #1
+    let _2: (T,); // arg #2
+    let _3: &'_0 generic_fn<T>[TraitClause0]; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_0 (dyn Fn<(T,), ImpliedClause1::ImpliedClause1::Output = T> + '1), &'_0 generic_fn<T>[TraitClause0]>(move _1)
+    _0 = {impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::call<'_0, T>[TraitClause0](move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_drop_shim}
+unsafe fn {impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_drop_shim}<'_0, T>(dyn_self: &'_0 mut (dyn Fn<(T,), ImpliedClause1::ImpliedClause1::Output = T>))
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: '_0,
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Fn<(T,), ImpliedClause1::ImpliedClause1::Output = T> + '0); // arg #1
+    let target_self: &'_0 mut generic_fn<T>[TraitClause0]; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Fn<(T,), ImpliedClause1::ImpliedClause1::Output = T> + '1), &'_0 mut generic_fn<T>[TraitClause0]>(move dyn_self)
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}
+fn {impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}<T>() -> core::ops::function::Fn::{vtable}<(T,), T>
+where
+    TraitClause0: (T: Sized),
+{
+    let ret: core::ops::function::Fn::{vtable}<(T,), T>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(T,), ImpliedClause1::ImpliedClause1::Output = T> + '1)); // anonymous local
+    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(T,), ImpliedClause1::ImpliedClause1::Output = T> + '3), (T,)) -> T; // anonymous local
+    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _6: &'static core::ops::function::FnMut::{vtable}<(T,), T>; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<generic_fn<T>[TraitClause0]>
+    storage_live(align)
+    align = align_of<generic_fn<T>[TraitClause0]>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_drop_shim}<'0, T>[TraitClause0], unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(T,), ImpliedClause1::ImpliedClause1::Output = T> + '1))>(const {impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_drop_shim}<'0, T>[TraitClause0])
+    storage_live(_4)
+    _4 = cast<for<'_0_1> {impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_method}<'2, T>[TraitClause0], extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(T,), ImpliedClause1::ImpliedClause1::Output = T> + '3), (T,)) -> T>(const {impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::{vtable_method}<'2, T>[TraitClause0])
+    storage_live(_5)
+    _5 = &core::marker::MetaSized::{vtable}<generic_fn<T>[TraitClause0]>
+    storage_live(_6)
+    _6 = &{impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}<T>[TraitClause0]
+    ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move _3, method_call: move _4, super_trait_0: move _5, super_trait_1: move _6 }
+    return
+}
+
+// Full name: test_crate::{impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}
+static {impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}<T>: core::ops::function::Fn::{vtable}<(T,), T>
+where
+    TraitClause0: (T: Sized),
+ = {impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}<T>[TraitClause0]()
+
+// Full name: test_crate::{impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}
+impl<T> FnOnce<(T,)> for generic_fn<T>[TraitClause0]
+where
+    TraitClause0: (T: Sized),
+{
+    proof ImpliedClause0: (generic_fn<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for generic_fn<T>[TraitClause0]}
+    proof ImpliedClause1: ((T,): Sized) = {built_in impl Sized for (T,)}
+    proof ImpliedClause2: ((T,): Tuple) = {built_in impl Tuple for (T,)}
+    proof ImpliedClause3: (T: Sized) = TraitClause0
+    type Output = T
+    fn call_once = {impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::call_once<T>[TraitClause0]
+    vtable: {impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}<T>[TraitClause0]
+}
+
+// Full name: test_crate::{impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}
+impl<T> FnMut<(T,)> for generic_fn<T>[TraitClause0]
+where
+    TraitClause0: (T: Sized),
+{
+    proof ImpliedClause0: (generic_fn<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for generic_fn<T>[TraitClause0]}
+    proof ImpliedClause1: (generic_fn<T>[TraitClause0]: FnOnce<(T,)>) = {impl FnOnce<(T,)> for generic_fn<T>[TraitClause0]}<T>[TraitClause0]
+    proof ImpliedClause2: ((T,): Sized) = {built_in impl Sized for (T,)}
+    proof ImpliedClause3: ((T,): Tuple) = {built_in impl Tuple for (T,)}
+    fn call_mut<'_0_1> = {impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::call_mut<'_0_1, T>[TraitClause0]
+    vtable: {impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}<T>[TraitClause0]
+}
+
+// Full name: test_crate::{impl Fn<(T,)> for generic_fn<T>[TraitClause0]}
+impl<T> Fn<(T,)> for generic_fn<T>[TraitClause0]
+where
+    TraitClause0: (T: Sized),
+{
+    proof ImpliedClause0: (generic_fn<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for generic_fn<T>[TraitClause0]}
+    proof ImpliedClause1: (generic_fn<T>[TraitClause0]: FnMut<(T,)>) = {impl FnMut<(T,)> for generic_fn<T>[TraitClause0]}<T>[TraitClause0]
+    proof ImpliedClause2: ((T,): Sized) = {built_in impl Sized for (T,)}
+    proof ImpliedClause3: ((T,): Tuple) = {built_in impl Tuple for (T,)}
+    fn call<'_0_1> = {impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::call<'_0_1, T>[TraitClause0]
+    vtable: {impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}<T>[TraitClause0]
+}
+
 // Full name: test_crate::main::{closure}
 struct {closure} {}
 
@@ -767,44 +1119,54 @@ fn main()
     let _6: &'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9); // anonymous local
     let _7: &'11 {closure}; // anonymous local
     let _8: &'12 {closure}; // anonymous local
-    let _9: &'13 {closure}; // anonymous local
-    let _10: &'14 some_fn; // anonymous local
-    let _11: &'15 some_fn; // anonymous local
-    let _12: &'20 {closure}; // anonymous local
-    let _13: &'25 some_fn; // anonymous local
-    let _14: some_fn; // anonymous local
-    let _15: &'26 {closure}; // anonymous local
-    let _16: {closure}; // anonymous local
+    let _9: (); // anonymous local
+    let _10: &'13 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '14); // anonymous local
+    let _11: &'16 generic_fn<u32>[{built_in impl Sized for u32}]; // anonymous local
+    let _12: &'17 generic_fn<u32>[{built_in impl Sized for u32}]; // anonymous local
+    let _13: &'18 generic_fn<u32>[{built_in impl Sized for u32}]; // anonymous local
+    let _14: &'19 {closure}; // anonymous local
+    let _15: &'20 some_fn; // anonymous local
+    let _16: &'21 some_fn; // anonymous local
+    let _17: &'26 {closure}; // anonymous local
+    let _18: &'31 generic_fn<u32>[{built_in impl Sized for u32}]; // anonymous local
+    let _19: &'36 some_fn; // anonymous local
+    let _20: some_fn; // anonymous local
+    let _21: &'37 {closure}; // anonymous local
+    let _22: {closure}; // anonymous local
+    let _23: &'38 generic_fn<u32>[{built_in impl Sized for u32}]; // anonymous local
+    let _24: generic_fn<u32>[{built_in impl Sized for u32}]; // anonymous local
 
-    storage_live(_11)
+    storage_live(_16)
+    storage_live(_19)
+    storage_live(_20)
+    _20 = const some_fn
+    _19 = &_20
+    _16 = move _19
+    storage_live(_0)
     storage_live(_13)
     storage_live(_14)
-    _14 = const some_fn
-    _13 = &_14
-    _11 = move _13
-    storage_live(_0)
-    storage_live(_9)
-    storage_live(_10)
+    storage_live(_15)
     _0 = ()
     storage_live(_1)
     storage_live(_2)
     storage_live(_3)
     storage_live(_4)
-    _10 = move _11
-    _4 = &(*_10)
+    _15 = move _16
+    _4 = &(*_15)
     _3 = &(*_4)
-    _2 = unsize_cast<&'6 some_fn, &'16 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '17), &{impl Fn<(u32,)> for some_fn}::{vtable}>(move _3)
+    _2 = unsize_cast<&'6 some_fn, &'22 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '23), &{impl Fn<(u32,)> for some_fn}::{vtable}>(move _3)
     storage_dead(_3)
-    _1 = takes_fn<'19>(move _2)
-    ↳⚡ storage_dead(_10)
-        storage_dead(_9)
+    _1 = takes_fn<'25>(move _2)
+    ↳⚡ storage_dead(_15)
+        storage_dead(_14)
+        storage_dead(_13)
         unwind_continue
-    storage_live(_12)
-    storage_live(_15)
-    storage_live(_16)
-    _16 = {closure} {  }
-    _15 = &_16
-    _12 = move _15
+    storage_live(_17)
+    storage_live(_21)
+    storage_live(_22)
+    _22 = {closure} {  }
+    _21 = &_22
+    _17 = move _21
     storage_dead(_2)
     storage_dead(_4)
     storage_dead(_1)
@@ -812,27 +1174,56 @@ fn main()
     storage_live(_6)
     storage_live(_7)
     storage_live(_8)
-    _9 = move _12
-    _8 = &(*_9)
+    _14 = move _17
+    _8 = &(*_14)
     _7 = &(*_8)
-    _6 = unsize_cast<&'11 {closure}, &'21 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '22), &impl_Fn_tuple_for_closure::{vtable}>(move _7)
+    _6 = unsize_cast<&'11 {closure}, &'27 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '28), &impl_Fn_tuple_for_closure::{vtable}>(move _7)
     storage_dead(_7)
-    _5 = takes_fn<'24>(move _6)
-    ↳⚡ storage_dead(_10)
-        storage_dead(_9)
+    _5 = takes_fn<'30>(move _6)
+    ↳⚡ storage_dead(_15)
+        storage_dead(_14)
+        storage_dead(_13)
         unwind_continue
+    storage_live(_18)
+    storage_live(_23)
+    storage_live(_24)
+    // The `Fn*` impls of an instantiated generic fn item.
+    _24 = const generic_fn<u32>[{built_in impl Sized for u32}]
+    _23 = &_24
+    _18 = move _23
     storage_dead(_6)
     storage_dead(_8)
     storage_dead(_5)
-    _0 = ()
+    storage_live(_9)
+    storage_live(_10)
+    storage_live(_11)
+    storage_live(_12)
+    _13 = move _18
+    _12 = &(*_13)
+    _11 = &(*_12)
+    _10 = unsize_cast<&'16 generic_fn<u32>[{built_in impl Sized for u32}], &'32 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '33), &{impl Fn<(T,)> for generic_fn<T>[TraitClause0]}::{vtable}<u32>[{built_in impl Sized for u32}]>(move _11)
+    storage_dead(_11)
+    _9 = takes_fn<'35>(move _10)
+    ↳⚡ storage_dead(_15)
+        storage_dead(_14)
+        storage_dead(_13)
+        unwind_continue
     storage_dead(_10)
+    storage_dead(_12)
     storage_dead(_9)
-    storage_dead(_16)
+    _0 = ()
     storage_dead(_15)
     storage_dead(_14)
     storage_dead(_13)
-    storage_dead(_12)
-    storage_dead(_11)
+    storage_dead(_24)
+    storage_dead(_23)
+    storage_dead(_22)
+    storage_dead(_21)
+    storage_dead(_20)
+    storage_dead(_19)
+    storage_dead(_18)
+    storage_dead(_17)
+    storage_dead(_16)
     return
 }
 

--- a/charon/tests/ui/dyn/builtin-vtables.rs
+++ b/charon/tests/ui/dyn/builtin-vtables.rs
@@ -5,7 +5,13 @@ fn some_fn(x: u32) -> u32 {
     x
 }
 
+fn generic_fn<T>(x: T) -> T {
+    x
+}
+
 fn main() {
     takes_fn(&some_fn);
     takes_fn(&|_| 42);
+    // The `Fn*` impls of an instantiated generic fn item.
+    takes_fn(&generic_fn::<u32>);
 }

--- a/charon/tests/ui/dyn/by-value-self-vtable.out
+++ b/charon/tests/ui/dyn/by-value-self-vtable.out
@@ -102,7 +102,7 @@ impl "impl_Destruct_for_S" Destruct for S {
 }
 
 // Full name: test_crate::{impl Consume for S}::read
-fn read<'_0>(self: &'_0 S) -> u32
+fn impl_Consume_for_S::read<'_0>(self: &'_0 S) -> u32
 {
     let _0: u32; // return
     let self: &'1 S; // arg #1
@@ -114,7 +114,7 @@ fn read<'_0>(self: &'_0 S) -> u32
 }
 
 // Full name: test_crate::{impl Consume for S}::consume
-fn consume(self: S) -> u32
+fn impl_Consume_for_S::consume(self: S) -> u32
 {
     let _0: u32; // return
     let self: S; // arg #1
@@ -135,7 +135,7 @@ fn impl_Consume_for_S::read::{vtable_method}<'_0>(_1: &'_0 (dyn Consume)) -> u32
     storage_live(_0)
     storage_live(_2)
     _2 = concretize<&'_0 (dyn Consume + '1), &'_0 S>(move _1)
-    _0 = read<'_0>(move _2)
+    _0 = impl_Consume_for_S::read<'_0>(move _2)
     ↳⚡ storage_dead(_2)
         storage_dead(_1)
         unwind_continue
@@ -154,7 +154,7 @@ fn impl_Consume_for_S::consume::{vtable_method}(_1: *mut (dyn Consume)) -> u32
     storage_live(_0)
     storage_live(_2)
     _2 = concretize<*mut (dyn Consume + '1), *mut S>(move _1)
-    _0 = consume(move (*_2))
+    _0 = impl_Consume_for_S::consume(move (*_2))
     ↳⚡ storage_dead(_2)
         storage_dead(_1)
         unwind_continue
@@ -164,7 +164,7 @@ fn impl_Consume_for_S::consume::{vtable_method}(_1: *mut (dyn Consume)) -> u32
 }
 
 // Full name: test_crate::{impl Consume for S}::{vtable_drop_shim}
-unsafe fn {vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Consume))
+unsafe fn impl_Consume_for_S::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Consume))
 {
     let ret: (); // return
     let dyn_self: &'_0 mut (dyn Consume + '0); // arg #1
@@ -200,7 +200,7 @@ fn impl_Consume_for_S::{vtable}() -> test_crate::Consume::{vtable}
     storage_live(align)
     align = align_of<S>
     storage_live(_3)
-    _3 = cast<for<'_0_1> {vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Consume + '1))>(const {vtable_drop_shim}<'0>)
+    _3 = cast<for<'_0_1> impl_Consume_for_S::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Consume + '1))>(const impl_Consume_for_S::{vtable_drop_shim}<'0>)
     storage_live(_4)
     _4 = cast<impl_Consume_for_S::consume::{vtable_method}, fn(*mut (dyn Consume + '2)) -> u32>(const impl_Consume_for_S::consume::{vtable_method})
     storage_live(_5)
@@ -217,9 +217,126 @@ static impl_Consume_for_S::{vtable}: test_crate::Consume::{vtable} = impl_Consum
 // Full name: test_crate::{impl Consume for S}
 impl "impl_Consume_for_S" Consume for S {
     proof ImpliedClause0: (S: MetaSized) = {built_in impl MetaSized for S}
-    fn consume = consume
-    fn read<'_0_1> = read<'_0_1>
+    fn consume = impl_Consume_for_S::consume
+    fn read<'_0_1> = impl_Consume_for_S::read<'_0_1>
     vtable: impl_Consume_for_S::{vtable}
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::read
+fn {impl Consume for *mut u32}::read<'_0>(self: &'_0 *mut u32) -> u32
+{
+    let _0: u32; // return
+    let self: &'1 *mut u32; // arg #1
+
+    storage_live(_0)
+    _0 = copy (*(*self))
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::consume
+fn {impl Consume for *mut u32}::consume(self: *mut u32) -> u32
+{
+    let _0: u32; // return
+    let self: *mut u32; // arg #1
+
+    storage_live(_0)
+    _0 = copy (*self)
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::read::{vtable_method}
+fn {impl Consume for *mut u32}::read::{vtable_method}<'_0>(_1: &'_0 (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_0 (dyn Consume + '0); // arg #1
+    let _2: &'_0 *mut u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<&'_0 (dyn Consume + '1), &'_0 *mut u32>(move _1)
+    _0 = {impl Consume for *mut u32}::read<'_0>(move _2)
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::consume::{vtable_method}
+fn {impl Consume for *mut u32}::consume::{vtable_method}(_1: *mut (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: *mut (dyn Consume + '0); // arg #1
+    let _2: *mut *mut u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<*mut (dyn Consume + '1), *mut *mut u32>(move _1)
+    _0 = {impl Consume for *mut u32}::consume(move (*_2))
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::{vtable_drop_shim}
+unsafe fn {impl Consume for *mut u32}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Consume))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Consume + '0); // arg #1
+    let target_self: &'_0 mut *mut u32; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Consume + '1), &'_0 mut *mut u32>(move dyn_self)
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::{vtable}
+fn {impl Consume for *mut u32}::{vtable}() -> test_crate::Consume::{vtable}
+{
+    let ret: test_crate::Consume::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Consume + '1)); // anonymous local
+    let _4: fn(*mut (dyn Consume + '2)) -> u32; // anonymous local
+    let _5: fn<'_0_1>(&'_0_1 (dyn Consume + '4)) -> u32; // anonymous local
+    let _6: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<*mut u32>
+    storage_live(align)
+    align = align_of<*mut u32>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {impl Consume for *mut u32}::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Consume + '1))>(const {impl Consume for *mut u32}::{vtable_drop_shim}<'0>)
+    storage_live(_4)
+    _4 = cast<{impl Consume for *mut u32}::consume::{vtable_method}, fn(*mut (dyn Consume + '2)) -> u32>(const {impl Consume for *mut u32}::consume::{vtable_method})
+    storage_live(_5)
+    _5 = cast<for<'_0_1> {impl Consume for *mut u32}::read::{vtable_method}<'3>, fn<'_0_1>(&'_0_1 (dyn Consume + '4)) -> u32>(const {impl Consume for *mut u32}::read::{vtable_method}<'3>)
+    storage_live(_6)
+    _6 = &core::marker::MetaSized::{vtable}<*mut u32>
+    ret = test_crate::Consume::{vtable} { size: move size, align: move align, drop: move _3, method_consume: move _4, method_read: move _5, super_trait_0: move _6 }
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::{vtable}
+static {impl Consume for *mut u32}::{vtable}: test_crate::Consume::{vtable} = {impl Consume for *mut u32}::{vtable}()
+
+// Full name: test_crate::{impl Consume for *mut u32}
+impl Consume for *mut u32 {
+    proof ImpliedClause0: (*mut u32: MetaSized) = {built_in impl MetaSized for *mut u32}
+    fn consume = {impl Consume for *mut u32}::consume
+    fn read<'_0_1> = {impl Consume for *mut u32}::read<'_0_1>
+    vtable: {impl Consume for *mut u32}::{vtable}
 }
 
 // Full name: test_crate::mk
@@ -249,13 +366,51 @@ fn mk() -> Box<(dyn Consume + 'static)>[{built_in impl MetaSized for (dyn Consum
     return
 }
 
+// Full name: test_crate::mk_ptr
+fn mk_ptr(x: *mut u32) -> Box<(dyn Consume + 'static)>[{built_in impl MetaSized for (dyn Consume + 'static)}, {built_in impl Sized for Global}]
+{
+    let _0: Box<(dyn Consume + '6)>[{built_in impl MetaSized for (dyn Consume + '8)}, {built_in impl Sized for Global}]; // return
+    let x: *mut u32; // arg #1
+    let _2: Box<(dyn Consume + '9)>[{built_in impl MetaSized for (dyn Consume + '11)}, {built_in impl Sized for Global}]; // anonymous local
+    let _3: Box<*mut u32>[{built_in impl MetaSized for *mut u32}, {built_in impl Sized for Global}]; // anonymous local
+    let _4: *mut u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    storage_live(_3)
+    storage_live(_4)
+    _4 = copy x
+    _3 = new<*mut u32>[{built_in impl Sized for *mut u32}](move _4)
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    _2 = unsize_cast<Box<*mut u32>[{built_in impl MetaSized for *mut u32}, {built_in impl Sized for Global}], Box<(dyn Consume + '12)>[{built_in impl MetaSized for (dyn Consume + '14)}, {built_in impl Sized for Global}], &{impl Consume for *mut u32}::{vtable}>(move _3)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'15, *mut u32, Global>[{built_in impl MetaSized for *mut u32}, {built_in impl Sized for Global}]] _3
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    storage_dead(_4)
+    storage_dead(_3)
+    _0 = unsize_cast<Box<(dyn Consume + '9)>[{built_in impl MetaSized for (dyn Consume + '11)}, {built_in impl Sized for Global}], Box<(dyn Consume + '16)>[{built_in impl MetaSized for (dyn Consume + '18)}, {built_in impl Sized for Global}],  at []>(move _2)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'33, (dyn Consume + '28), Global>[{built_in impl MetaSized for (dyn Consume + '28)}, {built_in impl Sized for Global}]] _2
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(x)
+    return
+}
+
 // Full name: test_crate::main
 fn main()
 {
     let _0: (); // return
     let x: Box<(dyn Consume + '6)>[{built_in impl MetaSized for (dyn Consume + '8)}, {built_in impl Sized for Global}]; // local
-    let _v: u32; // local
+    let _v_2: u32; // local
     let _3: &'11 (dyn Consume + '12); // anonymous local
+    let n: u32; // local
+    let p: Box<(dyn Consume + '13)>[{built_in impl MetaSized for (dyn Consume + '15)}, {built_in impl Sized for Global}]; // local
+    let _6: *mut u32; // anonymous local
+    let _7: &'17 mut u32; // anonymous local
+    let _v_8: u32; // local
+    let _9: &'18 (dyn Consume + '19); // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -263,18 +418,51 @@ fn main()
     x = mk()
     ↳⚡ unwind_continue
     fake_read(x)
-    storage_live(_v)
+    storage_live(_v_2)
     storage_live(_3)
     _3 = &(*x) with_metadata(copy x.metadata)
-    _v = (copy (*_3.metadata).method_read)(move _3)
-    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'31, (dyn Consume + '26), Global>[{built_in impl MetaSized for (dyn Consume + '26)}, {built_in impl Sized for Global}]] x
+    _v_2 = (copy (*_3.metadata).method_read)(move _3)
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'38, (dyn Consume + '33), Global>[{built_in impl MetaSized for (dyn Consume + '33)}, {built_in impl Sized for Global}]] x
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_3)
-    fake_read(_v)
+    fake_read(_v_2)
+    storage_live(n)
+    n = const 5u32
+    fake_read(n)
+    storage_live(p)
+    storage_live(_6)
+    storage_live(_7)
+    _7 = &mut n
+    _6 = &raw mut (*_7)
+    p = mk_ptr(move _6)
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'38, (dyn Consume + '33), Global>[{built_in impl MetaSized for (dyn Consume + '33)}, {built_in impl Sized for Global}]] x
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_6)
+    fake_read(p)
+    storage_dead(_7)
+    storage_live(_v_8)
+    storage_live(_9)
+    _9 = &(*p) with_metadata(copy p.metadata)
+    _v_8 = (copy (*_9.metadata).method_read)(move _9)
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'57, (dyn Consume + '52), Global>[{built_in impl MetaSized for (dyn Consume + '52)}, {built_in impl Sized for Global}]] p
+        ↳⚡ unwind_terminate
+        conditional_drop[impl_Destruct_for_Box::drop_glue<'38, (dyn Consume + '33), Global>[{built_in impl MetaSized for (dyn Consume + '33)}, {built_in impl Sized for Global}]] x
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_9)
+    fake_read(_v_8)
     _0 = ()
-    storage_dead(_v)
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'46, (dyn Consume + '41), Global>[{built_in impl MetaSized for (dyn Consume + '41)}, {built_in impl Sized for Global}]] x
+    storage_dead(_v_8)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'72, (dyn Consume + '67), Global>[{built_in impl MetaSized for (dyn Consume + '67)}, {built_in impl Sized for Global}]] p
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'38, (dyn Consume + '33), Global>[{built_in impl MetaSized for (dyn Consume + '33)}, {built_in impl Sized for Global}]] x
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(p)
+    storage_dead(n)
+    storage_dead(_v_2)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'87, (dyn Consume + '82), Global>[{built_in impl MetaSized for (dyn Consume + '82)}, {built_in impl Sized for Global}]] x
     ↳⚡ unwind_continue
     storage_dead(x)
     return

--- a/charon/tests/ui/dyn/by-value-self-vtable.out
+++ b/charon/tests/ui/dyn/by-value-self-vtable.out
@@ -1,0 +1,284 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+fn core::marker::MetaSized::{vtable}<Self>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}<Self>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}<Self>()
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+// Full name: alloc::alloc::Global
+#[lang_item(GlobalAlloc)]
+pub struct Global {}
+
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TypeOutlives0: T: '_0,
+    TypeOutlives1: A: '_0,
+= <opaque>
+
+// Full name: alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
+#[track_caller]
+#[diagnostic_item("box_new")]
+pub fn new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+where
+    TraitClause0: (T: Sized),
+= <opaque>
+
+struct test_crate::Consume::{vtable} {
+  size: usize,
+  align: usize,
+  drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn Consume)),
+  method_consume: fn(*mut (dyn Consume)) -> u32,
+  method_read: fn<'_0_1>(&'_0_1 (dyn Consume)) -> u32,
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+// Full name: test_crate::Consume
+trait Consume<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    fn consume;
+    fn read<'_0_1>;
+    vtable: test_crate::Consume::{vtable}
+}
+
+// Full name: test_crate::S
+struct S {
+  _0: u32,
+}
+
+// Full name: test_crate::S::{impl Destruct for S}::drop_glue
+unsafe fn impl_Destruct_for_S::drop_glue<'_0>(_1: &'_0 mut S)
+{
+    let _0: (); // return
+    let _1: &'1 mut S; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::S::{impl Destruct for S}
+impl "impl_Destruct_for_S" Destruct for S {
+    fn drop_glue<'_0_1> = impl_Destruct_for_S::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl Consume for S}::read
+fn read<'_0>(self: &'_0 S) -> u32
+{
+    let _0: u32; // return
+    let self: &'1 S; // arg #1
+
+    storage_live(_0)
+    _0 = copy (*self)._0
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::consume
+fn consume(self: S) -> u32
+{
+    let _0: u32; // return
+    let self: S; // arg #1
+
+    storage_live(_0)
+    _0 = copy self._0
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::read::{vtable_method}
+fn impl_Consume_for_S::read::{vtable_method}<'_0>(_1: &'_0 (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_0 (dyn Consume + '0); // arg #1
+    let _2: &'_0 S; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<&'_0 (dyn Consume + '1), &'_0 S>(move _1)
+    _0 = read<'_0>(move _2)
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::consume::{vtable_method}
+fn impl_Consume_for_S::consume::{vtable_method}(_1: *mut (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: *mut (dyn Consume + '0); // arg #1
+    let _2: *mut S; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<*mut (dyn Consume + '1), *mut S>(move _1)
+    _0 = consume(move (*_2))
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::{vtable_drop_shim}
+unsafe fn {vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Consume))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Consume + '0); // arg #1
+    let target_self: &'_0 mut S; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Consume + '1), &'_0 mut S>(move dyn_self)
+    drop[impl_Destruct_for_S::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::{vtable}
+fn impl_Consume_for_S::{vtable}() -> test_crate::Consume::{vtable}
+{
+    let ret: test_crate::Consume::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Consume + '1)); // anonymous local
+    let _4: fn(*mut (dyn Consume + '2)) -> u32; // anonymous local
+    let _5: fn<'_0_1>(&'_0_1 (dyn Consume + '4)) -> u32; // anonymous local
+    let _6: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<S>
+    storage_live(align)
+    align = align_of<S>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Consume + '1))>(const {vtable_drop_shim}<'0>)
+    storage_live(_4)
+    _4 = cast<impl_Consume_for_S::consume::{vtable_method}, fn(*mut (dyn Consume + '2)) -> u32>(const impl_Consume_for_S::consume::{vtable_method})
+    storage_live(_5)
+    _5 = cast<for<'_0_1> impl_Consume_for_S::read::{vtable_method}<'3>, fn<'_0_1>(&'_0_1 (dyn Consume + '4)) -> u32>(const impl_Consume_for_S::read::{vtable_method}<'3>)
+    storage_live(_6)
+    _6 = &core::marker::MetaSized::{vtable}<S>
+    ret = test_crate::Consume::{vtable} { size: move size, align: move align, drop: move _3, method_consume: move _4, method_read: move _5, super_trait_0: move _6 }
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::{vtable}
+static impl_Consume_for_S::{vtable}: test_crate::Consume::{vtable} = impl_Consume_for_S::{vtable}()
+
+// Full name: test_crate::{impl Consume for S}
+impl "impl_Consume_for_S" Consume for S {
+    proof ImpliedClause0: (S: MetaSized) = {built_in impl MetaSized for S}
+    fn consume = consume
+    fn read<'_0_1> = read<'_0_1>
+    vtable: impl_Consume_for_S::{vtable}
+}
+
+// Full name: test_crate::mk
+fn mk() -> Box<(dyn Consume + 'static)>[{built_in impl MetaSized for (dyn Consume + 'static)}, {built_in impl Sized for Global}]
+{
+    let _0: Box<(dyn Consume + '5)>[{built_in impl MetaSized for (dyn Consume + '7)}, {built_in impl Sized for Global}]; // return
+    let _1: Box<(dyn Consume + '8)>[{built_in impl MetaSized for (dyn Consume + '10)}, {built_in impl Sized for Global}]; // anonymous local
+    let _2: Box<S>[{built_in impl MetaSized for S}, {built_in impl Sized for Global}]; // anonymous local
+    let _3: S; // anonymous local
+
+    storage_live(_0)
+    storage_live(_1)
+    storage_live(_2)
+    storage_live(_3)
+    _3 = S { _0: const 42u32 }
+    _2 = new<S>[{built_in impl Sized for S}](move _3)
+    ↳⚡ unwind_continue
+    _1 = unsize_cast<Box<S>[{built_in impl MetaSized for S}, {built_in impl Sized for Global}], Box<(dyn Consume + '11)>[{built_in impl MetaSized for (dyn Consume + '13)}, {built_in impl Sized for Global}], &impl_Consume_for_S::{vtable}>(move _2)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'14, S, Global>[{built_in impl MetaSized for S}, {built_in impl Sized for Global}]] _2
+    ↳⚡ unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    _0 = unsize_cast<Box<(dyn Consume + '8)>[{built_in impl MetaSized for (dyn Consume + '10)}, {built_in impl Sized for Global}], Box<(dyn Consume + '15)>[{built_in impl MetaSized for (dyn Consume + '17)}, {built_in impl Sized for Global}],  at []>(move _1)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'30, (dyn Consume + '26), Global>[{built_in impl MetaSized for (dyn Consume + '26)}, {built_in impl Sized for Global}]] _1
+    ↳⚡ unwind_continue
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let x: Box<(dyn Consume + '5)>[{built_in impl MetaSized for (dyn Consume + '7)}, {built_in impl Sized for Global}]; // local
+    let _v: u32; // local
+    let _3: &'10 (dyn Consume + '11); // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(x)
+    x = mk()
+    ↳⚡ unwind_continue
+    fake_read(x)
+    storage_live(_v)
+    storage_live(_3)
+    _3 = &(*x) with_metadata(copy x.metadata)
+    _v = (copy (*_3.metadata).method_read)(move _3)
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'28, (dyn Consume + '24), Global>[{built_in impl MetaSized for (dyn Consume + '24)}, {built_in impl Sized for Global}]] x
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_3)
+    fake_read(_v)
+    _0 = ()
+    storage_dead(_v)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'41, (dyn Consume + '37), Global>[{built_in impl MetaSized for (dyn Consume + '37)}, {built_in impl Sized for Global}]] x
+    ↳⚡ unwind_continue
+    storage_dead(x)
+    return
+}
+
+
+

--- a/charon/tests/ui/dyn/by-value-self-vtable.out
+++ b/charon/tests/ui/dyn/by-value-self-vtable.out
@@ -225,8 +225,8 @@ impl "impl_Consume_for_S" Consume for S {
 // Full name: test_crate::mk
 fn mk() -> Box<(dyn Consume + 'static)>[{built_in impl MetaSized for (dyn Consume + 'static)}, {built_in impl Sized for Global}]
 {
-    let _0: Box<(dyn Consume + '5)>[{built_in impl MetaSized for (dyn Consume + '7)}, {built_in impl Sized for Global}]; // return
-    let _1: Box<(dyn Consume + '8)>[{built_in impl MetaSized for (dyn Consume + '10)}, {built_in impl Sized for Global}]; // anonymous local
+    let _0: Box<(dyn Consume + '6)>[{built_in impl MetaSized for (dyn Consume + '8)}, {built_in impl Sized for Global}]; // return
+    let _1: Box<(dyn Consume + '9)>[{built_in impl MetaSized for (dyn Consume + '11)}, {built_in impl Sized for Global}]; // anonymous local
     let _2: Box<S>[{built_in impl MetaSized for S}, {built_in impl Sized for Global}]; // anonymous local
     let _3: S; // anonymous local
 
@@ -237,13 +237,13 @@ fn mk() -> Box<(dyn Consume + 'static)>[{built_in impl MetaSized for (dyn Consum
     _3 = S { _0: const 42u32 }
     _2 = new<S>[{built_in impl Sized for S}](move _3)
     ↳⚡ unwind_continue
-    _1 = unsize_cast<Box<S>[{built_in impl MetaSized for S}, {built_in impl Sized for Global}], Box<(dyn Consume + '11)>[{built_in impl MetaSized for (dyn Consume + '13)}, {built_in impl Sized for Global}], &impl_Consume_for_S::{vtable}>(move _2)
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'14, S, Global>[{built_in impl MetaSized for S}, {built_in impl Sized for Global}]] _2
+    _1 = unsize_cast<Box<S>[{built_in impl MetaSized for S}, {built_in impl Sized for Global}], Box<(dyn Consume + '12)>[{built_in impl MetaSized for (dyn Consume + '14)}, {built_in impl Sized for Global}], &impl_Consume_for_S::{vtable}>(move _2)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'15, S, Global>[{built_in impl MetaSized for S}, {built_in impl Sized for Global}]] _2
     ↳⚡ unwind_continue
     storage_dead(_3)
     storage_dead(_2)
-    _0 = unsize_cast<Box<(dyn Consume + '8)>[{built_in impl MetaSized for (dyn Consume + '10)}, {built_in impl Sized for Global}], Box<(dyn Consume + '15)>[{built_in impl MetaSized for (dyn Consume + '17)}, {built_in impl Sized for Global}],  at []>(move _1)
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'30, (dyn Consume + '26), Global>[{built_in impl MetaSized for (dyn Consume + '26)}, {built_in impl Sized for Global}]] _1
+    _0 = unsize_cast<Box<(dyn Consume + '9)>[{built_in impl MetaSized for (dyn Consume + '11)}, {built_in impl Sized for Global}], Box<(dyn Consume + '16)>[{built_in impl MetaSized for (dyn Consume + '18)}, {built_in impl Sized for Global}],  at []>(move _1)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'33, (dyn Consume + '28), Global>[{built_in impl MetaSized for (dyn Consume + '28)}, {built_in impl Sized for Global}]] _1
     ↳⚡ unwind_continue
     storage_dead(_1)
     return
@@ -253,9 +253,9 @@ fn mk() -> Box<(dyn Consume + 'static)>[{built_in impl MetaSized for (dyn Consum
 fn main()
 {
     let _0: (); // return
-    let x: Box<(dyn Consume + '5)>[{built_in impl MetaSized for (dyn Consume + '7)}, {built_in impl Sized for Global}]; // local
+    let x: Box<(dyn Consume + '6)>[{built_in impl MetaSized for (dyn Consume + '8)}, {built_in impl Sized for Global}]; // local
     let _v: u32; // local
-    let _3: &'10 (dyn Consume + '11); // anonymous local
+    let _3: &'11 (dyn Consume + '12); // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -267,14 +267,14 @@ fn main()
     storage_live(_3)
     _3 = &(*x) with_metadata(copy x.metadata)
     _v = (copy (*_3.metadata).method_read)(move _3)
-    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'28, (dyn Consume + '24), Global>[{built_in impl MetaSized for (dyn Consume + '24)}, {built_in impl Sized for Global}]] x
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'31, (dyn Consume + '26), Global>[{built_in impl MetaSized for (dyn Consume + '26)}, {built_in impl Sized for Global}]] x
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_3)
     fake_read(_v)
     _0 = ()
     storage_dead(_v)
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'41, (dyn Consume + '37), Global>[{built_in impl MetaSized for (dyn Consume + '37)}, {built_in impl Sized for Global}]] x
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'46, (dyn Consume + '41), Global>[{built_in impl MetaSized for (dyn Consume + '41)}, {built_in impl Sized for Global}]] x
     ↳⚡ unwind_continue
     storage_dead(x)
     return

--- a/charon/tests/ui/dyn/by-value-self-vtable.rs
+++ b/charon/tests/ui/dyn/by-value-self-vtable.rs
@@ -1,0 +1,26 @@
+//! A trait method taking `self: Self` by value is still dyn-compatible; its vtable shim must
+//! take the receiver via `*mut Self` (like rustc's `ShimKind::VTable`) since a `dyn Trait`
+//! value can't be passed directly.
+trait Consume {
+    fn consume(self) -> u32;
+    fn read(&self) -> u32;
+}
+
+struct S(u32);
+impl Consume for S {
+    fn consume(self) -> u32 {
+        self.0
+    }
+    fn read(&self) -> u32 {
+        self.0
+    }
+}
+
+fn mk() -> Box<dyn Consume> {
+    Box::new(S(42))
+}
+
+fn main() {
+    let x = mk();
+    let _v = x.read();
+}

--- a/charon/tests/ui/dyn/dyn-cast-to-supertrait.out
+++ b/charon/tests/ui/dyn/dyn-cast-to-supertrait.out
@@ -431,7 +431,7 @@ fn main()
     storage_live(_9)
     storage_live(_10)
     _10 = &(*dyn_cat) with_metadata(copy dyn_cat.metadata)
-    _9 = takes_pettable<'47, (dyn Cat + '40)>[{built_in impl MetaSized for (dyn Cat + '42)}, Cat<(dyn Cat + '45)>::ImpliedClause2](move _10)
+    _9 = takes_pettable<'48, (dyn Cat + '40)>[{built_in impl MetaSized for (dyn Cat + '42)}, Cat<(dyn Cat + '46)>::ImpliedClause2](move _10)
     ↳⚡ unwind_continue
     storage_dead(_10)
     storage_dead(_9)

--- a/charon/tests/ui/dyn/dyn-fn.out
+++ b/charon/tests/ui/dyn/dyn-fn.out
@@ -16,6 +16,11 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
+fn core::marker::MetaSized::{vtable}<Self>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}<Self>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}<Self>()
+
 struct () {}
 
 // Full name: core::marker::Destruct
@@ -150,6 +155,13 @@ fn takes_fn<'_0>(f: &'_0 (dyn for<'a> Fn<(&'a mut u32,), ImpliedClause1::Implied
     return
 }
 
+// Full name: test_crate::gives_fn::{impl FnMut<(&'_ mut u32,)> for {closure}}::{vtable}
+fn impl_FnMut_tuple_for_closure::{vtable}<'_0>() -> core::ops::function::FnMut::{vtable}<(&'_ mut u32,), bool>
+= <opaque>
+
+// Full name: test_crate::gives_fn::{impl FnMut<(&'_ mut u32,)> for {closure}}::{vtable}
+static impl_FnMut_tuple_for_closure::{vtable}<'_0>: core::ops::function::FnMut::{vtable}<(&'_ mut u32,), bool> = impl_FnMut_tuple_for_closure::{vtable}<'_0>()
+
 // Full name: test_crate::gives_fn::{closure}
 struct {closure} {}
 
@@ -176,6 +188,91 @@ fn call<'_0, '_1>(_1: &'_1 {closure}, tupled_args: (&'_0 mut u32,)) -> bool
     return
 }
 
+// Full name: test_crate::gives_fn::{impl Fn<(&'_ mut u32,)> for {closure}}::{vtable_method}
+extern "rust-call" fn {vtable_method}<'_0, '_1>(_1: &'_1 (dyn Fn<(&'_ mut u32,), ImpliedClause1::ImpliedClause1::Output = bool>), _2: (&'_ mut u32,)) -> bool
+{
+    let _0: bool; // return
+    let _1: &'_1 (dyn Fn<(&'0 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '1); // arg #1
+    let _2: (&'5 mut u32,); // arg #2
+    let _3: &'_1 {closure}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_1 (dyn Fn<(&'6 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '7), &'_1 {closure}>(move _1)
+    _0 = call<'_0, '_1>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::gives_fn::{closure}::{impl Destruct for {closure}}::drop_glue
+unsafe fn drop_glue<'_0>(_1: &'_0 mut {closure})
+{
+    let _0: (); // return
+    let _1: &'1 mut {closure}; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::gives_fn::{impl Fn<(&'_ mut u32,)> for {closure}}::{vtable_drop_shim}
+unsafe fn {vtable_drop_shim}<'_0, '_1>(dyn_self: &'_1 mut (dyn Fn<(&'_ mut u32,), ImpliedClause1::ImpliedClause1::Output = bool>))
+{
+    let ret: (); // return
+    let dyn_self: &'_1 mut (dyn Fn<(&'0 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '1); // arg #1
+    let target_self: &'_1 mut {closure}; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_1 mut (dyn Fn<(&'5 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '6), &'_1 mut {closure}>(move dyn_self)
+    drop[drop_glue<'15>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::gives_fn::{impl Fn<(&'_ mut u32,)> for {closure}}::{vtable}
+fn impl_Fn_tuple_for_closure::{vtable}<'_0>() -> core::ops::function::Fn::{vtable}<(&'_ mut u32,), bool>
+{
+    let ret: core::ops::function::Fn::{vtable}<(&'0 mut u32,), bool>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(&'4 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '5)); // anonymous local
+    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(&'10 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '11), (&'15 mut u32,)) -> bool; // anonymous local
+    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _6: &'static core::ops::function::FnMut::{vtable}<(&'35 mut u32,), bool>; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<{closure}>
+    storage_live(align)
+    align = align_of<{closure}>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {vtable_drop_shim}<'_0, '3>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(&'4 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '5))>(const {vtable_drop_shim}<'_0, '3>)
+    storage_live(_4)
+    _4 = cast<for<'_0_1> {vtable_method}<'_0, '9>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(&'10 mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '11), (&'15 mut u32,)) -> bool>(const {vtable_method}<'_0, '9>)
+    storage_live(_5)
+    _5 = &core::marker::MetaSized::{vtable}<{closure}>
+    storage_live(_6)
+    _6 = &impl_FnMut_tuple_for_closure::{vtable}<'_0>
+    ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move _3, method_call: move _4, super_trait_0: move _5, super_trait_1: move _6 }
+    return
+}
+
+// Full name: test_crate::gives_fn::{impl Fn<(&'_ mut u32,)> for {closure}}::{vtable}
+static impl_Fn_tuple_for_closure::{vtable}<'_0>: core::ops::function::Fn::{vtable}<(&'_ mut u32,), bool> = impl_Fn_tuple_for_closure::{vtable}<'_0>()
+
 // Full name: test_crate::gives_fn::{impl FnMut<(&'_ mut u32,)> for {closure}}::call_mut
 fn call_mut<'_0, '_1>(state: &'_1 mut {closure}, args: (&'_0 mut u32,)) -> bool
 {
@@ -195,18 +292,6 @@ fn call_mut<'_0, '_1>(state: &'_1 mut {closure}, args: (&'_0 mut u32,)) -> bool
     storage_dead(_3)
     storage_dead(args)
     storage_dead(state)
-    return
-}
-
-// Full name: test_crate::gives_fn::{closure}::{impl Destruct for {closure}}::drop_glue
-unsafe fn drop_glue<'_0>(_1: &'_0 mut {closure})
-{
-    let _0: (); // return
-    let _1: &'1 mut {closure}; // arg #1
-
-    storage_live(_0)
-    _0 = ()
-    storage_dead(_1)
     return
 }
 
@@ -282,7 +367,7 @@ fn gives_fn()
     let _3: &'12 {closure}; // anonymous local
     let _4: &'13 {closure}; // anonymous local
     let _5: &'14 {closure}; // anonymous local
-    let _6: &'23 {closure}; // anonymous local
+    let _6: &'24 {closure}; // anonymous local
     let _7: {closure}; // anonymous local
 
     storage_live(_5)
@@ -300,9 +385,9 @@ fn gives_fn()
     _4 = move _5
     _3 = &(*_4)
     _2 = &(*_3)
-    _1 = unsize_cast<&'11 {closure}, &'15 (dyn for<'a> Fn<(&'a mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '16), &vtable_of(impl_Fn_tuple_for_closure<'20>)>(move _2)
+    _1 = unsize_cast<&'11 {closure}, &'15 (dyn for<'a> Fn<(&'a mut u32,), ImpliedClause1::ImpliedClause1::Output = bool> + '16), &impl_Fn_tuple_for_closure::{vtable}<'20>>(move _2)
     storage_dead(_2)
-    _0 = takes_fn<'22>(move _1)
+    _0 = takes_fn<'23>(move _1)
     ↳⚡ storage_dead(_4)
         unwind_continue
     storage_dead(_1)

--- a/charon/tests/ui/dyn/dyn-sized.out
+++ b/charon/tests/ui/dyn/dyn-sized.out
@@ -1,5 +1,5 @@
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:233:14:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:246:14:
 trait should be dyn-compatible
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: Thread panicked when extracting item `test_crate::DynSized`.

--- a/charon/tests/ui/dyn/dyn-sized.out
+++ b/charon/tests/ui/dyn/dyn-sized.out
@@ -1,5 +1,5 @@
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:246:14:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:247:14:
 trait should be dyn-compatible
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: Thread panicked when extracting item `test_crate::DynSized`.

--- a/charon/tests/ui/dyn/dyn-sized.out
+++ b/charon/tests/ui/dyn/dyn-sized.out
@@ -1,5 +1,5 @@
 
-thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:247:14:
+thread 'rustc' panicked at src/bin/charon-driver/translate/translate_trait_objects.rs:250:14:
 trait should be dyn-compatible
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: Thread panicked when extracting item `test_crate::DynSized`.

--- a/charon/tests/ui/dyn/dyn-trait.out
+++ b/charon/tests/ui/dyn/dyn-trait.out
@@ -136,7 +136,7 @@ fn destruct<'_0>(x: &'_0 (dyn Display + '_0)) -> String
     storage_live(_0)
     storage_live(_2)
     _2 = &(*x) with_metadata(copy x.metadata)
-    _0 = to_string<'16, (dyn Display + '9)>[{built_in impl MetaSized for (dyn Display + '11)}, Display<(dyn Display + '14)>](move _2)
+    _0 = to_string<'17, (dyn Display + '9)>[{built_in impl MetaSized for (dyn Display + '11)}, Display<(dyn Display + '15)>](move _2)
     ↳⚡ storage_dead(x)
         unwind_continue
     storage_dead(_2)

--- a/charon/tests/ui/dyn/fn-pointer-vtable-clause.out
+++ b/charon/tests/ui/dyn/fn-pointer-vtable-clause.out
@@ -1,0 +1,580 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Tuple
+#[fundamental]
+#[lang_item(Tuple)]
+pub trait Tuple<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct core::ops::function::FnOnce::{vtable}<Args, Ty0> {
+  size: usize,
+  align: usize,
+  drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Ty0>)),
+  method_call_once: extern "rust-call" fn((dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+// Full name: core::ops::function::FnOnce
+#[fundamental]
+#[lang_item(FnOnce)]
+pub trait FnOnce<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
+    type Output
+    fn call_once;
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
+}
+
+struct core::ops::function::FnMut::{vtable}<Args, Ty0> {
+  size: usize,
+  align: usize,
+  drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<Args, ImpliedClause1::Output = Ty0>)),
+  method_call_mut: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<Args, ImpliedClause1::Output = Ty0>), Args) -> Ty0,
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+  super_trait_1: &'static core::ops::function::FnOnce::{vtable}<Args, Ty0>,
+}
+
+// Full name: core::ops::function::FnMut
+#[fundamental]
+#[lang_item(FnMut)]
+pub trait FnMut<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    fn call_mut<'_0_1>;
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
+}
+
+struct core::ops::function::Fn::{vtable}<Args, Ty0> {
+  size: usize,
+  align: usize,
+  drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Ty0>)),
+  method_call: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Ty0>), Args) -> Ty0,
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+  super_trait_1: &'static core::ops::function::FnMut::{vtable}<Args, Ty0>,
+}
+
+// Full name: core::ops::function::Fn
+#[fundamental]
+#[lang_item(Fn)]
+pub trait Fn<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    fn call<'_0_1>;
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
+}
+
+extern "rust-call" fn core::ops::function::Fn::{vtable_method}<Self, Args>(_1: &'_ (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output>), _2: Args) -> Self::ImpliedClause1::ImpliedClause1::Output
+{
+    let _0: Self::ImpliedClause1::ImpliedClause1::Output; // return
+    let _1: &'0 (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '1); // arg #1
+    let _2: Args; // arg #2
+    let _3: &'2 Self; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'4 (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '5), &'6 Self>(move _1)
+    _0 = Self::call<'9>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+unsafe fn core::ops::function::Fn::{vtable_drop_shim}<'_0, Self, Args>(dyn_self: &'_0 mut (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output>))
+where
+    TypeOutlives0: Args: '_0,
+    TypeOutlives1: Self::ImpliedClause1::ImpliedClause1::Output: '_0,
+    TypeOutlives2: Self: '_0,
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '0); // arg #1
+    let target_self: &'_0 mut Self; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '1), &'_0 mut Self>(move dyn_self)
+    drop[{built_in impl Destruct for Self}::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+fn core::ops::function::Fn::{vtable}<Self, Args>() -> core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
+{
+    let ret: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '1)); // anonymous local
+    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '2), Args) -> Self::ImpliedClause1::ImpliedClause1::Output; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<Self>
+    storage_live(align)
+    align = align_of<Self>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> core::ops::function::Fn::{vtable_drop_shim}<'0, Self, Args>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '1))>(const core::ops::function::Fn::{vtable_drop_shim}<'0, Self, Args>)
+    storage_live(_4)
+    _4 = cast<for<'_0_1> core::ops::function::Fn::{vtable_method}<Self, Args>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '2), Args) -> Self::ImpliedClause1::ImpliedClause1::Output>(const core::ops::function::Fn::{vtable_method}<Self, Args>)
+    ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move _3, method_call: move _4, super_trait_0: const &vtable_of(Self::ImpliedClause0), super_trait_1: const &vtable_of(Self::ImpliedClause1) }
+    return
+}
+
+static core::ops::function::Fn::{vtable}<Self, Args>: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output> = core::ops::function::Fn::{vtable}<Self, Args>()
+
+extern "rust-call" fn core::ops::function::FnMut::{vtable_method}<Self, Args>(_1: &'_ mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output>), _2: Args) -> Self::ImpliedClause1::Output
+{
+    let _0: Self::ImpliedClause1::Output; // return
+    let _1: &'0 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '1); // arg #1
+    let _2: Args; // arg #2
+    let _3: &'2 mut Self; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'4 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '5), &'6 mut Self>(move _1)
+    _0 = Self::call_mut<'9>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+unsafe fn core::ops::function::FnMut::{vtable_drop_shim}<'_0, Self, Args>(dyn_self: &'_0 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output>))
+where
+    TypeOutlives0: Args: '_0,
+    TypeOutlives1: Self::ImpliedClause1::Output: '_0,
+    TypeOutlives2: Self: '_0,
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '0); // arg #1
+    let target_self: &'_0 mut Self; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '1), &'_0 mut Self>(move dyn_self)
+    drop[{built_in impl Destruct for Self}::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+fn core::ops::function::FnMut::{vtable}<Self, Args>() -> core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
+{
+    let ret: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '1)); // anonymous local
+    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '2), Args) -> Self::ImpliedClause1::Output; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<Self>
+    storage_live(align)
+    align = align_of<Self>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> core::ops::function::FnMut::{vtable_drop_shim}<'0, Self, Args>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '1))>(const core::ops::function::FnMut::{vtable_drop_shim}<'0, Self, Args>)
+    storage_live(_4)
+    _4 = cast<for<'_0_1> core::ops::function::FnMut::{vtable_method}<Self, Args>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '2), Args) -> Self::ImpliedClause1::Output>(const core::ops::function::FnMut::{vtable_method}<Self, Args>)
+    ret = core::ops::function::FnMut::{vtable} { size: move size, align: move align, drop: move _3, method_call_mut: move _4, super_trait_0: const &vtable_of(Self::ImpliedClause0), super_trait_1: const &vtable_of(Self::ImpliedClause1) }
+    return
+}
+
+static core::ops::function::FnMut::{vtable}<Self, Args>: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output> = core::ops::function::FnMut::{vtable}<Self, Args>()
+
+extern "rust-call" fn core::ops::function::FnOnce::{vtable_method}<Self, Args>(_1: (dyn FnOnce<Args, Output = Self::Output>), _2: Args) -> Self::Output
+{
+    let _0: Self::Output; // return
+    let _1: (dyn FnOnce<Args, Output = Self::Output> + '0); // arg #1
+    let _2: Args; // arg #2
+    let _3: Self; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<(dyn FnOnce<Args, Output = Self::Output> + '1), Self>(move _1)
+    _0 = Self::call_once(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+unsafe fn core::ops::function::FnOnce::{vtable_drop_shim}<'_0, Self, Args>(dyn_self: &'_0 mut (dyn FnOnce<Args, Output = Self::Output>))
+where
+    TypeOutlives0: Args: '_0,
+    TypeOutlives1: Self::Output: '_0,
+    TypeOutlives2: Self: '_0,
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnOnce<Args, Output = Self::Output> + '0); // arg #1
+    let target_self: &'_0 mut Self; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnOnce<Args, Output = Self::Output> + '1), &'_0 mut Self>(move dyn_self)
+    drop[{built_in impl Destruct for Self}::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+fn core::ops::function::FnOnce::{vtable}<Self, Args>() -> core::ops::function::FnOnce::{vtable}<Args, Self::Output>
+{
+    let ret: core::ops::function::FnOnce::{vtable}<Args, Self::Output>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Self::Output> + '1)); // anonymous local
+    let _4: extern "rust-call" fn((dyn FnOnce<Args, Output = Self::Output> + '2), Args) -> Self::Output; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<Self>
+    storage_live(align)
+    align = align_of<Self>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> core::ops::function::FnOnce::{vtable_drop_shim}<'0, Self, Args>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Self::Output> + '1))>(const core::ops::function::FnOnce::{vtable_drop_shim}<'0, Self, Args>)
+    storage_live(_4)
+    _4 = cast<core::ops::function::FnOnce::{vtable_method}<Self, Args>, extern "rust-call" fn((dyn FnOnce<Args, Output = Self::Output> + '2), Args) -> Self::Output>(const core::ops::function::FnOnce::{vtable_method}<Self, Args>)
+    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: const &vtable_of(Self::ImpliedClause0) }
+    return
+}
+
+static core::ops::function::FnOnce::{vtable}<Self, Args>: core::ops::function::FnOnce::{vtable}<Args, Self::Output> = core::ops::function::FnOnce::{vtable}<Self, Args>()
+
+// Full name: alloc::alloc::Global
+#[lang_item(GlobalAlloc)]
+pub struct Global {}
+
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TypeOutlives0: T: '_0,
+    TypeOutlives1: A: '_0,
+= <opaque>
+
+// Full name: alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
+#[track_caller]
+#[diagnostic_item("box_new")]
+pub fn new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+where
+    TraitClause0: (T: Sized),
+= <opaque>
+
+// Full name: alloc::boxed::{impl Fn<Args> for Box<F>[TraitClause1, TraitClause2]}::call
+pub extern "rust-call" fn call<'_0, Args, F, A>(_1: &'_0 Box<F>[TraitClause1, TraitClause2], _2: Args) -> TraitClause4::ImpliedClause1::ImpliedClause1::Output
+where
+    TraitClause0: (Args: Sized),
+    TraitClause1: (F: MetaSized),
+    TraitClause2: (A: Sized),
+    TraitClause3: (Args: Tuple),
+    TraitClause4: (F: Fn<Args>),
+    TypeOutlives0: F: '_0,
+    TypeOutlives1: A: '_0,
+= <opaque>
+
+struct (_,)<A> {
+  _0: A,
+}
+
+// Full name: test_crate::foo
+fn foo(x: u32) -> u32
+{
+    let _0: u32; // return
+    let x: u32; // arg #1
+
+    storage_live(_0)
+    _0 = copy x
+    storage_dead(x)
+    return
+}
+
+// Full name: test_crate::wrap
+fn wrap<F>(f: F) -> Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + 'static)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + 'static)}, {built_in impl Sized for Global}]
+where
+    TraitClause0: (F: Sized),
+    TraitClause1: (F: Fn<(u32,)>),
+    TypeOutlives0: F: 'static,
+    TypeConstraint0: TraitClause1::ImpliedClause1::ImpliedClause1::Output = u32,
+{
+    let _0: Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '5)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '7)}, {built_in impl Sized for Global}]; // return
+    let f: F; // arg #1
+    let _2: Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '8)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '10)}, {built_in impl Sized for Global}]; // anonymous local
+    let _3: Box<F>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]; // anonymous local
+    let _4: F; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    storage_live(_3)
+    storage_live(_4)
+    _4 = move f
+    _3 = new<F>[TraitClause0](move _4)
+    ↳⚡ conditional_drop[{built_in impl Destruct for F}::drop_glue<'11>] _4
+        ↳⚡ storage_dead(f)
+            unwind_terminate
+        conditional_drop[{built_in impl Destruct for F}::drop_glue<'16>] f
+        ↳⚡ storage_dead(f)
+            unwind_terminate
+        storage_dead(f)
+        unwind_continue
+    _2 = unsize_cast<Box<F>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}], Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '12)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '14)}, {built_in impl Sized for Global}], &vtable_of(TraitClause1)>(move _3)
+    conditional_drop[drop_glue<'15, F, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]] _3
+    ↳⚡ conditional_drop[{built_in impl Destruct for F}::drop_glue<'11>] _4
+        ↳⚡ storage_dead(f)
+            unwind_terminate
+        conditional_drop[{built_in impl Destruct for F}::drop_glue<'16>] f
+        ↳⚡ storage_dead(f)
+            unwind_terminate
+        storage_dead(f)
+        unwind_continue
+    storage_dead(_4)
+    storage_dead(_3)
+    _0 = unsize_cast<Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '8)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '10)}, {built_in impl Sized for Global}], Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '17)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '19)}, {built_in impl Sized for Global}],  at []>(move _2)
+    conditional_drop[drop_glue<'32, (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '28), Global>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '28)}, {built_in impl Sized for Global}]] _2
+    ↳⚡ conditional_drop[{built_in impl Destruct for F}::drop_glue<'16>] f
+        ↳⚡ storage_dead(f)
+            unwind_terminate
+        storage_dead(f)
+        unwind_continue
+    storage_dead(_2)
+    conditional_drop[{built_in impl Destruct for F}::drop_glue<'33>] f
+    ↳⚡ storage_dead(f)
+        unwind_continue
+    storage_dead(f)
+    return
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let f: &'3 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4); // local
+    let _2: &'6 fn(u32) -> u32; // anonymous local
+    let _3: &'7 fn(u32) -> u32; // anonymous local
+    let _4: u32; // anonymous local
+    let _5: &'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9); // anonymous local
+    let _6: (u32,); // anonymous local
+    let g: &'13 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '14); // local
+    let _8: &'16 mut fn(u32) -> u32; // anonymous local
+    let _9: &'17 mut fn(u32) -> u32; // anonymous local
+    let _10: fn(u32) -> u32; // anonymous local
+    let _11: u32; // anonymous local
+    let _12: &'18 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '19); // anonymous local
+    let _13: (u32,); // anonymous local
+    let _h: Box<(dyn FnOnce<(u32,), Output = u32> + '25)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '27)}, {built_in impl Sized for Global}]; // local
+    let _15: Box<fn(u32) -> u32>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}]; // anonymous local
+    let _16: fn(u32) -> u32; // anonymous local
+    let _17: u32; // anonymous local
+    let _18: &'36 Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '37)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '39)}, {built_in impl Sized for Global}]; // anonymous local
+    let _19: Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '40)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '42)}, {built_in impl Sized for Global}]; // anonymous local
+    let _20: fn(u32) -> u32; // anonymous local
+    let _21: (u32,); // anonymous local
+    let _22: &'43 fn(u32) -> u32; // anonymous local
+    let _23: &'44 fn(u32) -> u32; // anonymous local
+    let _24: &'129 fn(u32) -> u32; // anonymous local
+    let _25: fn(u32) -> u32; // anonymous local
+
+    storage_live(_23)
+    storage_live(_24)
+    storage_live(_25)
+    // These coercions translate the vtable instances for `fn(u32) -> u32: Fn*<(u32,)>`.
+    _25 = cast<foo, fn(u32) -> u32>(const foo)
+    _24 = &_25
+    _23 = move _24
+    storage_live(_0)
+    storage_live(_22)
+    _0 = ()
+    storage_live(f)
+    storage_live(_2)
+    storage_live(_3)
+    _22 = move _23
+    _3 = &(*_22)
+    _2 = &(*_3)
+    f = unsize_cast<&'6 fn(u32) -> u32, &'45 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '46), &core::ops::function::Fn::{vtable}<fn(u32) -> u32, (u32,)>>(move _2)
+    storage_dead(_2)
+    fake_read(f)
+    set_type(typeof(f) == &'47 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '48))
+    storage_dead(_3)
+    storage_live(_4)
+    storage_live(_5)
+    _5 = &(*f) with_metadata(copy f.metadata)
+    storage_live(_6)
+    _6 = (const 1u32,)
+    _4 = (copy (*_5.metadata).method_call)(move _5, move _6)
+    ↳⚡ storage_dead(_22)
+        unwind_continue
+    storage_dead(_6)
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_live(g)
+    storage_live(_8)
+    storage_live(_9)
+    storage_live(_10)
+    _10 = cast<foo, fn(u32) -> u32>(const foo)
+    _9 = &mut _10
+    _8 = &mut (*_9)
+    g = unsize_cast<&'16 mut fn(u32) -> u32, &'53 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '54), &core::ops::function::FnMut::{vtable}<fn(u32) -> u32, (u32,)>>(move _8)
+    storage_dead(_8)
+    fake_read(g)
+    set_type(typeof(g) == &'55 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '56))
+    storage_dead(_9)
+    storage_live(_11)
+    storage_live(_12)
+    _12 = &mut (*g) with_metadata(copy g.metadata)
+    storage_live(_13)
+    _13 = (const 2u32,)
+    _11 = (copy (*_12.metadata).method_call_mut)(move _12, move _13)
+    ↳⚡ storage_dead(_22)
+        unwind_continue
+    storage_dead(_13)
+    storage_dead(_12)
+    storage_dead(_11)
+    storage_live(_h)
+    storage_live(_15)
+    storage_live(_16)
+    _16 = cast<foo, fn(u32) -> u32>(const foo)
+    _15 = new<fn(u32) -> u32>[{built_in impl Sized for fn(u32) -> u32}](move _16)
+    ↳⚡ storage_dead(_22)
+        unwind_continue
+    _h = unsize_cast<Box<fn(u32) -> u32>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}], Box<(dyn FnOnce<(u32,), Output = u32> + '61)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '63)}, {built_in impl Sized for Global}], &core::ops::function::FnOnce::{vtable}<fn(u32) -> u32, (u32,)>>(move _15)
+    conditional_drop[drop_glue<'64, fn(u32) -> u32, Global>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}]] _15
+    ↳⚡ storage_dead(_22)
+        unwind_continue
+    storage_dead(_16)
+    storage_dead(_15)
+    fake_read(_h)
+    set_type(typeof(_h) == Box<(dyn FnOnce<(u32,), Output = u32> + '65)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '67)}, {built_in impl Sized for Global}])
+    storage_live(_17)
+    storage_live(_18)
+    storage_live(_19)
+    storage_live(_20)
+    // The same builtin impls appear as clause proofs in the call generics.
+    _20 = cast<foo, fn(u32) -> u32>(const foo)
+    _19 = wrap<fn(u32) -> u32>[{built_in impl Sized for fn(u32) -> u32}, {built_in impl Fn<(u32,)> for fn(u32) -> u32}](move _20)
+    ↳⚡ conditional_drop[drop_glue<'80, (dyn FnOnce<(u32,), Output = u32> + '76), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '76)}, {built_in impl Sized for Global}]] _h
+        ↳⚡ storage_dead(_22)
+            storage_dead(_25)
+            storage_dead(_24)
+            storage_dead(_23)
+            unwind_terminate
+        storage_dead(_22)
+        unwind_continue
+    _18 = &_19
+    storage_dead(_20)
+    storage_live(_21)
+    _21 = (const 3u32,)
+    _17 = call<'89, (u32,), (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '82), Global>[{built_in impl Sized for (u32,)}, {built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '84)}, {built_in impl Sized for Global}, {built_in impl Tuple for (u32,)}, Fn<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '87), (u32,)>](move _18, move _21)
+    ↳⚡ conditional_drop[drop_glue<'102, (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '98), Global>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '98)}, {built_in impl Sized for Global}]] _19
+        ↳⚡ storage_dead(_22)
+            storage_dead(_25)
+            storage_dead(_24)
+            storage_dead(_23)
+            unwind_terminate
+        conditional_drop[drop_glue<'80, (dyn FnOnce<(u32,), Output = u32> + '76), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '76)}, {built_in impl Sized for Global}]] _h
+        ↳⚡ storage_dead(_22)
+            storage_dead(_25)
+            storage_dead(_24)
+            storage_dead(_23)
+            unwind_terminate
+        storage_dead(_22)
+        unwind_continue
+    storage_dead(_21)
+    storage_dead(_18)
+    conditional_drop[drop_glue<'115, (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '111), Global>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '111)}, {built_in impl Sized for Global}]] _19
+    ↳⚡ conditional_drop[drop_glue<'80, (dyn FnOnce<(u32,), Output = u32> + '76), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '76)}, {built_in impl Sized for Global}]] _h
+        ↳⚡ storage_dead(_22)
+            storage_dead(_25)
+            storage_dead(_24)
+            storage_dead(_23)
+            unwind_terminate
+        storage_dead(_22)
+        unwind_continue
+    storage_dead(_19)
+    storage_dead(_17)
+    _0 = ()
+    conditional_drop[drop_glue<'128, (dyn FnOnce<(u32,), Output = u32> + '124), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '124)}, {built_in impl Sized for Global}]] _h
+    ↳⚡ storage_dead(_22)
+        unwind_continue
+    storage_dead(_h)
+    storage_dead(_10)
+    storage_dead(g)
+    storage_dead(f)
+    storage_dead(_22)
+    storage_dead(_25)
+    storage_dead(_24)
+    storage_dead(_23)
+    return
+}
+
+
+

--- a/charon/tests/ui/dyn/fn-pointer-vtable-clause.out
+++ b/charon/tests/ui/dyn/fn-pointer-vtable-clause.out
@@ -39,7 +39,7 @@ struct core::ops::function::FnOnce::{vtable}<Args, Ty0> {
   size: usize,
   align: usize,
   drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Ty0>)),
-  method_call_once: extern "rust-call" fn((dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
+  method_call_once: extern "rust-call" fn(*mut (dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
   super_trait_0: &'static core::marker::MetaSized::{vtable},
 }
 
@@ -235,17 +235,17 @@ fn core::ops::function::FnMut::{vtable}<Self, Args>() -> core::ops::function::Fn
 
 static core::ops::function::FnMut::{vtable}<Self, Args>: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output> = core::ops::function::FnMut::{vtable}<Self, Args>()
 
-extern "rust-call" fn core::ops::function::FnOnce::{vtable_method}<Self, Args>(_1: (dyn FnOnce<Args, Output = Self::Output>), _2: Args) -> Self::Output
+extern "rust-call" fn core::ops::function::FnOnce::{vtable_method}<Self, Args>(_1: *mut (dyn FnOnce<Args, Output = Self::Output>), _2: Args) -> Self::Output
 {
     let _0: Self::Output; // return
-    let _1: (dyn FnOnce<Args, Output = Self::Output> + '0); // arg #1
+    let _1: *mut (dyn FnOnce<Args, Output = Self::Output> + '0); // arg #1
     let _2: Args; // arg #2
-    let _3: Self; // anonymous local
+    let _3: *mut Self; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
-    _3 = concretize<(dyn FnOnce<Args, Output = Self::Output> + '1), Self>(move _1)
-    _0 = Self::call_once(move _3, move _2)
+    _3 = concretize<*mut (dyn FnOnce<Args, Output = Self::Output> + '1), *mut Self>(move _1)
+    _0 = Self::call_once(move (*_3), move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -285,7 +285,7 @@ fn core::ops::function::FnOnce::{vtable}<Self, Args>() -> core::ops::function::F
     let size: usize; // local
     let align: usize; // local
     let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Self::Output> + '1)); // anonymous local
-    let _4: extern "rust-call" fn((dyn FnOnce<Args, Output = Self::Output> + '2), Args) -> Self::Output; // anonymous local
+    let _4: extern "rust-call" fn(*mut (dyn FnOnce<Args, Output = Self::Output> + '2), Args) -> Self::Output; // anonymous local
 
     storage_live(ret)
     storage_live(size)
@@ -295,7 +295,7 @@ fn core::ops::function::FnOnce::{vtable}<Self, Args>() -> core::ops::function::F
     storage_live(_3)
     _3 = cast<for<'_0_1> core::ops::function::FnOnce::{vtable_drop_shim}<'0, Self, Args>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Self::Output> + '1))>(const core::ops::function::FnOnce::{vtable_drop_shim}<'0, Self, Args>)
     storage_live(_4)
-    _4 = cast<core::ops::function::FnOnce::{vtable_method}<Self, Args>, extern "rust-call" fn((dyn FnOnce<Args, Output = Self::Output> + '2), Args) -> Self::Output>(const core::ops::function::FnOnce::{vtable_method}<Self, Args>)
+    _4 = cast<core::ops::function::FnOnce::{vtable_method}<Self, Args>, extern "rust-call" fn(*mut (dyn FnOnce<Args, Output = Self::Output> + '2), Args) -> Self::Output>(const core::ops::function::FnOnce::{vtable_method}<Self, Args>)
     ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: const &vtable_of(Self::ImpliedClause0) }
     return
 }

--- a/charon/tests/ui/dyn/fn-pointer-vtable-clause.out
+++ b/charon/tests/ui/dyn/fn-pointer-vtable-clause.out
@@ -367,9 +367,9 @@ where
     TypeOutlives0: F: 'static,
     TypeConstraint0: TraitClause1::ImpliedClause1::ImpliedClause1::Output = u32,
 {
-    let _0: Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '5)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '7)}, {built_in impl Sized for Global}]; // return
+    let _0: Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '6)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '8)}, {built_in impl Sized for Global}]; // return
     let f: F; // arg #1
-    let _2: Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '8)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '10)}, {built_in impl Sized for Global}]; // anonymous local
+    let _2: Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '11)}, {built_in impl Sized for Global}]; // anonymous local
     let _3: Box<F>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]; // anonymous local
     let _4: F; // anonymous local
 
@@ -379,35 +379,35 @@ where
     storage_live(_4)
     _4 = move f
     _3 = new<F>[TraitClause0](move _4)
-    ↳⚡ conditional_drop[{built_in impl Destruct for F}::drop_glue<'11>] _4
+    ↳⚡ conditional_drop[{built_in impl Destruct for F}::drop_glue<'12>] _4
         ↳⚡ storage_dead(f)
             unwind_terminate
-        conditional_drop[{built_in impl Destruct for F}::drop_glue<'16>] f
+        conditional_drop[{built_in impl Destruct for F}::drop_glue<'17>] f
         ↳⚡ storage_dead(f)
             unwind_terminate
         storage_dead(f)
         unwind_continue
-    _2 = unsize_cast<Box<F>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}], Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '12)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '14)}, {built_in impl Sized for Global}], &vtable_of(TraitClause1)>(move _3)
-    conditional_drop[drop_glue<'15, F, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]] _3
-    ↳⚡ conditional_drop[{built_in impl Destruct for F}::drop_glue<'11>] _4
+    _2 = unsize_cast<Box<F>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}], Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '13)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '15)}, {built_in impl Sized for Global}], &vtable_of(TraitClause1)>(move _3)
+    conditional_drop[drop_glue<'16, F, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]] _3
+    ↳⚡ conditional_drop[{built_in impl Destruct for F}::drop_glue<'12>] _4
         ↳⚡ storage_dead(f)
             unwind_terminate
-        conditional_drop[{built_in impl Destruct for F}::drop_glue<'16>] f
+        conditional_drop[{built_in impl Destruct for F}::drop_glue<'17>] f
         ↳⚡ storage_dead(f)
             unwind_terminate
         storage_dead(f)
         unwind_continue
     storage_dead(_4)
     storage_dead(_3)
-    _0 = unsize_cast<Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '8)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '10)}, {built_in impl Sized for Global}], Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '17)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '19)}, {built_in impl Sized for Global}],  at []>(move _2)
-    conditional_drop[drop_glue<'32, (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '28), Global>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '28)}, {built_in impl Sized for Global}]] _2
-    ↳⚡ conditional_drop[{built_in impl Destruct for F}::drop_glue<'16>] f
+    _0 = unsize_cast<Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '11)}, {built_in impl Sized for Global}], Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '18)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '20)}, {built_in impl Sized for Global}],  at []>(move _2)
+    conditional_drop[drop_glue<'35, (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '30), Global>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '30)}, {built_in impl Sized for Global}]] _2
+    ↳⚡ conditional_drop[{built_in impl Destruct for F}::drop_glue<'17>] f
         ↳⚡ storage_dead(f)
             unwind_terminate
         storage_dead(f)
         unwind_continue
     storage_dead(_2)
-    conditional_drop[{built_in impl Destruct for F}::drop_glue<'33>] f
+    conditional_drop[{built_in impl Destruct for F}::drop_glue<'36>] f
     ↳⚡ storage_dead(f)
         unwind_continue
     storage_dead(f)
@@ -431,17 +431,17 @@ fn main()
     let _11: u32; // anonymous local
     let _12: &'18 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '19); // anonymous local
     let _13: (u32,); // anonymous local
-    let _h: Box<(dyn FnOnce<(u32,), Output = u32> + '25)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '27)}, {built_in impl Sized for Global}]; // local
+    let _h: Box<(dyn FnOnce<(u32,), Output = u32> + '26)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '28)}, {built_in impl Sized for Global}]; // local
     let _15: Box<fn(u32) -> u32>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}]; // anonymous local
     let _16: fn(u32) -> u32; // anonymous local
     let _17: u32; // anonymous local
-    let _18: &'36 Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '37)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '39)}, {built_in impl Sized for Global}]; // anonymous local
-    let _19: Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '40)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '42)}, {built_in impl Sized for Global}]; // anonymous local
+    let _18: &'38 Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '39)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '41)}, {built_in impl Sized for Global}]; // anonymous local
+    let _19: Box<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '42)>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '44)}, {built_in impl Sized for Global}]; // anonymous local
     let _20: fn(u32) -> u32; // anonymous local
     let _21: (u32,); // anonymous local
-    let _22: &'43 fn(u32) -> u32; // anonymous local
-    let _23: &'44 fn(u32) -> u32; // anonymous local
-    let _24: &'129 fn(u32) -> u32; // anonymous local
+    let _22: &'45 fn(u32) -> u32; // anonymous local
+    let _23: &'46 fn(u32) -> u32; // anonymous local
+    let _24: &'140 fn(u32) -> u32; // anonymous local
     let _25: fn(u32) -> u32; // anonymous local
 
     storage_live(_23)
@@ -460,10 +460,10 @@ fn main()
     _22 = move _23
     _3 = &(*_22)
     _2 = &(*_3)
-    f = unsize_cast<&'6 fn(u32) -> u32, &'45 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '46), &core::ops::function::Fn::{vtable}<fn(u32) -> u32, (u32,)>>(move _2)
+    f = unsize_cast<&'6 fn(u32) -> u32, &'47 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '48), &core::ops::function::Fn::{vtable}<fn(u32) -> u32, (u32,)>>(move _2)
     storage_dead(_2)
     fake_read(f)
-    set_type(typeof(f) == &'47 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '48))
+    set_type(typeof(f) == &'49 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '50))
     storage_dead(_3)
     storage_live(_4)
     storage_live(_5)
@@ -483,10 +483,10 @@ fn main()
     _10 = cast<foo, fn(u32) -> u32>(const foo)
     _9 = &mut _10
     _8 = &mut (*_9)
-    g = unsize_cast<&'16 mut fn(u32) -> u32, &'53 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '54), &core::ops::function::FnMut::{vtable}<fn(u32) -> u32, (u32,)>>(move _8)
+    g = unsize_cast<&'16 mut fn(u32) -> u32, &'55 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '56), &core::ops::function::FnMut::{vtable}<fn(u32) -> u32, (u32,)>>(move _8)
     storage_dead(_8)
     fake_read(g)
-    set_type(typeof(g) == &'55 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '56))
+    set_type(typeof(g) == &'57 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '58))
     storage_dead(_9)
     storage_live(_11)
     storage_live(_12)
@@ -506,14 +506,14 @@ fn main()
     _15 = new<fn(u32) -> u32>[{built_in impl Sized for fn(u32) -> u32}](move _16)
     ↳⚡ storage_dead(_22)
         unwind_continue
-    _h = unsize_cast<Box<fn(u32) -> u32>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}], Box<(dyn FnOnce<(u32,), Output = u32> + '61)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '63)}, {built_in impl Sized for Global}], &core::ops::function::FnOnce::{vtable}<fn(u32) -> u32, (u32,)>>(move _15)
-    conditional_drop[drop_glue<'64, fn(u32) -> u32, Global>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}]] _15
+    _h = unsize_cast<Box<fn(u32) -> u32>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}], Box<(dyn FnOnce<(u32,), Output = u32> + '63)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '65)}, {built_in impl Sized for Global}], &core::ops::function::FnOnce::{vtable}<fn(u32) -> u32, (u32,)>>(move _15)
+    conditional_drop[drop_glue<'66, fn(u32) -> u32, Global>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}]] _15
     ↳⚡ storage_dead(_22)
         unwind_continue
     storage_dead(_16)
     storage_dead(_15)
     fake_read(_h)
-    set_type(typeof(_h) == Box<(dyn FnOnce<(u32,), Output = u32> + '65)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '67)}, {built_in impl Sized for Global}])
+    set_type(typeof(_h) == Box<(dyn FnOnce<(u32,), Output = u32> + '67)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '69)}, {built_in impl Sized for Global}])
     storage_live(_17)
     storage_live(_18)
     storage_live(_19)
@@ -521,7 +521,7 @@ fn main()
     // The same builtin impls appear as clause proofs in the call generics.
     _20 = cast<foo, fn(u32) -> u32>(const foo)
     _19 = wrap<fn(u32) -> u32>[{built_in impl Sized for fn(u32) -> u32}, {built_in impl Fn<(u32,)> for fn(u32) -> u32}](move _20)
-    ↳⚡ conditional_drop[drop_glue<'80, (dyn FnOnce<(u32,), Output = u32> + '76), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '76)}, {built_in impl Sized for Global}]] _h
+    ↳⚡ conditional_drop[drop_glue<'84, (dyn FnOnce<(u32,), Output = u32> + '79), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '79)}, {built_in impl Sized for Global}]] _h
         ↳⚡ storage_dead(_22)
             storage_dead(_25)
             storage_dead(_24)
@@ -533,14 +533,14 @@ fn main()
     storage_dead(_20)
     storage_live(_21)
     _21 = (const 3u32,)
-    _17 = call<'89, (u32,), (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '82), Global>[{built_in impl Sized for (u32,)}, {built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '84)}, {built_in impl Sized for Global}, {built_in impl Tuple for (u32,)}, Fn<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '87), (u32,)>](move _18, move _21)
-    ↳⚡ conditional_drop[drop_glue<'102, (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '98), Global>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '98)}, {built_in impl Sized for Global}]] _19
+    _17 = call<'94, (u32,), (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '86), Global>[{built_in impl Sized for (u32,)}, {built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '88)}, {built_in impl Sized for Global}, {built_in impl Tuple for (u32,)}, Fn<(dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '92), (u32,)>](move _18, move _21)
+    ↳⚡ conditional_drop[drop_glue<'109, (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '104), Global>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '104)}, {built_in impl Sized for Global}]] _19
         ↳⚡ storage_dead(_22)
             storage_dead(_25)
             storage_dead(_24)
             storage_dead(_23)
             unwind_terminate
-        conditional_drop[drop_glue<'80, (dyn FnOnce<(u32,), Output = u32> + '76), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '76)}, {built_in impl Sized for Global}]] _h
+        conditional_drop[drop_glue<'84, (dyn FnOnce<(u32,), Output = u32> + '79), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '79)}, {built_in impl Sized for Global}]] _h
         ↳⚡ storage_dead(_22)
             storage_dead(_25)
             storage_dead(_24)
@@ -550,8 +550,8 @@ fn main()
         unwind_continue
     storage_dead(_21)
     storage_dead(_18)
-    conditional_drop[drop_glue<'115, (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '111), Global>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '111)}, {built_in impl Sized for Global}]] _19
-    ↳⚡ conditional_drop[drop_glue<'80, (dyn FnOnce<(u32,), Output = u32> + '76), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '76)}, {built_in impl Sized for Global}]] _h
+    conditional_drop[drop_glue<'124, (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '119), Global>[{built_in impl MetaSized for (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '119)}, {built_in impl Sized for Global}]] _19
+    ↳⚡ conditional_drop[drop_glue<'84, (dyn FnOnce<(u32,), Output = u32> + '79), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '79)}, {built_in impl Sized for Global}]] _h
         ↳⚡ storage_dead(_22)
             storage_dead(_25)
             storage_dead(_24)
@@ -562,7 +562,7 @@ fn main()
     storage_dead(_19)
     storage_dead(_17)
     _0 = ()
-    conditional_drop[drop_glue<'128, (dyn FnOnce<(u32,), Output = u32> + '124), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '124)}, {built_in impl Sized for Global}]] _h
+    conditional_drop[drop_glue<'139, (dyn FnOnce<(u32,), Output = u32> + '134), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '134)}, {built_in impl Sized for Global}]] _h
     ↳⚡ storage_dead(_22)
         unwind_continue
     storage_dead(_h)

--- a/charon/tests/ui/dyn/fn-pointer-vtable-clause.rs
+++ b/charon/tests/ui/dyn/fn-pointer-vtable-clause.rs
@@ -1,0 +1,20 @@
+//@ charon-args=--include=core::ops::function
+
+fn foo(x: u32) -> u32 {
+    x
+}
+
+fn wrap<F: Fn(u32) -> u32 + 'static>(f: F) -> Box<dyn Fn(u32) -> u32> {
+    Box::new(f)
+}
+
+fn main() {
+    // These coercions translate the vtable instances for `fn(u32) -> u32: Fn*<(u32,)>`.
+    let f: &dyn Fn(u32) -> u32 = &(foo as fn(u32) -> u32);
+    let _ = f(1);
+    let g: &mut dyn FnMut(u32) -> u32 = &mut (foo as fn(u32) -> u32);
+    let _ = g(2);
+    let _h: Box<dyn FnOnce(u32) -> u32> = Box::new(foo as fn(u32) -> u32);
+    // The same builtin impls appear as clause proofs in the call generics.
+    let _ = wrap(foo as fn(u32) -> u32)(3);
+}

--- a/charon/tests/ui/dyn/fn-pointer-vtable.out
+++ b/charon/tests/ui/dyn/fn-pointer-vtable.out
@@ -1,34 +1,461 @@
-error: vtable shims for function pointers need monomorphized arguments, got `Args`
- --> /rustc/library/core/src/ops/function.rs:76:1
+# Final LLBC before serialization:
 
-note: the error occurred when translating `core::ops::function::Fn::{vtable_method}`, which is (transitively) used at the following location(s):
-  --> tests/ui/dyn/fn-pointer-vtable.rs:20:34
-   |
-20 |     let f: &dyn Fn(u32) -> u32 = &(foo as fn(u32) -> u32);
-   |                                  ------------------------
-error: Item `core::ops::function::Fn` caused errors; ignoring.
- --> /rustc/library/core/src/ops/function.rs:76:1
+opaque type core::marker::MetaSized::{vtable}
 
-error: vtable shims for function pointers need monomorphized arguments, got `Args`
- --> /rustc/library/core/src/ops/function.rs:163:1
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
 
-note: the error occurred when translating `core::ops::function::FnMut::{vtable_method}`, which is (transitively) used at the following location(s):
-  --> tests/ui/dyn/fn-pointer-vtable.rs:22:41
-   |
-22 |     let g: &mut dyn FnMut(u32) -> u32 = &mut (foo as fn(u32) -> u32);
-   |                                         ----------------------------
-error: Item `core::ops::function::FnMut` caused errors; ignoring.
- --> /rustc/library/core/src/ops/function.rs:163:1
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
 
-error: vtable shims for function pointers need monomorphized arguments, got `Args`
- --> /rustc/library/core/src/ops/function.rs:242:1
+struct () {}
 
-note: the error occurred when translating `core::ops::function::FnOnce::{vtable_method}`, which is (transitively) used at the following location(s):
-  --> tests/ui/dyn/fn-pointer-vtable.rs:25:43
-   |
-25 |     let _h: Box<dyn FnOnce(u32) -> u32> = Box::new(foo as fn(u32) -> u32);
-   |                                           -------------------------------
-error: Item `core::ops::function::FnOnce` caused errors; ignoring.
- --> /rustc/library/core/src/ops/function.rs:242:1
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
 
-ERROR Charon failed to translate this code (6 errors)
+// Full name: core::marker::Tuple
+#[fundamental]
+#[lang_item(Tuple)]
+pub trait Tuple<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct core::ops::function::FnOnce::{vtable}<Args, Ty0> {
+  size: usize,
+  align: usize,
+  drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Ty0>)),
+  method_call_once: extern "rust-call" fn((dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+// Full name: core::ops::function::FnOnce
+#[fundamental]
+#[lang_item(FnOnce)]
+pub trait FnOnce<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
+    type Output
+    fn call_once;
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
+}
+
+struct core::ops::function::FnMut::{vtable}<Args, Ty0> {
+  size: usize,
+  align: usize,
+  drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<Args, ImpliedClause1::Output = Ty0>)),
+  method_call_mut: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<Args, ImpliedClause1::Output = Ty0>), Args) -> Ty0,
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+  super_trait_1: &'static core::ops::function::FnOnce::{vtable}<Args, Ty0>,
+}
+
+// Full name: core::ops::function::FnMut
+#[fundamental]
+#[lang_item(FnMut)]
+pub trait FnMut<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    fn call_mut<'_0_1>;
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
+}
+
+struct core::ops::function::Fn::{vtable}<Args, Ty0> {
+  size: usize,
+  align: usize,
+  drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Ty0>)),
+  method_call: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Ty0>), Args) -> Ty0,
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+  super_trait_1: &'static core::ops::function::FnMut::{vtable}<Args, Ty0>,
+}
+
+// Full name: core::ops::function::Fn
+#[fundamental]
+#[lang_item(Fn)]
+pub trait Fn<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    fn call<'_0_1>;
+    vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
+}
+
+extern "rust-call" fn core::ops::function::Fn::{vtable_method}<Self, Args>(_1: &'_ (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output>), _2: Args) -> Self::ImpliedClause1::ImpliedClause1::Output
+{
+    let _0: Self::ImpliedClause1::ImpliedClause1::Output; // return
+    let _1: &'0 (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '1); // arg #1
+    let _2: Args; // arg #2
+    let _3: &'2 Self; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'4 (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '5), &'6 Self>(move _1)
+    _0 = Self::call<'9>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+unsafe fn core::ops::function::Fn::{vtable_drop_shim}<'_0, Self, Args>(dyn_self: &'_0 mut (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output>))
+where
+    TypeOutlives0: Args: '_0,
+    TypeOutlives1: Self::ImpliedClause1::ImpliedClause1::Output: '_0,
+    TypeOutlives2: Self: '_0,
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '0); // arg #1
+    let target_self: &'_0 mut Self; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '1), &'_0 mut Self>(move dyn_self)
+    drop[{built_in impl Destruct for Self}::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+fn core::ops::function::Fn::{vtable}<Self, Args>() -> core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
+{
+    let ret: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '1)); // anonymous local
+    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '2), Args) -> Self::ImpliedClause1::ImpliedClause1::Output; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<Self>
+    storage_live(align)
+    align = align_of<Self>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> core::ops::function::Fn::{vtable_drop_shim}<'0, Self, Args>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '1))>(const core::ops::function::Fn::{vtable_drop_shim}<'0, Self, Args>)
+    storage_live(_4)
+    _4 = cast<for<'_0_1> core::ops::function::Fn::{vtable_method}<Self, Args>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<Args, ImpliedClause1::ImpliedClause1::Output = Self::ImpliedClause1::ImpliedClause1::Output> + '2), Args) -> Self::ImpliedClause1::ImpliedClause1::Output>(const core::ops::function::Fn::{vtable_method}<Self, Args>)
+    ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move _3, method_call: move _4, super_trait_0: const &vtable_of(Self::ImpliedClause0), super_trait_1: const &vtable_of(Self::ImpliedClause1) }
+    return
+}
+
+static core::ops::function::Fn::{vtable}<Self, Args>: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output> = core::ops::function::Fn::{vtable}<Self, Args>()
+
+extern "rust-call" fn core::ops::function::FnMut::{vtable_method}<Self, Args>(_1: &'_ mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output>), _2: Args) -> Self::ImpliedClause1::Output
+{
+    let _0: Self::ImpliedClause1::Output; // return
+    let _1: &'0 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '1); // arg #1
+    let _2: Args; // arg #2
+    let _3: &'2 mut Self; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'4 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '5), &'6 mut Self>(move _1)
+    _0 = Self::call_mut<'9>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+unsafe fn core::ops::function::FnMut::{vtable_drop_shim}<'_0, Self, Args>(dyn_self: &'_0 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output>))
+where
+    TypeOutlives0: Args: '_0,
+    TypeOutlives1: Self::ImpliedClause1::Output: '_0,
+    TypeOutlives2: Self: '_0,
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '0); // arg #1
+    let target_self: &'_0 mut Self; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '1), &'_0 mut Self>(move dyn_self)
+    drop[{built_in impl Destruct for Self}::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+fn core::ops::function::FnMut::{vtable}<Self, Args>() -> core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
+{
+    let ret: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '1)); // anonymous local
+    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '2), Args) -> Self::ImpliedClause1::Output; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<Self>
+    storage_live(align)
+    align = align_of<Self>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> core::ops::function::FnMut::{vtable_drop_shim}<'0, Self, Args>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '1))>(const core::ops::function::FnMut::{vtable_drop_shim}<'0, Self, Args>)
+    storage_live(_4)
+    _4 = cast<for<'_0_1> core::ops::function::FnMut::{vtable_method}<Self, Args>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<Args, ImpliedClause1::Output = Self::ImpliedClause1::Output> + '2), Args) -> Self::ImpliedClause1::Output>(const core::ops::function::FnMut::{vtable_method}<Self, Args>)
+    ret = core::ops::function::FnMut::{vtable} { size: move size, align: move align, drop: move _3, method_call_mut: move _4, super_trait_0: const &vtable_of(Self::ImpliedClause0), super_trait_1: const &vtable_of(Self::ImpliedClause1) }
+    return
+}
+
+static core::ops::function::FnMut::{vtable}<Self, Args>: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output> = core::ops::function::FnMut::{vtable}<Self, Args>()
+
+extern "rust-call" fn core::ops::function::FnOnce::{vtable_method}<Self, Args>(_1: (dyn FnOnce<Args, Output = Self::Output>), _2: Args) -> Self::Output
+{
+    let _0: Self::Output; // return
+    let _1: (dyn FnOnce<Args, Output = Self::Output> + '0); // arg #1
+    let _2: Args; // arg #2
+    let _3: Self; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<(dyn FnOnce<Args, Output = Self::Output> + '1), Self>(move _1)
+    _0 = Self::call_once(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+unsafe fn core::ops::function::FnOnce::{vtable_drop_shim}<'_0, Self, Args>(dyn_self: &'_0 mut (dyn FnOnce<Args, Output = Self::Output>))
+where
+    TypeOutlives0: Args: '_0,
+    TypeOutlives1: Self::Output: '_0,
+    TypeOutlives2: Self: '_0,
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnOnce<Args, Output = Self::Output> + '0); // arg #1
+    let target_self: &'_0 mut Self; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnOnce<Args, Output = Self::Output> + '1), &'_0 mut Self>(move dyn_self)
+    drop[{built_in impl Destruct for Self}::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+fn core::ops::function::FnOnce::{vtable}<Self, Args>() -> core::ops::function::FnOnce::{vtable}<Args, Self::Output>
+{
+    let ret: core::ops::function::FnOnce::{vtable}<Args, Self::Output>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Self::Output> + '1)); // anonymous local
+    let _4: extern "rust-call" fn((dyn FnOnce<Args, Output = Self::Output> + '2), Args) -> Self::Output; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<Self>
+    storage_live(align)
+    align = align_of<Self>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> core::ops::function::FnOnce::{vtable_drop_shim}<'0, Self, Args>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Self::Output> + '1))>(const core::ops::function::FnOnce::{vtable_drop_shim}<'0, Self, Args>)
+    storage_live(_4)
+    _4 = cast<core::ops::function::FnOnce::{vtable_method}<Self, Args>, extern "rust-call" fn((dyn FnOnce<Args, Output = Self::Output> + '2), Args) -> Self::Output>(const core::ops::function::FnOnce::{vtable_method}<Self, Args>)
+    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: const &vtable_of(Self::ImpliedClause0) }
+    return
+}
+
+static core::ops::function::FnOnce::{vtable}<Self, Args>: core::ops::function::FnOnce::{vtable}<Args, Self::Output> = core::ops::function::FnOnce::{vtable}<Self, Args>()
+
+// Full name: alloc::alloc::Global
+#[lang_item(GlobalAlloc)]
+pub struct Global {}
+
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TypeOutlives0: T: '_0,
+    TypeOutlives1: A: '_0,
+= <opaque>
+
+// Full name: alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
+#[track_caller]
+#[diagnostic_item("box_new")]
+pub fn new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+where
+    TraitClause0: (T: Sized),
+= <opaque>
+
+struct (_,)<A> {
+  _0: A,
+}
+
+// Full name: test_crate::foo
+fn foo(x: u32) -> u32
+{
+    let _0: u32; // return
+    let x: u32; // arg #1
+
+    storage_live(_0)
+    _0 = copy x
+    storage_dead(x)
+    return
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let f: &'3 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4); // local
+    let _2: &'6 fn(u32) -> u32; // anonymous local
+    let _3: &'7 fn(u32) -> u32; // anonymous local
+    let _4: u32; // anonymous local
+    let _5: &'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9); // anonymous local
+    let _6: (u32,); // anonymous local
+    let g: &'13 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '14); // local
+    let _8: &'16 mut fn(u32) -> u32; // anonymous local
+    let _9: &'17 mut fn(u32) -> u32; // anonymous local
+    let _10: fn(u32) -> u32; // anonymous local
+    let _11: u32; // anonymous local
+    let _12: &'18 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '19); // anonymous local
+    let _13: (u32,); // anonymous local
+    let _h: Box<(dyn FnOnce<(u32,), Output = u32> + '25)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '27)}, {built_in impl Sized for Global}]; // local
+    let _15: Box<fn(u32) -> u32>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}]; // anonymous local
+    let _16: fn(u32) -> u32; // anonymous local
+    let _17: &'28 fn(u32) -> u32; // anonymous local
+    let _18: &'29 fn(u32) -> u32; // anonymous local
+    let _19: &'66 fn(u32) -> u32; // anonymous local
+    let _20: fn(u32) -> u32; // anonymous local
+
+    storage_live(_18)
+    storage_live(_19)
+    storage_live(_20)
+    _20 = cast<foo, fn(u32) -> u32>(const foo)
+    _19 = &_20
+    _18 = move _19
+    storage_live(_0)
+    storage_live(_17)
+    _0 = ()
+    storage_live(f)
+    storage_live(_2)
+    storage_live(_3)
+    _17 = move _18
+    _3 = &(*_17)
+    _2 = &(*_3)
+    f = unsize_cast<&'6 fn(u32) -> u32, &'30 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '31), &core::ops::function::Fn::{vtable}<fn(u32) -> u32, (u32,)>>(move _2)
+    storage_dead(_2)
+    fake_read(f)
+    set_type(typeof(f) == &'32 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '33))
+    storage_dead(_3)
+    storage_live(_4)
+    storage_live(_5)
+    _5 = &(*f) with_metadata(copy f.metadata)
+    storage_live(_6)
+    _6 = (const 1u32,)
+    _4 = (copy (*_5.metadata).method_call)(move _5, move _6)
+    ↳⚡ storage_dead(_17)
+        unwind_continue
+    storage_dead(_6)
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_live(g)
+    storage_live(_8)
+    storage_live(_9)
+    storage_live(_10)
+    _10 = cast<foo, fn(u32) -> u32>(const foo)
+    _9 = &mut _10
+    _8 = &mut (*_9)
+    g = unsize_cast<&'16 mut fn(u32) -> u32, &'38 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '39), &core::ops::function::FnMut::{vtable}<fn(u32) -> u32, (u32,)>>(move _8)
+    storage_dead(_8)
+    fake_read(g)
+    set_type(typeof(g) == &'40 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '41))
+    storage_dead(_9)
+    storage_live(_11)
+    storage_live(_12)
+    _12 = &mut (*g) with_metadata(copy g.metadata)
+    storage_live(_13)
+    _13 = (const 2u32,)
+    _11 = (copy (*_12.metadata).method_call_mut)(move _12, move _13)
+    ↳⚡ storage_dead(_17)
+        unwind_continue
+    storage_dead(_13)
+    storage_dead(_12)
+    storage_dead(_11)
+    storage_live(_h)
+    storage_live(_15)
+    storage_live(_16)
+    // Built but not called: calling a by-value `dyn` receiver is a separate issue.
+    _16 = cast<foo, fn(u32) -> u32>(const foo)
+    _15 = new<fn(u32) -> u32>[{built_in impl Sized for fn(u32) -> u32}](move _16)
+    ↳⚡ storage_dead(_17)
+        unwind_continue
+    _h = unsize_cast<Box<fn(u32) -> u32>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}], Box<(dyn FnOnce<(u32,), Output = u32> + '46)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '48)}, {built_in impl Sized for Global}], &core::ops::function::FnOnce::{vtable}<fn(u32) -> u32, (u32,)>>(move _15)
+    conditional_drop[drop_glue<'49, fn(u32) -> u32, Global>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}]] _15
+    ↳⚡ storage_dead(_17)
+        unwind_continue
+    storage_dead(_16)
+    storage_dead(_15)
+    fake_read(_h)
+    set_type(typeof(_h) == Box<(dyn FnOnce<(u32,), Output = u32> + '50)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '52)}, {built_in impl Sized for Global}])
+    _0 = ()
+    conditional_drop[drop_glue<'65, (dyn FnOnce<(u32,), Output = u32> + '61), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '61)}, {built_in impl Sized for Global}]] _h
+    ↳⚡ storage_dead(_17)
+        unwind_continue
+    storage_dead(_h)
+    storage_dead(_10)
+    storage_dead(g)
+    storage_dead(f)
+    storage_dead(_17)
+    storage_dead(_20)
+    storage_dead(_19)
+    storage_dead(_18)
+    return
+}
+
+
+

--- a/charon/tests/ui/dyn/fn-pointer-vtable.out
+++ b/charon/tests/ui/dyn/fn-pointer-vtable.out
@@ -1,0 +1,34 @@
+error: vtable shims for function pointers need monomorphized arguments, got `Args`
+ --> /rustc/library/core/src/ops/function.rs:76:1
+
+note: the error occurred when translating `core::ops::function::Fn::{vtable_method}`, which is (transitively) used at the following location(s):
+  --> tests/ui/dyn/fn-pointer-vtable.rs:20:34
+   |
+20 |     let f: &dyn Fn(u32) -> u32 = &(foo as fn(u32) -> u32);
+   |                                  ------------------------
+error: Item `core::ops::function::Fn` caused errors; ignoring.
+ --> /rustc/library/core/src/ops/function.rs:76:1
+
+error: vtable shims for function pointers need monomorphized arguments, got `Args`
+ --> /rustc/library/core/src/ops/function.rs:163:1
+
+note: the error occurred when translating `core::ops::function::FnMut::{vtable_method}`, which is (transitively) used at the following location(s):
+  --> tests/ui/dyn/fn-pointer-vtable.rs:22:41
+   |
+22 |     let g: &mut dyn FnMut(u32) -> u32 = &mut (foo as fn(u32) -> u32);
+   |                                         ----------------------------
+error: Item `core::ops::function::FnMut` caused errors; ignoring.
+ --> /rustc/library/core/src/ops/function.rs:163:1
+
+error: vtable shims for function pointers need monomorphized arguments, got `Args`
+ --> /rustc/library/core/src/ops/function.rs:242:1
+
+note: the error occurred when translating `core::ops::function::FnOnce::{vtable_method}`, which is (transitively) used at the following location(s):
+  --> tests/ui/dyn/fn-pointer-vtable.rs:25:43
+   |
+25 |     let _h: Box<dyn FnOnce(u32) -> u32> = Box::new(foo as fn(u32) -> u32);
+   |                                           -------------------------------
+error: Item `core::ops::function::FnOnce` caused errors; ignoring.
+ --> /rustc/library/core/src/ops/function.rs:242:1
+
+ERROR Charon failed to translate this code (6 errors)

--- a/charon/tests/ui/dyn/fn-pointer-vtable.out
+++ b/charon/tests/ui/dyn/fn-pointer-vtable.out
@@ -39,7 +39,7 @@ struct core::ops::function::FnOnce::{vtable}<Args, Ty0> {
   size: usize,
   align: usize,
   drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Ty0>)),
-  method_call_once: extern "rust-call" fn((dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
+  method_call_once: extern "rust-call" fn(*mut (dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
   super_trait_0: &'static core::marker::MetaSized::{vtable},
 }
 
@@ -235,17 +235,17 @@ fn core::ops::function::FnMut::{vtable}<Self, Args>() -> core::ops::function::Fn
 
 static core::ops::function::FnMut::{vtable}<Self, Args>: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output> = core::ops::function::FnMut::{vtable}<Self, Args>()
 
-extern "rust-call" fn core::ops::function::FnOnce::{vtable_method}<Self, Args>(_1: (dyn FnOnce<Args, Output = Self::Output>), _2: Args) -> Self::Output
+extern "rust-call" fn core::ops::function::FnOnce::{vtable_method}<Self, Args>(_1: *mut (dyn FnOnce<Args, Output = Self::Output>), _2: Args) -> Self::Output
 {
     let _0: Self::Output; // return
-    let _1: (dyn FnOnce<Args, Output = Self::Output> + '0); // arg #1
+    let _1: *mut (dyn FnOnce<Args, Output = Self::Output> + '0); // arg #1
     let _2: Args; // arg #2
-    let _3: Self; // anonymous local
+    let _3: *mut Self; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
-    _3 = concretize<(dyn FnOnce<Args, Output = Self::Output> + '1), Self>(move _1)
-    _0 = Self::call_once(move _3, move _2)
+    _3 = concretize<*mut (dyn FnOnce<Args, Output = Self::Output> + '1), *mut Self>(move _1)
+    _0 = Self::call_once(move (*_3), move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -285,7 +285,7 @@ fn core::ops::function::FnOnce::{vtable}<Self, Args>() -> core::ops::function::F
     let size: usize; // local
     let align: usize; // local
     let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Self::Output> + '1)); // anonymous local
-    let _4: extern "rust-call" fn((dyn FnOnce<Args, Output = Self::Output> + '2), Args) -> Self::Output; // anonymous local
+    let _4: extern "rust-call" fn(*mut (dyn FnOnce<Args, Output = Self::Output> + '2), Args) -> Self::Output; // anonymous local
 
     storage_live(ret)
     storage_live(size)
@@ -295,7 +295,7 @@ fn core::ops::function::FnOnce::{vtable}<Self, Args>() -> core::ops::function::F
     storage_live(_3)
     _3 = cast<for<'_0_1> core::ops::function::FnOnce::{vtable_drop_shim}<'0, Self, Args>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Self::Output> + '1))>(const core::ops::function::FnOnce::{vtable_drop_shim}<'0, Self, Args>)
     storage_live(_4)
-    _4 = cast<core::ops::function::FnOnce::{vtable_method}<Self, Args>, extern "rust-call" fn((dyn FnOnce<Args, Output = Self::Output> + '2), Args) -> Self::Output>(const core::ops::function::FnOnce::{vtable_method}<Self, Args>)
+    _4 = cast<core::ops::function::FnOnce::{vtable_method}<Self, Args>, extern "rust-call" fn(*mut (dyn FnOnce<Args, Output = Self::Output> + '2), Args) -> Self::Output>(const core::ops::function::FnOnce::{vtable_method}<Self, Args>)
     ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: const &vtable_of(Self::ImpliedClause0) }
     return
 }

--- a/charon/tests/ui/dyn/fn-pointer-vtable.out
+++ b/charon/tests/ui/dyn/fn-pointer-vtable.out
@@ -347,6 +347,18 @@ fn foo(x: u32) -> u32
     return
 }
 
+// Full name: test_crate::bar
+fn bar<'_0>(x: &'_0 u32) -> u32
+{
+    let _0: u32; // return
+    let x: &'1 u32; // arg #1
+
+    storage_live(_0)
+    _0 = copy (*x)
+    storage_dead(x)
+    return
+}
+
 // Full name: test_crate::main
 fn main()
 {
@@ -364,33 +376,51 @@ fn main()
     let _11: u32; // anonymous local
     let _12: &'18 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '19); // anonymous local
     let _13: (u32,); // anonymous local
-    let _h: Box<(dyn FnOnce<(u32,), Output = u32> + '25)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '27)}, {built_in impl Sized for Global}]; // local
+    let _h: Box<(dyn FnOnce<(u32,), Output = u32> + '26)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '28)}, {built_in impl Sized for Global}]; // local
     let _15: Box<fn(u32) -> u32>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}]; // anonymous local
     let _16: fn(u32) -> u32; // anonymous local
-    let _17: &'28 fn(u32) -> u32; // anonymous local
-    let _18: &'29 fn(u32) -> u32; // anonymous local
-    let _19: &'66 fn(u32) -> u32; // anonymous local
-    let _20: fn(u32) -> u32; // anonymous local
+    let h: &'36 (dyn for<'a> Fn<(&'a u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '37); // local
+    let _18: &'40 fn<'_0_1>(&'_0_1 u32) -> u32; // anonymous local
+    let _19: &'41 fn<'_0_1>(&'_0_1 u32) -> u32; // anonymous local
+    let _20: u32; // anonymous local
+    let _21: &'42 (dyn for<'a> Fn<(&'a u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '43); // anonymous local
+    let _22: (&'47 u32,); // anonymous local
+    let _23: &'48 u32; // anonymous local
+    let _24: &'49 u32; // anonymous local
+    let _25: &'50 u32; // anonymous local
+    let _26: &'51 fn<'_0_1>(&'_0_1 u32) -> u32; // anonymous local
+    let _27: &'52 fn(u32) -> u32; // anonymous local
+    let _28: &'53 fn(u32) -> u32; // anonymous local
+    let _29: &'77 fn<'_0_1>(&'_0_1 u32) -> u32; // anonymous local
+    let _30: &'155 u32; // anonymous local
+    let _31: &'203 fn(u32) -> u32; // anonymous local
+    let _32: fn(u32) -> u32; // anonymous local
+    let _33: &'204 fn<'_0_1>(&'_0_1 u32) -> u32; // anonymous local
+    let _34: fn<'_0_1>(&'_0_1 u32) -> u32; // anonymous local
+    let _35: &'208 u32; // anonymous local
+    let _36: u32; // anonymous local
 
-    storage_live(_18)
-    storage_live(_19)
-    storage_live(_20)
-    _20 = cast<foo, fn(u32) -> u32>(const foo)
-    _19 = &_20
-    _18 = move _19
+    storage_live(_28)
+    storage_live(_31)
+    storage_live(_32)
+    _32 = cast<foo, fn(u32) -> u32>(const foo)
+    _31 = &_32
+    _28 = move _31
     storage_live(_0)
-    storage_live(_17)
+    storage_live(_25)
+    storage_live(_26)
+    storage_live(_27)
     _0 = ()
     storage_live(f)
     storage_live(_2)
     storage_live(_3)
-    _17 = move _18
-    _3 = &(*_17)
+    _27 = move _28
+    _3 = &(*_27)
     _2 = &(*_3)
-    f = unsize_cast<&'6 fn(u32) -> u32, &'30 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '31), &core::ops::function::Fn::{vtable}<fn(u32) -> u32, (u32,)>>(move _2)
+    f = unsize_cast<&'6 fn(u32) -> u32, &'54 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '55), &core::ops::function::Fn::{vtable}<fn(u32) -> u32, (u32,)>>(move _2)
     storage_dead(_2)
     fake_read(f)
-    set_type(typeof(f) == &'32 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '33))
+    set_type(typeof(f) == &'56 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '57))
     storage_dead(_3)
     storage_live(_4)
     storage_live(_5)
@@ -398,7 +428,9 @@ fn main()
     storage_live(_6)
     _6 = (const 1u32,)
     _4 = (copy (*_5.metadata).method_call)(move _5, move _6)
-    ↳⚡ storage_dead(_17)
+    ↳⚡ storage_dead(_27)
+        storage_dead(_26)
+        storage_dead(_25)
         unwind_continue
     storage_dead(_6)
     storage_dead(_5)
@@ -410,10 +442,10 @@ fn main()
     _10 = cast<foo, fn(u32) -> u32>(const foo)
     _9 = &mut _10
     _8 = &mut (*_9)
-    g = unsize_cast<&'16 mut fn(u32) -> u32, &'38 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '39), &core::ops::function::FnMut::{vtable}<fn(u32) -> u32, (u32,)>>(move _8)
+    g = unsize_cast<&'16 mut fn(u32) -> u32, &'62 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '63), &core::ops::function::FnMut::{vtable}<fn(u32) -> u32, (u32,)>>(move _8)
     storage_dead(_8)
     fake_read(g)
-    set_type(typeof(g) == &'40 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '41))
+    set_type(typeof(g) == &'64 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '65))
     storage_dead(_9)
     storage_live(_11)
     storage_live(_12)
@@ -421,7 +453,9 @@ fn main()
     storage_live(_13)
     _13 = (const 2u32,)
     _11 = (copy (*_12.metadata).method_call_mut)(move _12, move _13)
-    ↳⚡ storage_dead(_17)
+    ↳⚡ storage_dead(_27)
+        storage_dead(_26)
+        storage_dead(_25)
         unwind_continue
     storage_dead(_13)
     storage_dead(_12)
@@ -432,28 +466,101 @@ fn main()
     // Built but not called: calling a by-value `dyn` receiver is a separate issue.
     _16 = cast<foo, fn(u32) -> u32>(const foo)
     _15 = new<fn(u32) -> u32>[{built_in impl Sized for fn(u32) -> u32}](move _16)
-    ↳⚡ storage_dead(_17)
+    ↳⚡ storage_dead(_27)
+        storage_dead(_26)
+        storage_dead(_25)
         unwind_continue
-    _h = unsize_cast<Box<fn(u32) -> u32>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}], Box<(dyn FnOnce<(u32,), Output = u32> + '46)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '48)}, {built_in impl Sized for Global}], &core::ops::function::FnOnce::{vtable}<fn(u32) -> u32, (u32,)>>(move _15)
-    conditional_drop[drop_glue<'49, fn(u32) -> u32, Global>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}]] _15
-    ↳⚡ storage_dead(_17)
+    _h = unsize_cast<Box<fn(u32) -> u32>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}], Box<(dyn FnOnce<(u32,), Output = u32> + '70)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '72)}, {built_in impl Sized for Global}], &core::ops::function::FnOnce::{vtable}<fn(u32) -> u32, (u32,)>>(move _15)
+    conditional_drop[drop_glue<'73, fn(u32) -> u32, Global>[{built_in impl MetaSized for fn(u32) -> u32}, {built_in impl Sized for Global}]] _15
+    ↳⚡ storage_dead(_27)
+        storage_dead(_26)
+        storage_dead(_25)
         unwind_continue
+    storage_live(_30)
+    storage_live(_35)
+    storage_live(_36)
+    // A higher-ranked fn pointer.
+    _36 = const 3u32
+    _35 = &_36
+    _30 = move _35
+    storage_live(_29)
+    storage_live(_33)
+    storage_live(_34)
+    _34 = cast<for<'_0_1> bar<'_0_1>, fn<'_0_1>(&'_0_1 u32) -> u32>(const bar<'207>)
+    _33 = &_34
+    _29 = move _33
     storage_dead(_16)
     storage_dead(_15)
     fake_read(_h)
-    set_type(typeof(_h) == Box<(dyn FnOnce<(u32,), Output = u32> + '50)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '52)}, {built_in impl Sized for Global}])
+    set_type(typeof(_h) == Box<(dyn FnOnce<(u32,), Output = u32> + '74)>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '76)}, {built_in impl Sized for Global}])
+    storage_live(h)
+    storage_live(_18)
+    storage_live(_19)
+    _26 = move _29
+    _19 = &(*_26)
+    _18 = &(*_19)
+    h = unsize_cast<&'40 fn<'_0_1>(&'_0_1 u32) -> u32, &'78 (dyn for<'a> Fn<(&'a u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '79), &core::ops::function::Fn::{vtable}<fn<'_0_1>(&'_0_1 u32) -> u32, (&'149 u32,)>>(move _18)
+    storage_dead(_18)
+    fake_read(h)
+    set_type(typeof(h) == &'150 (dyn for<'a> Fn<(&'a u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '151))
+    storage_dead(_19)
+    storage_live(_20)
+    storage_live(_21)
+    _21 = &(*h) with_metadata(copy h.metadata)
+    storage_live(_22)
+    storage_live(_23)
+    storage_live(_24)
+    _25 = move _30
+    _24 = &(*_25)
+    _23 = &(*_24)
+    _22 = (move _23,)
+    _20 = (copy (*_21.metadata).method_call)(move _21, move _22)
+    ↳⚡ conditional_drop[drop_glue<'187, (dyn FnOnce<(u32,), Output = u32> + '182), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '182)}, {built_in impl Sized for Global}]] _h
+        ↳⚡ storage_dead(_27)
+            storage_dead(_26)
+            storage_dead(_25)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
+            storage_dead(_31)
+            storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_28)
+            unwind_terminate
+        storage_dead(_27)
+        storage_dead(_26)
+        storage_dead(_25)
+        unwind_continue
+    storage_dead(_23)
+    storage_dead(_22)
+    storage_dead(_21)
+    storage_dead(_24)
+    storage_dead(_20)
     _0 = ()
-    conditional_drop[drop_glue<'65, (dyn FnOnce<(u32,), Output = u32> + '61), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '61)}, {built_in impl Sized for Global}]] _h
-    ↳⚡ storage_dead(_17)
+    storage_dead(h)
+    conditional_drop[drop_glue<'202, (dyn FnOnce<(u32,), Output = u32> + '197), Global>[{built_in impl MetaSized for (dyn FnOnce<(u32,), Output = u32> + '197)}, {built_in impl Sized for Global}]] _h
+    ↳⚡ storage_dead(_27)
+        storage_dead(_26)
+        storage_dead(_25)
         unwind_continue
     storage_dead(_h)
     storage_dead(_10)
     storage_dead(g)
     storage_dead(f)
-    storage_dead(_17)
-    storage_dead(_20)
-    storage_dead(_19)
-    storage_dead(_18)
+    storage_dead(_27)
+    storage_dead(_26)
+    storage_dead(_25)
+    storage_dead(_36)
+    storage_dead(_35)
+    storage_dead(_34)
+    storage_dead(_33)
+    storage_dead(_32)
+    storage_dead(_31)
+    storage_dead(_30)
+    storage_dead(_29)
+    storage_dead(_28)
     return
 }
 

--- a/charon/tests/ui/dyn/fn-pointer-vtable.rs
+++ b/charon/tests/ui/dyn/fn-pointer-vtable.rs
@@ -1,0 +1,26 @@
+//@ known-failure
+//@ charon-args=--include=core::ops::function
+//! Polymorphic counterpart of `mono-fn-pointer-vtable.rs`: function *pointers* coerced to
+//! `dyn Fn`/`dyn FnMut`/`dyn FnOnce`.
+//!
+//! Unlike a closure or fn item, a `fn(..)` type has no item to hang its builtin `Fn*` impl off,
+//! so we key the vtable method shim on the `Fn*` trait itself. In poly mode items are keyed by
+//! `DefId` alone, so we only get one shim for the whole trait, with `Self` and `Args` still type
+//! variables: we can neither see that the receiver is a function pointer nor untuple `Args` to
+//! build the call. Supporting this would need the shim to be keyed on the trait ref rather than
+//! the trait, so `--monomorphize` is required for now.
+//!
+//! `issue-1264-closure-vtable-poly.rs` covers the closure case, which works in poly mode because
+//! the shim hangs off the closure, where both are concrete.
+fn foo(x: u32) -> u32 {
+    x
+}
+
+fn main() {
+    let f: &dyn Fn(u32) -> u32 = &(foo as fn(u32) -> u32);
+    let _ = f(1);
+    let g: &mut dyn FnMut(u32) -> u32 = &mut (foo as fn(u32) -> u32);
+    let _ = g(2);
+    // Built but not called: calling a by-value `dyn` receiver is a separate issue.
+    let _h: Box<dyn FnOnce(u32) -> u32> = Box::new(foo as fn(u32) -> u32);
+}

--- a/charon/tests/ui/dyn/fn-pointer-vtable.rs
+++ b/charon/tests/ui/dyn/fn-pointer-vtable.rs
@@ -4,6 +4,10 @@ fn foo(x: u32) -> u32 {
     x
 }
 
+fn bar(x: &u32) -> u32 {
+    *x
+}
+
 fn main() {
     let f: &dyn Fn(u32) -> u32 = &(foo as fn(u32) -> u32);
     let _ = f(1);
@@ -11,4 +15,7 @@ fn main() {
     let _ = g(2);
     // Built but not called: calling a by-value `dyn` receiver is a separate issue.
     let _h: Box<dyn FnOnce(u32) -> u32> = Box::new(foo as fn(u32) -> u32);
+    // A higher-ranked fn pointer.
+    let h: &dyn for<'a> Fn(&'a u32) -> u32 = &(bar as fn(&u32) -> u32);
+    let _ = h(&3);
 }

--- a/charon/tests/ui/dyn/fn-pointer-vtable.rs
+++ b/charon/tests/ui/dyn/fn-pointer-vtable.rs
@@ -1,16 +1,5 @@
 //@ charon-args=--include=core::ops::function
-//! Polymorphic counterpart of `mono-fn-pointer-vtable.rs`: function *pointers* coerced to
-//! `dyn Fn`/`dyn FnMut`/`dyn FnOnce`.
-//!
-//! Unlike a closure or fn item, a `fn(..)` type has no item to hang its builtin `Fn*` impl off,
-//! so we key the vtable method shim on the `Fn*` trait itself. In poly mode items are keyed by
-//! `DefId` alone, so we only get one shim for the whole trait, with `Self` and `Args` still type
-//! variables: we cannot untuple `Args` to call the function pointer directly, so the shim instead
-//! forwards to `<Self as Fn*<Args>>::call*` through the `Self: Fn*<Args>` clause, which resolves
-//! to the builtin fn-pointer impl at instantiation time.
-//!
-//! `issue-1264-closure-vtable-poly.rs` covers the closure case, where the shim hangs off the
-//! closure and both `Self` and `Args` are concrete.
+
 fn foo(x: u32) -> u32 {
     x
 }

--- a/charon/tests/ui/dyn/fn-pointer-vtable.rs
+++ b/charon/tests/ui/dyn/fn-pointer-vtable.rs
@@ -1,4 +1,3 @@
-//@ known-failure
 //@ charon-args=--include=core::ops::function
 //! Polymorphic counterpart of `mono-fn-pointer-vtable.rs`: function *pointers* coerced to
 //! `dyn Fn`/`dyn FnMut`/`dyn FnOnce`.
@@ -6,12 +5,12 @@
 //! Unlike a closure or fn item, a `fn(..)` type has no item to hang its builtin `Fn*` impl off,
 //! so we key the vtable method shim on the `Fn*` trait itself. In poly mode items are keyed by
 //! `DefId` alone, so we only get one shim for the whole trait, with `Self` and `Args` still type
-//! variables: we can neither see that the receiver is a function pointer nor untuple `Args` to
-//! build the call. Supporting this would need the shim to be keyed on the trait ref rather than
-//! the trait, so `--monomorphize` is required for now.
+//! variables: we cannot untuple `Args` to call the function pointer directly, so the shim instead
+//! forwards to `<Self as Fn*<Args>>::call*` through the `Self: Fn*<Args>` clause, which resolves
+//! to the builtin fn-pointer impl at instantiation time.
 //!
-//! `issue-1264-closure-vtable-poly.rs` covers the closure case, which works in poly mode because
-//! the shim hangs off the closure, where both are concrete.
+//! `issue-1264-closure-vtable-poly.rs` covers the closure case, where the shim hangs off the
+//! closure and both `Self` and `Args` are concrete.
 fn foo(x: u32) -> u32 {
     x
 }

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.out
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.out
@@ -40,6 +40,21 @@ pub trait Tuple<Self>
     non-dyn-compatible
 }
 
+// Full name: core::ops::drop::Drop
+#[lang_item(Drop)]
+pub trait Drop<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    fn drop<'_0_1> = core::ops::drop::Drop::drop<'_0_1, Self>[Self]
+    vtable: core::ops::drop::Drop::{vtable}
+}
+
+pub fn core::ops::drop::Drop::drop<'_0, Self>(_1: &'_0 mut Self)
+where
+    TraitClause0: (Self: Drop),
+    TypeOutlives0: Self: '_0,
+= <opaque>
+
 struct core::ops::function::FnOnce::{vtable}<Args, Ty0> {
   size: usize,
   align: usize,
@@ -106,6 +121,35 @@ pub trait Fn<Self, Args>
     vtable: core::ops::function::Fn::{vtable}<Args, Self::ImpliedClause1::ImpliedClause1::Output>
 }
 
+// Full name: alloc::alloc::Global
+#[lang_item(GlobalAlloc)]
+pub struct Global {}
+
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TypeOutlives0: T: '_0,
+    TypeOutlives1: A: '_0,
+= <opaque>
+
+// Full name: alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
+#[track_caller]
+#[diagnostic_item("box_new")]
+pub fn new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+where
+    TraitClause0: (T: Sized),
+= <opaque>
+
 struct (_,)<A> {
   _0: A,
 }
@@ -118,14 +162,400 @@ where
   _1: B,
 }
 
-// Full name: test_crate::main::{closure}
-struct {closure} {}
+// Full name: test_crate::Droppable
+struct Droppable {
+  _0: u32,
+}
 
-// Full name: test_crate::main::{closure}::{impl Destruct for {closure}}::drop_glue
-unsafe fn drop_glue<'_0>(_1: &'_0 mut {closure})
+// Full name: test_crate::{impl Drop for Droppable}::drop
+pub fn impl_Drop_for_Droppable::drop<'_0>(self: &'_0 mut Droppable)
 {
     let _0: (); // return
-    let _1: &'1 mut {closure}; // arg #1
+    let self: &'1 mut Droppable; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::Droppable::{impl Destruct for Droppable}::drop_glue
+unsafe fn impl_Destruct_for_Droppable::drop_glue<'_0>(_1: &'_0 mut Droppable)
+{
+    let _0: (); // return
+    let _1: &'1 mut Droppable; // arg #1
+    let _2: &'2 mut Droppable; // anonymous local
+    let _3: (); // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    storage_live(_3)
+    _0 = ()
+    _2 = &mut (*_1)
+    _3 = impl_Drop_for_Droppable::drop<'4>(move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::Droppable::{impl Destruct for Droppable}
+impl "impl_Destruct_for_Droppable" Destruct for Droppable {
+    fn drop_glue<'_0_1> = impl_Destruct_for_Droppable::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl Drop for Droppable}
+impl "impl_Drop_for_Droppable" Drop for Droppable {
+    proof ImpliedClause0: (Droppable: MetaSized) = {built_in impl MetaSized for Droppable}
+    fn drop<'_0_1> = impl_Drop_for_Droppable::drop<'_0_1>
+    vtable: impl_Drop_for_Droppable::{vtable}
+}
+
+struct test_crate::wrap::{closure}<T>
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'static,
+{
+  _0: T,
+}
+
+// Full name: test_crate::wrap::{closure}::{impl Destruct for test_crate::wrap::{closure}<T>[TraitClause0]}::drop_glue
+unsafe fn {impl Destruct for test_crate::wrap::{closure}<T>[TraitClause0]}::drop_glue<'_0, T>(_1: &'_0 mut test_crate::wrap::{closure}<T>[TraitClause0])
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'static,
+    TypeOutlives1: T: '_0,
+{
+    let _0: (); // return
+    let _1: &'1 mut test_crate::wrap::{closure}<T>[TraitClause0]; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    drop[{built_in impl Destruct for T}::drop_glue<'2>] (*_1)._0
+    ↳⚡ storage_dead(_1)
+        unwind_continue
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::wrap::{impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::call_once
+fn {impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::call_once<T>(_1: test_crate::wrap::{closure}<T>[TraitClause0], tupled_args: ()) -> T
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'static,
+{
+    let _0: T; // return
+    let _1: test_crate::wrap::{closure}<T>[TraitClause0]; // arg #1
+    let tupled_args: (); // arg #2
+
+    storage_live(_0)
+    _0 = move _1._0
+    conditional_drop[{impl Destruct for test_crate::wrap::{closure}<T>[TraitClause0]}::drop_glue<'0, T>[TraitClause0]] _1
+    ↳⚡ storage_dead(tupled_args)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::wrap::{impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::{vtable_method}
+extern "rust-call" fn {impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::{vtable_method}<T>(_1: *mut (dyn FnOnce<(), Output = T>), _2: ()) -> T
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'static,
+{
+    let _0: T; // return
+    let _1: *mut (dyn FnOnce<(), Output = T> + '0); // arg #1
+    let _2: (); // arg #2
+    let _3: *mut test_crate::wrap::{closure}<T>[TraitClause0]; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<*mut (dyn FnOnce<(), Output = T> + '1), *mut test_crate::wrap::{closure}<T>[TraitClause0]>(move _1)
+    _0 = {impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::call_once<T>[TraitClause0](move (*_3), move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::wrap::{impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::{vtable_drop_shim}
+unsafe fn {impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::{vtable_drop_shim}<'_0, T>(dyn_self: &'_0 mut (dyn FnOnce<(), Output = T>))
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'static,
+    TypeOutlives1: T: '_0,
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnOnce<(), Output = T> + '0); // arg #1
+    let target_self: &'_0 mut test_crate::wrap::{closure}<T>[TraitClause0]; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnOnce<(), Output = T> + '1), &'_0 mut test_crate::wrap::{closure}<T>[TraitClause0]>(move dyn_self)
+    drop[{impl Destruct for test_crate::wrap::{closure}<T>[TraitClause0]}::drop_glue<'3, T>[TraitClause0]] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::wrap::{impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::{vtable}
+fn {impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::{vtable}<T>() -> core::ops::function::FnOnce::{vtable}<(), T>
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'static,
+{
+    let ret: core::ops::function::FnOnce::{vtable}<(), T>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(), Output = T> + '1)); // anonymous local
+    let _4: extern "rust-call" fn(*mut (dyn FnOnce<(), Output = T> + '2), ()) -> T; // anonymous local
+    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<test_crate::wrap::{closure}<T>[TraitClause0]>
+    storage_live(align)
+    align = align_of<test_crate::wrap::{closure}<T>[TraitClause0]>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::{vtable_drop_shim}<'0, T>[TraitClause0], unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(), Output = T> + '1))>(const {impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::{vtable_drop_shim}<'0, T>[TraitClause0])
+    storage_live(_4)
+    _4 = cast<{impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::{vtable_method}<T>[TraitClause0], extern "rust-call" fn(*mut (dyn FnOnce<(), Output = T> + '2), ()) -> T>(const {impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::{vtable_method}<T>[TraitClause0])
+    storage_live(_5)
+    _5 = &core::marker::MetaSized::{vtable}<test_crate::wrap::{closure}<T>[TraitClause0]>
+    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: move _5 }
+    return
+}
+
+// Full name: test_crate::wrap::{impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::{vtable}
+static {impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::{vtable}<T>: core::ops::function::FnOnce::{vtable}<(), T>
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'static,
+ = {impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::{vtable}<T>[TraitClause0]()
+
+// Full name: test_crate::wrap::{impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}
+impl<T> FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'static,
+{
+    proof ImpliedClause0: (test_crate::wrap::{closure}<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for test_crate::wrap::{closure}<T>[TraitClause0]}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: (T: Sized) = TraitClause0
+    type Output = T
+    fn call_once = {impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::call_once<T>[TraitClause0]
+    vtable: {impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::{vtable}<T>[TraitClause0]
+}
+
+// Full name: test_crate::wrap
+fn wrap<T>(x: T) -> Box<(dyn FnOnce<(), Output = T> + 'static)>[{built_in impl MetaSized for (dyn FnOnce<(), Output = T> + 'static)}, {built_in impl Sized for Global}]
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'static,
+{
+    let _0: Box<(dyn FnOnce<(), Output = T> + '6)>[{built_in impl MetaSized for (dyn FnOnce<(), Output = T> + '8)}, {built_in impl Sized for Global}]; // return
+    let x: T; // arg #1
+    let _2: Box<(dyn FnOnce<(), Output = T> + '9)>[{built_in impl MetaSized for (dyn FnOnce<(), Output = T> + '11)}, {built_in impl Sized for Global}]; // anonymous local
+    let _3: Box<test_crate::wrap::{closure}<T>[TraitClause0]>[{built_in impl MetaSized for test_crate::wrap::{closure}<T>[TraitClause0]}, {built_in impl Sized for Global}]; // anonymous local
+    let _4: test_crate::wrap::{closure}<T>[TraitClause0]; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    storage_live(_3)
+    storage_live(_4)
+    _4 = test_crate::wrap::{closure} { _0: move x }
+    _3 = new<test_crate::wrap::{closure}<T>[TraitClause0]>[{built_in impl Sized for test_crate::wrap::{closure}<T>[TraitClause0]}](move _4)
+    ↳⚡ conditional_drop[{impl Destruct for test_crate::wrap::{closure}<T>[TraitClause0]}::drop_glue<'12, T>[TraitClause0]] _4
+        ↳⚡ storage_dead(x)
+            unwind_terminate
+        conditional_drop[{built_in impl Destruct for T}::drop_glue<'17>] x
+        ↳⚡ storage_dead(x)
+            unwind_terminate
+        storage_dead(x)
+        unwind_continue
+    _2 = unsize_cast<Box<test_crate::wrap::{closure}<T>[TraitClause0]>[{built_in impl MetaSized for test_crate::wrap::{closure}<T>[TraitClause0]}, {built_in impl Sized for Global}], Box<(dyn FnOnce<(), Output = T> + '13)>[{built_in impl MetaSized for (dyn FnOnce<(), Output = T> + '15)}, {built_in impl Sized for Global}], &{impl FnOnce<()> for test_crate::wrap::{closure}<T>[TraitClause0]}::{vtable}<T>[TraitClause0]>(move _3)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'16, test_crate::wrap::{closure}<T>[TraitClause0], Global>[{built_in impl MetaSized for test_crate::wrap::{closure}<T>[TraitClause0]}, {built_in impl Sized for Global}]] _3
+    ↳⚡ conditional_drop[{impl Destruct for test_crate::wrap::{closure}<T>[TraitClause0]}::drop_glue<'12, T>[TraitClause0]] _4
+        ↳⚡ storage_dead(x)
+            unwind_terminate
+        conditional_drop[{built_in impl Destruct for T}::drop_glue<'17>] x
+        ↳⚡ storage_dead(x)
+            unwind_terminate
+        storage_dead(x)
+        unwind_continue
+    storage_dead(_4)
+    storage_dead(_3)
+    _0 = unsize_cast<Box<(dyn FnOnce<(), Output = T> + '9)>[{built_in impl MetaSized for (dyn FnOnce<(), Output = T> + '11)}, {built_in impl Sized for Global}], Box<(dyn FnOnce<(), Output = T> + '18)>[{built_in impl MetaSized for (dyn FnOnce<(), Output = T> + '20)}, {built_in impl Sized for Global}],  at []>(move _2)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'35, (dyn FnOnce<(), Output = T> + '30), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = T> + '30)}, {built_in impl Sized for Global}]] _2
+    ↳⚡ conditional_drop[{built_in impl Destruct for T}::drop_glue<'17>] x
+        ↳⚡ storage_dead(x)
+            unwind_terminate
+        storage_dead(x)
+        unwind_continue
+    storage_dead(_2)
+    conditional_drop[{built_in impl Destruct for T}::drop_glue<'36>] x
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    storage_dead(x)
+    return
+}
+
+// Full name: test_crate::wrap::{closure}::{impl Destruct for test_crate::wrap::{closure}<T>[TraitClause0]}
+impl<T> Destruct for test_crate::wrap::{closure}<T>[TraitClause0]
+where
+    TraitClause0: (T: Sized),
+    TypeOutlives0: T: 'static,
+{
+    fn drop_glue<'_0_1> = {impl Destruct for test_crate::wrap::{closure}<T>[TraitClause0]}::drop_glue<'_0_1, T>[TraitClause0]
+    non-dyn-compatible
+}
+
+struct test_crate::main::{closure#2} {
+  _0: Droppable,
+}
+
+// Full name: test_crate::main::{closure#2}::{impl Destruct for test_crate::main::{closure#2}}::drop_glue
+unsafe fn {impl Destruct for test_crate::main::{closure#2}}::drop_glue<'_0>(_1: &'_0 mut test_crate::main::{closure#2})
+{
+    let _0: (); // return
+    let _1: &'1 mut test_crate::main::{closure#2}; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    drop[impl_Destruct_for_Droppable::drop_glue<'2>] (*_1)._0
+    ↳⚡ storage_dead(_1)
+        unwind_continue
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<()> for test_crate::main::{closure#2}}::call_once
+fn {impl FnOnce<()> for test_crate::main::{closure#2}}::call_once(_1: test_crate::main::{closure#2}, tupled_args: ()) -> Droppable
+{
+    let _0: Droppable; // return
+    let _1: test_crate::main::{closure#2}; // arg #1
+    let tupled_args: (); // arg #2
+
+    storage_live(_0)
+    _0 = move _1._0
+    conditional_drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'0>] _1
+    ↳⚡ storage_dead(tupled_args)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable_method}
+extern "rust-call" fn {impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable_method}(_1: *mut (dyn FnOnce<(), Output = Droppable>), _2: ()) -> Droppable
+{
+    let _0: Droppable; // return
+    let _1: *mut (dyn FnOnce<(), Output = Droppable> + '0); // arg #1
+    let _2: (); // arg #2
+    let _3: *mut test_crate::main::{closure#2}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<*mut (dyn FnOnce<(), Output = Droppable> + '1), *mut test_crate::main::{closure#2}>(move _1)
+    _0 = {impl FnOnce<()> for test_crate::main::{closure#2}}::call_once(move (*_3), move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable_drop_shim}
+unsafe fn {impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnOnce<(), Output = Droppable>))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnOnce<(), Output = Droppable> + '0); // arg #1
+    let target_self: &'_0 mut test_crate::main::{closure#2}; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnOnce<(), Output = Droppable> + '1), &'_0 mut test_crate::main::{closure#2}>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable}
+fn {impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable}() -> core::ops::function::FnOnce::{vtable}<(), Droppable>
+{
+    let ret: core::ops::function::FnOnce::{vtable}<(), Droppable>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(), Output = Droppable> + '1)); // anonymous local
+    let _4: extern "rust-call" fn(*mut (dyn FnOnce<(), Output = Droppable> + '2), ()) -> Droppable; // anonymous local
+    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<test_crate::main::{closure#2}>
+    storage_live(align)
+    align = align_of<test_crate::main::{closure#2}>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(), Output = Droppable> + '1))>(const {impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable_drop_shim}<'0>)
+    storage_live(_4)
+    _4 = cast<{impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable_method}, extern "rust-call" fn(*mut (dyn FnOnce<(), Output = Droppable> + '2), ()) -> Droppable>(const {impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable_method})
+    storage_live(_5)
+    _5 = &core::marker::MetaSized::{vtable}<test_crate::main::{closure#2}>
+    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: move _5 }
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable}
+static {impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable}: core::ops::function::FnOnce::{vtable}<(), Droppable> = {impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable}()
+
+// Full name: test_crate::main::{impl FnOnce<()> for test_crate::main::{closure#2}}
+impl FnOnce<()> for test_crate::main::{closure#2} {
+    proof ImpliedClause0: (test_crate::main::{closure#2}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#2}}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    proof ImpliedClause3: (Droppable: Sized) = {built_in impl Sized for Droppable}
+    type Output = Droppable
+    fn call_once = {impl FnOnce<()> for test_crate::main::{closure#2}}::call_once
+    vtable: {impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable}
+}
+
+struct test_crate::main::{closure#1}<'_0> {
+  _0: &'_0 u32,
+}
+
+// Full name: test_crate::main::{closure#1}::{impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue
+unsafe fn {impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue<'_0, '_1>(_1: &'_1 mut test_crate::main::{closure#1}<'_0>)
+where
+    RegionOutlives0: '_0: '_1,
+{
+    let _0: (); // return
+    let _1: &'1 mut test_crate::main::{closure#1}<'_0>; // arg #1
 
     storage_live(_0)
     _0 = ()
@@ -133,11 +563,360 @@ unsafe fn drop_glue<'_0>(_1: &'_0 mut {closure})
     return
 }
 
-// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::call
-fn call<'_0>(_1: &'_0 {closure}, tupled_args: (u32,)) -> u32
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::call
+fn {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::call<'_0, '_1>(_1: &'_1 test_crate::main::{closure#1}<'_0>, tupled_args: (u32,)) -> u32
+where
+    RegionOutlives0: '_0: '_1,
 {
     let _0: u32; // return
-    let _1: &'1 {closure}; // arg #1
+    let _1: &'1 test_crate::main::{closure#1}<'_0>; // arg #1
+    let tupled_args: (u32,); // arg #2
+    let x: u32; // local
+    let _4: u32; // anonymous local
+    let _5: u32; // anonymous local
+    let _6: u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(x)
+    storage_live(_6)
+    x = move tupled_args._0
+    storage_live(_4)
+    _4 = copy x
+    storage_live(_5)
+    _5 = copy (*(*_1)._0)
+    _6 = copy _4 panic.+ copy _5
+    _0 = move _6
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_dead(_6)
+    storage_dead(x)
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_mut
+fn {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_mut<'_0, '_1>(state: &'_1 mut test_crate::main::{closure#1}<'_0>, args: (u32,)) -> u32
+where
+    RegionOutlives0: '_0: '_1,
+{
+    let _0: u32; // return
+    let state: &'_1 mut test_crate::main::{closure#1}<'_0>; // arg #1
+    let args: (u32,); // arg #2
+    let _3: &'0 test_crate::main::{closure#1}<'_0>; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &(*state)
+    _0 = {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::call<'_0, '2>(move _3, move args)
+    ↳⚡ storage_dead(_3)
+        storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_once
+fn {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_once<'_0>(_1: test_crate::main::{closure#1}<'_0>, _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: test_crate::main::{closure#1}<'_0>; // arg #1
+    let _2: (u32,); // arg #2
+    let _3: &'1 mut test_crate::main::{closure#1}<'_0>; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_mut<'_0, '4>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue<'_0, '7>] _1
+        ↳⚡ storage_dead(_3)
+            storage_dead(_2)
+            storage_dead(_1)
+            unwind_terminate
+        storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    drop[{impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue<'_0, '10>] _1
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}
+extern "rust-call" fn {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0>(_1: *mut (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: *mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
+    let _2: (u32,); // arg #2
+    let _3: *mut test_crate::main::{closure#1}<'_0>; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<*mut (dyn FnOnce<(u32,), Output = u32> + '1), *mut test_crate::main::{closure#1}<'_0>>(move _1)
+    _0 = {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_once<'_0>(move (*_3), move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}
+unsafe fn {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '_1>(dyn_self: &'_1 mut (dyn FnOnce<(u32,), Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_1 mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
+    let target_self: &'_1 mut test_crate::main::{closure#1}<'_0>; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_1 mut (dyn FnOnce<(u32,), Output = u32> + '1), &'_1 mut test_crate::main::{closure#1}<'_0>>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue<'_0, '3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}
+fn {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>() -> core::ops::function::FnOnce::{vtable}<(u32,), u32>
+{
+    let ret: core::ops::function::FnOnce::{vtable}<(u32,), u32>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(u32,), Output = u32> + '1)); // anonymous local
+    let _4: extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32; // anonymous local
+    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<test_crate::main::{closure#1}<'_0>>
+    storage_live(align)
+    align = align_of<test_crate::main::{closure#1}<'_0>>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(u32,), Output = u32> + '1))>(const {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '0>)
+    storage_live(_4)
+    _4 = cast<{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0>, extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32>(const {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0>)
+    storage_live(_5)
+    _5 = &core::marker::MetaSized::{vtable}<test_crate::main::{closure#1}<'_0>>
+    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: move _5 }
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}
+static {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>: core::ops::function::FnOnce::{vtable}<(u32,), u32> = {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>()
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}
+extern "rust-call" fn {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0, '_1>(_1: &'_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
+    let _2: (u32,); // arg #2
+    let _3: &'_1 mut test_crate::main::{closure#1}<'_0>; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_1 mut test_crate::main::{closure#1}<'_0>>(move _1)
+    _0 = {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_mut<'_0, '_1>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}
+unsafe fn {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '_1>(dyn_self: &'_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
+    let target_self: &'_1 mut test_crate::main::{closure#1}<'_0>; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_1 mut test_crate::main::{closure#1}<'_0>>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue<'_0, '3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}
+fn {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>() -> core::ops::function::FnMut::{vtable}<(u32,), u32>
+{
+    let ret: core::ops::function::FnMut::{vtable}<(u32,), u32>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1)); // anonymous local
+    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '3), (u32,)) -> u32; // anonymous local
+    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _6: &'static core::ops::function::FnOnce::{vtable}<(u32,), u32>; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<test_crate::main::{closure#1}<'_0>>
+    storage_live(align)
+    align = align_of<test_crate::main::{closure#1}<'_0>>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1))>(const {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '0>)
+    storage_live(_4)
+    _4 = cast<for<'_0_1> {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0, '2>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '3), (u32,)) -> u32>(const {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0, '2>)
+    storage_live(_5)
+    _5 = &core::marker::MetaSized::{vtable}<test_crate::main::{closure#1}<'_0>>
+    storage_live(_6)
+    _6 = &{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>
+    ret = core::ops::function::FnMut::{vtable} { size: move size, align: move align, drop: move _3, method_call_mut: move _4, super_trait_0: move _5, super_trait_1: move _6 }
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}
+static {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>: core::ops::function::FnMut::{vtable}<(u32,), u32> = {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>()
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}
+extern "rust-call" fn {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0, '_1>(_1: &'_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
+    let _2: (u32,); // arg #2
+    let _3: &'_1 test_crate::main::{closure#1}<'_0>; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_1 test_crate::main::{closure#1}<'_0>>(move _1)
+    _0 = {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::call<'_0, '_1>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}
+unsafe fn {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '_1>(dyn_self: &'_1 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_1 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
+    let target_self: &'_1 mut test_crate::main::{closure#1}<'_0>; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_1 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_1 mut test_crate::main::{closure#1}<'_0>>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue<'_0, '3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}
+fn {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>() -> core::ops::function::Fn::{vtable}<(u32,), u32>
+{
+    let ret: core::ops::function::Fn::{vtable}<(u32,), u32>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1)); // anonymous local
+    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '3), (u32,)) -> u32; // anonymous local
+    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _6: &'static core::ops::function::FnMut::{vtable}<(u32,), u32>; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<test_crate::main::{closure#1}<'_0>>
+    storage_live(align)
+    align = align_of<test_crate::main::{closure#1}<'_0>>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1))>(const {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '0>)
+    storage_live(_4)
+    _4 = cast<for<'_0_1> {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0, '2>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '3), (u32,)) -> u32>(const {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0, '2>)
+    storage_live(_5)
+    _5 = &core::marker::MetaSized::{vtable}<test_crate::main::{closure#1}<'_0>>
+    storage_live(_6)
+    _6 = &{impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>
+    ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move _3, method_call: move _4, super_trait_0: move _5, super_trait_1: move _6 }
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}
+static {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>: core::ops::function::Fn::{vtable}<(u32,), u32> = {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>()
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}
+impl<'_0> FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0> {
+    proof ImpliedClause0: (test_crate::main::{closure#1}<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#1}<'_0>}
+    proof ImpliedClause1: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
+    type Output = u32
+    fn call_once = {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_once<'_0>
+    vtable: {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}
+impl<'_0> FnMut<(u32,)> for test_crate::main::{closure#1}<'_0> {
+    proof ImpliedClause0: (test_crate::main::{closure#1}<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#1}<'_0>}
+    proof ImpliedClause1: (test_crate::main::{closure#1}<'_0>: FnOnce<(u32,)>) = {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}<'_0>
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    fn call_mut<'_0_1> = {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_mut<'_0, '_0_1>
+    vtable: {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}
+impl<'_0> Fn<(u32,)> for test_crate::main::{closure#1}<'_0> {
+    proof ImpliedClause0: (test_crate::main::{closure#1}<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#1}<'_0>}
+    proof ImpliedClause1: (test_crate::main::{closure#1}<'_0>: FnMut<(u32,)>) = {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}<'_0>
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    fn call<'_0_1> = {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::call<'_0, '_0_1>
+    vtable: {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>
+}
+
+struct test_crate::main::{closure} {}
+
+// Full name: test_crate::main::{closure}::{impl Destruct for test_crate::main::{closure}}::drop_glue
+unsafe fn {impl Destruct for test_crate::main::{closure}}::drop_glue<'_0>(_1: &'_0 mut test_crate::main::{closure})
+{
+    let _0: (); // return
+    let _1: &'1 mut test_crate::main::{closure}; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure}}::call
+fn {impl Fn<(u32,)> for test_crate::main::{closure}}::call<'_0>(_1: &'_0 test_crate::main::{closure}, tupled_args: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'1 test_crate::main::{closure}; // arg #1
     let tupled_args: (u32,); // arg #2
     let x: u32; // local
     let _4: u32; // anonymous local
@@ -159,18 +938,18 @@ fn call<'_0>(_1: &'_0 {closure}, tupled_args: (u32,)) -> u32
     return
 }
 
-// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::call_mut
-fn call_mut<'_0>(state: &'_0 mut {closure}, args: (u32,)) -> u32
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure}}::call_mut
+fn {impl FnMut<(u32,)> for test_crate::main::{closure}}::call_mut<'_0>(state: &'_0 mut test_crate::main::{closure}, args: (u32,)) -> u32
 {
     let _0: u32; // return
-    let state: &'_0 mut {closure}; // arg #1
+    let state: &'_0 mut test_crate::main::{closure}; // arg #1
     let args: (u32,); // arg #2
-    let _3: &'0 {closure}; // anonymous local
+    let _3: &'0 test_crate::main::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &(*state)
-    _0 = call<'2>(move _3, move args)
+    _0 = {impl Fn<(u32,)> for test_crate::main::{closure}}::call<'2>(move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -181,19 +960,19 @@ fn call_mut<'_0>(state: &'_0 mut {closure}, args: (u32,)) -> u32
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::call_once
-fn call_once(_1: {closure}, _2: (u32,)) -> u32
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure}}::call_once
+fn {impl FnOnce<(u32,)> for test_crate::main::{closure}}::call_once(_1: test_crate::main::{closure}, _2: (u32,)) -> u32
 {
     let _0: u32; // return
-    let _1: {closure}; // arg #1
+    let _1: test_crate::main::{closure}; // arg #1
     let _2: (u32,); // arg #2
-    let _3: &'1 mut {closure}; // anonymous local
+    let _3: &'1 mut test_crate::main::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = call_mut<'2>(move _3, move _2)
-    ↳⚡ drop[drop_glue<'3>] _1
+    _0 = {impl FnMut<(u32,)> for test_crate::main::{closure}}::call_mut<'2>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::main::{closure}}::drop_glue<'3>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -202,7 +981,7 @@ fn call_once(_1: {closure}, _2: (u32,)) -> u32
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[drop_glue<'4>] _1
+    drop[{impl Destruct for test_crate::main::{closure}}::drop_glue<'4>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -213,18 +992,18 @@ fn call_once(_1: {closure}, _2: (u32,)) -> u32
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::{vtable_method}
-extern "rust-call" fn impl_FnOnce_tuple_for_closure::{vtable_method}(_1: *mut (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_method}
+extern "rust-call" fn {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_method}(_1: *mut (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: *mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
     let _2: (u32,); // arg #2
-    let _3: *mut {closure}; // anonymous local
+    let _3: *mut test_crate::main::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
-    _3 = concretize<*mut (dyn FnOnce<(u32,), Output = u32> + '1), *mut {closure}>(move _1)
-    _0 = call_once(move (*_3), move _2)
+    _3 = concretize<*mut (dyn FnOnce<(u32,), Output = u32> + '1), *mut test_crate::main::{closure}>(move _1)
+    _0 = {impl FnOnce<(u32,)> for test_crate::main::{closure}}::call_once(move (*_3), move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -235,18 +1014,18 @@ extern "rust-call" fn impl_FnOnce_tuple_for_closure::{vtable_method}(_1: *mut (d
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::{vtable_drop_shim}
-unsafe fn impl_FnOnce_tuple_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32>))
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}
+unsafe fn {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32>))
 {
     let ret: (); // return
     let dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
-    let target_self: &'_0 mut {closure}; // local
+    let target_self: &'_0 mut test_crate::main::{closure}; // local
 
     storage_live(ret)
     ret = ()
     storage_live(target_self)
-    target_self = concretize<&'_0 mut (dyn FnOnce<(u32,), Output = u32> + '1), &'_0 mut {closure}>(move dyn_self)
-    drop[drop_glue<'3>] (*target_self)
+    target_self = concretize<&'_0 mut (dyn FnOnce<(u32,), Output = u32> + '1), &'_0 mut test_crate::main::{closure}>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure}}::drop_glue<'3>] (*target_self)
     ↳⚡ storage_dead(target_self)
         storage_dead(dyn_self)
         unwind_continue
@@ -255,8 +1034,8 @@ unsafe fn impl_FnOnce_tuple_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::{vtable}
-fn impl_FnOnce_tuple_for_closure::{vtable}() -> core::ops::function::FnOnce::{vtable}<(u32,), u32>
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable}
+fn {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable}() -> core::ops::function::FnOnce::{vtable}<(u32,), u32>
 {
     let ret: core::ops::function::FnOnce::{vtable}<(u32,), u32>; // return
     let size: usize; // local
@@ -267,34 +1046,34 @@ fn impl_FnOnce_tuple_for_closure::{vtable}() -> core::ops::function::FnOnce::{vt
 
     storage_live(ret)
     storage_live(size)
-    size = size_of<{closure}>
+    size = size_of<test_crate::main::{closure}>
     storage_live(align)
-    align = align_of<{closure}>
+    align = align_of<test_crate::main::{closure}>
     storage_live(_3)
-    _3 = cast<for<'_0_1> impl_FnOnce_tuple_for_closure::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(u32,), Output = u32> + '1))>(const impl_FnOnce_tuple_for_closure::{vtable_drop_shim}<'0>)
+    _3 = cast<for<'_0_1> {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(u32,), Output = u32> + '1))>(const {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'0>)
     storage_live(_4)
-    _4 = cast<impl_FnOnce_tuple_for_closure::{vtable_method}, extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32>(const impl_FnOnce_tuple_for_closure::{vtable_method})
+    _4 = cast<{impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_method}, extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32>(const {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_method})
     storage_live(_5)
-    _5 = &core::marker::MetaSized::{vtable}<{closure}>
+    _5 = &core::marker::MetaSized::{vtable}<test_crate::main::{closure}>
     ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: move _5 }
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::{vtable}
-static impl_FnOnce_tuple_for_closure::{vtable}: core::ops::function::FnOnce::{vtable}<(u32,), u32> = impl_FnOnce_tuple_for_closure::{vtable}()
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable}
+static {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable}: core::ops::function::FnOnce::{vtable}<(u32,), u32> = {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable}()
 
-// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::{vtable_method}
-extern "rust-call" fn impl_FnMut_tuple_for_closure::{vtable_method}<'_0>(_1: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_method}
+extern "rust-call" fn {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_method}<'_0>(_1: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
     let _2: (u32,); // arg #2
-    let _3: &'_0 mut {closure}; // anonymous local
+    let _3: &'_0 mut test_crate::main::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
-    _3 = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut {closure}>(move _1)
-    _0 = call_mut<'_0>(move _3, move _2)
+    _3 = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut test_crate::main::{closure}>(move _1)
+    _0 = {impl FnMut<(u32,)> for test_crate::main::{closure}}::call_mut<'_0>(move _3, move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -305,18 +1084,18 @@ extern "rust-call" fn impl_FnMut_tuple_for_closure::{vtable_method}<'_0>(_1: &'_
     return
 }
 
-// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::{vtable_drop_shim}
-unsafe fn impl_FnMut_tuple_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>))
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}
+unsafe fn {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>))
 {
     let ret: (); // return
     let dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
-    let target_self: &'_0 mut {closure}; // local
+    let target_self: &'_0 mut test_crate::main::{closure}; // local
 
     storage_live(ret)
     ret = ()
     storage_live(target_self)
-    target_self = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut {closure}>(move dyn_self)
-    drop[drop_glue<'3>] (*target_self)
+    target_self = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut test_crate::main::{closure}>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure}}::drop_glue<'3>] (*target_self)
     ↳⚡ storage_dead(target_self)
         storage_dead(dyn_self)
         unwind_continue
@@ -325,8 +1104,8 @@ unsafe fn impl_FnMut_tuple_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 m
     return
 }
 
-// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::{vtable}
-fn impl_FnMut_tuple_for_closure::{vtable}() -> core::ops::function::FnMut::{vtable}<(u32,), u32>
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable}
+fn {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable}() -> core::ops::function::FnMut::{vtable}<(u32,), u32>
 {
     let ret: core::ops::function::FnMut::{vtable}<(u32,), u32>; // return
     let size: usize; // local
@@ -338,36 +1117,36 @@ fn impl_FnMut_tuple_for_closure::{vtable}() -> core::ops::function::FnMut::{vtab
 
     storage_live(ret)
     storage_live(size)
-    size = size_of<{closure}>
+    size = size_of<test_crate::main::{closure}>
     storage_live(align)
-    align = align_of<{closure}>
+    align = align_of<test_crate::main::{closure}>
     storage_live(_3)
-    _3 = cast<for<'_0_1> impl_FnMut_tuple_for_closure::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1))>(const impl_FnMut_tuple_for_closure::{vtable_drop_shim}<'0>)
+    _3 = cast<for<'_0_1> {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1))>(const {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'0>)
     storage_live(_4)
-    _4 = cast<for<'_0_1> impl_FnMut_tuple_for_closure::{vtable_method}<'2>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '3), (u32,)) -> u32>(const impl_FnMut_tuple_for_closure::{vtable_method}<'2>)
+    _4 = cast<for<'_0_1> {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_method}<'2>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '3), (u32,)) -> u32>(const {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_method}<'2>)
     storage_live(_5)
-    _5 = &core::marker::MetaSized::{vtable}<{closure}>
+    _5 = &core::marker::MetaSized::{vtable}<test_crate::main::{closure}>
     storage_live(_6)
-    _6 = &impl_FnOnce_tuple_for_closure::{vtable}
+    _6 = &{impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable}
     ret = core::ops::function::FnMut::{vtable} { size: move size, align: move align, drop: move _3, method_call_mut: move _4, super_trait_0: move _5, super_trait_1: move _6 }
     return
 }
 
-// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::{vtable}
-static impl_FnMut_tuple_for_closure::{vtable}: core::ops::function::FnMut::{vtable}<(u32,), u32> = impl_FnMut_tuple_for_closure::{vtable}()
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable}
+static {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable}: core::ops::function::FnMut::{vtable}<(u32,), u32> = {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable}()
 
-// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::{vtable_method}
-extern "rust-call" fn impl_Fn_tuple_for_closure::{vtable_method}<'_0>(_1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_method}
+extern "rust-call" fn {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_method}<'_0>(_1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
     let _2: (u32,); // arg #2
-    let _3: &'_0 {closure}; // anonymous local
+    let _3: &'_0 test_crate::main::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
-    _3 = concretize<&'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 {closure}>(move _1)
-    _0 = call<'_0>(move _3, move _2)
+    _3 = concretize<&'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 test_crate::main::{closure}>(move _1)
+    _0 = {impl Fn<(u32,)> for test_crate::main::{closure}}::call<'_0>(move _3, move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -378,18 +1157,18 @@ extern "rust-call" fn impl_Fn_tuple_for_closure::{vtable_method}<'_0>(_1: &'_0 (
     return
 }
 
-// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::{vtable_drop_shim}
-unsafe fn impl_Fn_tuple_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>))
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}
+unsafe fn {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>))
 {
     let ret: (); // return
     let dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
-    let target_self: &'_0 mut {closure}; // local
+    let target_self: &'_0 mut test_crate::main::{closure}; // local
 
     storage_live(ret)
     ret = ()
     storage_live(target_self)
-    target_self = concretize<&'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 mut {closure}>(move dyn_self)
-    drop[drop_glue<'3>] (*target_self)
+    target_self = concretize<&'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 mut test_crate::main::{closure}>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure}}::drop_glue<'3>] (*target_self)
     ↳⚡ storage_dead(target_self)
         storage_dead(dyn_self)
         unwind_continue
@@ -398,8 +1177,8 @@ unsafe fn impl_Fn_tuple_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut 
     return
 }
 
-// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::{vtable}
-fn impl_Fn_tuple_for_closure::{vtable}() -> core::ops::function::Fn::{vtable}<(u32,), u32>
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}
+fn {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}() -> core::ops::function::Fn::{vtable}<(u32,), u32>
 {
     let ret: core::ops::function::Fn::{vtable}<(u32,), u32>; // return
     let size: usize; // local
@@ -411,53 +1190,53 @@ fn impl_Fn_tuple_for_closure::{vtable}() -> core::ops::function::Fn::{vtable}<(u
 
     storage_live(ret)
     storage_live(size)
-    size = size_of<{closure}>
+    size = size_of<test_crate::main::{closure}>
     storage_live(align)
-    align = align_of<{closure}>
+    align = align_of<test_crate::main::{closure}>
     storage_live(_3)
-    _3 = cast<for<'_0_1> impl_Fn_tuple_for_closure::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1))>(const impl_Fn_tuple_for_closure::{vtable_drop_shim}<'0>)
+    _3 = cast<for<'_0_1> {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1))>(const {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'0>)
     storage_live(_4)
-    _4 = cast<for<'_0_1> impl_Fn_tuple_for_closure::{vtable_method}<'2>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '3), (u32,)) -> u32>(const impl_Fn_tuple_for_closure::{vtable_method}<'2>)
+    _4 = cast<for<'_0_1> {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_method}<'2>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '3), (u32,)) -> u32>(const {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_method}<'2>)
     storage_live(_5)
-    _5 = &core::marker::MetaSized::{vtable}<{closure}>
+    _5 = &core::marker::MetaSized::{vtable}<test_crate::main::{closure}>
     storage_live(_6)
-    _6 = &impl_FnMut_tuple_for_closure::{vtable}
+    _6 = &{impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable}
     ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move _3, method_call: move _4, super_trait_0: move _5, super_trait_1: move _6 }
     return
 }
 
-// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::{vtable}
-static impl_Fn_tuple_for_closure::{vtable}: core::ops::function::Fn::{vtable}<(u32,), u32> = impl_Fn_tuple_for_closure::{vtable}()
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}
+static {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}: core::ops::function::Fn::{vtable}<(u32,), u32> = {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}()
 
-// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}
-impl "impl_FnOnce_tuple_for_closure" FnOnce<(u32,)> for {closure} {
-    proof ImpliedClause0: ({closure}: MetaSized) = {built_in impl MetaSized for {closure}}
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure}}
+impl FnOnce<(u32,)> for test_crate::main::{closure} {
+    proof ImpliedClause0: (test_crate::main::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure}}
     proof ImpliedClause1: ((u32,): Sized) = {built_in impl Sized for (u32,)}
     proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
     proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
     type Output = u32
-    fn call_once = call_once
-    vtable: impl_FnOnce_tuple_for_closure::{vtable}
+    fn call_once = {impl FnOnce<(u32,)> for test_crate::main::{closure}}::call_once
+    vtable: {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable}
 }
 
-// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}
-impl "impl_FnMut_tuple_for_closure" FnMut<(u32,)> for {closure} {
-    proof ImpliedClause0: ({closure}: MetaSized) = {built_in impl MetaSized for {closure}}
-    proof ImpliedClause1: ({closure}: FnOnce<(u32,)>) = impl_FnOnce_tuple_for_closure
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure}}
+impl FnMut<(u32,)> for test_crate::main::{closure} {
+    proof ImpliedClause0: (test_crate::main::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure}}
+    proof ImpliedClause1: (test_crate::main::{closure}: FnOnce<(u32,)>) = {impl FnOnce<(u32,)> for test_crate::main::{closure}}
     proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
     proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
-    fn call_mut<'_0_1> = call_mut<'_0_1>
-    vtable: impl_FnMut_tuple_for_closure::{vtable}
+    fn call_mut<'_0_1> = {impl FnMut<(u32,)> for test_crate::main::{closure}}::call_mut<'_0_1>
+    vtable: {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable}
 }
 
-// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}
-impl "impl_Fn_tuple_for_closure" Fn<(u32,)> for {closure} {
-    proof ImpliedClause0: ({closure}: MetaSized) = {built_in impl MetaSized for {closure}}
-    proof ImpliedClause1: ({closure}: FnMut<(u32,)>) = impl_FnMut_tuple_for_closure
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure}}
+impl Fn<(u32,)> for test_crate::main::{closure} {
+    proof ImpliedClause0: (test_crate::main::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure}}
+    proof ImpliedClause1: (test_crate::main::{closure}: FnMut<(u32,)>) = {impl FnMut<(u32,)> for test_crate::main::{closure}}
     proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
     proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
-    fn call<'_0_1> = call<'_0_1>
-    vtable: impl_Fn_tuple_for_closure::{vtable}
+    fn call<'_0_1> = {impl Fn<(u32,)> for test_crate::main::{closure}}::call<'_0_1>
+    vtable: {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}
 }
 
 // Full name: test_crate::main
@@ -465,60 +1244,210 @@ fn main()
 {
     let _0: (); // return
     let f: &'3 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4); // local
-    let _2: &'6 {closure}; // anonymous local
-    let _3: &'7 {closure}; // anonymous local
-    let _y: u32; // local
+    let _2: &'6 test_crate::main::{closure}; // anonymous local
+    let _3: &'7 test_crate::main::{closure}; // anonymous local
+    let _y_4: u32; // local
     let _5: &'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9); // anonymous local
     let _6: (u32,); // anonymous local
-    let _7: &'10 {closure}; // anonymous local
-    let _8: &'11 {closure}; // anonymous local
-    let _9: &'20 {closure}; // anonymous local
-    let _10: {closure}; // anonymous local
+    let captured: u32; // local
+    let g: &'10 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '11); // local
+    let _9: &'15 test_crate::main::{closure#1}<'16>; // anonymous local
+    let _10: &'17 test_crate::main::{closure#1}<'18>; // anonymous local
+    let _11: test_crate::main::{closure#1}<'19>; // anonymous local
+    let _12: &'21 u32; // anonymous local
+    let _y_13: u32; // local
+    let _14: &'22 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '23); // anonymous local
+    let _15: (u32,); // anonymous local
+    let d: Droppable; // local
+    let _h: Box<(dyn FnOnce<(), Output = Droppable> + '30)>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '32)}, {built_in impl Sized for Global}]; // local
+    let _18: Box<test_crate::main::{closure#2}>[{built_in impl MetaSized for test_crate::main::{closure#2}}, {built_in impl Sized for Global}]; // anonymous local
+    let _19: test_crate::main::{closure#2}; // anonymous local
+    let _w: Box<(dyn FnOnce<(), Output = u32> + '39)>[{built_in impl MetaSized for (dyn FnOnce<(), Output = u32> + '41)}, {built_in impl Sized for Global}]; // local
+    let _21: &'42 test_crate::main::{closure}; // anonymous local
+    let _22: &'43 test_crate::main::{closure}; // anonymous local
+    let _23: &'123 test_crate::main::{closure}; // anonymous local
+    let _24: test_crate::main::{closure}; // anonymous local
 
-    storage_live(_8)
-    storage_live(_9)
-    storage_live(_10)
-    _10 = {closure} {  }
-    _9 = &_10
-    _8 = move _9
+    storage_live(_22)
+    storage_live(_23)
+    storage_live(_24)
+    _24 = test_crate::main::{closure} {  }
+    _23 = &_24
+    _22 = move _23
     storage_live(_0)
-    storage_live(_7)
+    storage_live(_21)
     _0 = ()
     storage_live(f)
     storage_live(_2)
     storage_live(_3)
-    _7 = move _8
-    _3 = &(*_7)
+    _21 = move _22
+    _3 = &(*_21)
     _2 = &(*_3)
-    f = unsize_cast<&'6 {closure}, &'12 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '13), &impl_Fn_tuple_for_closure::{vtable}>(move _2)
+    f = unsize_cast<&'6 test_crate::main::{closure}, &'44 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '45), &{impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}>(move _2)
     storage_dead(_2)
     fake_read(f)
-    set_type(typeof(f) == &'14 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '15))
+    set_type(typeof(f) == &'46 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '47))
     storage_dead(_3)
-    storage_live(_y)
+    storage_live(_y_4)
     storage_live(_5)
     _5 = &(*f) with_metadata(copy f.metadata)
     storage_live(_6)
     _6 = (const 1u32,)
-    _y = (copy (*_5.metadata).method_call)(move _5, move _6)
-    ↳⚡ storage_dead(_7)
+    _y_4 = (copy (*_5.metadata).method_call)(move _5, move _6)
+    ↳⚡ storage_dead(_21)
         unwind_continue
     storage_dead(_6)
     storage_dead(_5)
-    fake_read(_y)
-    _0 = ()
-    storage_dead(_y)
-    storage_dead(f)
-    storage_dead(_7)
-    storage_dead(_10)
+    fake_read(_y_4)
+    storage_live(captured)
+    // A closure with captured state.
+    captured = const 10u32
+    fake_read(captured)
+    storage_live(g)
+    storage_live(_9)
+    storage_live(_10)
+    storage_live(_11)
+    storage_live(_12)
+    _12 = &captured
+    _11 = test_crate::main::{closure#1} { _0: move _12 }
+    storage_dead(_12)
+    _10 = &_11
+    _9 = &(*_10)
+    g = unsize_cast<&'15 test_crate::main::{closure#1}<'16>, &'54 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '55), &{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'61>>(move _9)
     storage_dead(_9)
-    storage_dead(_8)
+    fake_read(g)
+    set_type(typeof(g) == &'62 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '63))
+    storage_dead(_10)
+    storage_live(_y_13)
+    storage_live(_14)
+    _14 = &(*g) with_metadata(copy g.metadata)
+    storage_live(_15)
+    _15 = (const 2u32,)
+    _y_13 = (copy (*_14.metadata).method_call)(move _14, move _15)
+    ↳⚡ storage_dead(_21)
+        unwind_continue
+    storage_dead(_15)
+    storage_dead(_14)
+    fake_read(_y_13)
+    storage_live(d)
+    // Built but not called: the drop shim must drop the captured state.
+    d = Droppable { _0: const 0u32 }
+    fake_read(d)
+    storage_live(_h)
+    storage_live(_18)
+    storage_live(_19)
+    _19 = test_crate::main::{closure#2} { _0: move d }
+    _18 = new<test_crate::main::{closure#2}>[{built_in impl Sized for test_crate::main::{closure#2}}](move _19)
+    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'68>] _19
+        ↳⚡ storage_dead(_21)
+            storage_dead(_24)
+            storage_dead(_23)
+            storage_dead(_22)
+            unwind_terminate
+        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'73>] d
+        ↳⚡ storage_dead(_21)
+            storage_dead(_24)
+            storage_dead(_23)
+            storage_dead(_22)
+            unwind_terminate
+        storage_dead(_21)
+        unwind_continue
+    _h = unsize_cast<Box<test_crate::main::{closure#2}>[{built_in impl MetaSized for test_crate::main::{closure#2}}, {built_in impl Sized for Global}], Box<(dyn FnOnce<(), Output = Droppable> + '69)>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '71)}, {built_in impl Sized for Global}], &{impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable}>(move _18)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'72, test_crate::main::{closure#2}, Global>[{built_in impl MetaSized for test_crate::main::{closure#2}}, {built_in impl Sized for Global}]] _18
+    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'68>] _19
+        ↳⚡ storage_dead(_21)
+            storage_dead(_24)
+            storage_dead(_23)
+            storage_dead(_22)
+            unwind_terminate
+        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'73>] d
+        ↳⚡ storage_dead(_21)
+            storage_dead(_24)
+            storage_dead(_23)
+            storage_dead(_22)
+            unwind_terminate
+        storage_dead(_21)
+        unwind_continue
+    storage_dead(_19)
+    storage_dead(_18)
+    fake_read(_h)
+    set_type(typeof(_h) == Box<(dyn FnOnce<(), Output = Droppable> + '74)>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '76)}, {built_in impl Sized for Global}])
+    storage_live(_w)
+    _w = wrap<u32>[{built_in impl Sized for u32}](const 3u32)
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'91, (dyn FnOnce<(), Output = Droppable> + '86), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '86)}, {built_in impl Sized for Global}]] _h
+        ↳⚡ storage_dead(_21)
+            storage_dead(_24)
+            storage_dead(_23)
+            storage_dead(_22)
+            unwind_terminate
+        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'73>] d
+        ↳⚡ storage_dead(_21)
+            storage_dead(_24)
+            storage_dead(_23)
+            storage_dead(_22)
+            unwind_terminate
+        storage_dead(_21)
+        unwind_continue
+    fake_read(_w)
+    _0 = ()
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'106, (dyn FnOnce<(), Output = u32> + '101), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = u32> + '101)}, {built_in impl Sized for Global}]] _w
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'91, (dyn FnOnce<(), Output = Droppable> + '86), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '86)}, {built_in impl Sized for Global}]] _h
+        ↳⚡ storage_dead(_21)
+            storage_dead(_24)
+            storage_dead(_23)
+            storage_dead(_22)
+            unwind_terminate
+        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'73>] d
+        ↳⚡ storage_dead(_21)
+            storage_dead(_24)
+            storage_dead(_23)
+            storage_dead(_22)
+            unwind_terminate
+        storage_dead(_21)
+        unwind_continue
+    storage_dead(_w)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'121, (dyn FnOnce<(), Output = Droppable> + '116), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '116)}, {built_in impl Sized for Global}]] _h
+    ↳⚡ conditional_drop[impl_Destruct_for_Droppable::drop_glue<'73>] d
+        ↳⚡ storage_dead(_21)
+            storage_dead(_24)
+            storage_dead(_23)
+            storage_dead(_22)
+            unwind_terminate
+        storage_dead(_21)
+        unwind_continue
+    storage_dead(_h)
+    conditional_drop[impl_Destruct_for_Droppable::drop_glue<'122>] d
+    ↳⚡ storage_dead(_21)
+        unwind_continue
+    storage_dead(d)
+    storage_dead(_y_13)
+    storage_dead(_11)
+    storage_dead(g)
+    storage_dead(captured)
+    storage_dead(_y_4)
+    storage_dead(f)
+    storage_dead(_21)
+    storage_dead(_24)
+    storage_dead(_23)
+    storage_dead(_22)
     return
 }
 
-// Full name: test_crate::main::{closure}::{impl Destruct for {closure}}
-impl "impl_Destruct_for_closure" Destruct for {closure} {
-    fn drop_glue<'_0_1> = drop_glue<'_0_1>
+// Full name: test_crate::main::{closure}::{impl Destruct for test_crate::main::{closure}}
+impl Destruct for test_crate::main::{closure} {
+    fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::{closure}}::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::main::{closure#1}::{impl Destruct for test_crate::main::{closure#1}<'_0>}
+impl<'_0> Destruct for test_crate::main::{closure#1}<'_0> {
+    fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue<'_0, '_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::main::{closure#2}::{impl Destruct for test_crate::main::{closure#2}}
+impl Destruct for test_crate::main::{closure#2} {
+    fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::{closure#2}}::drop_glue<'_0_1>
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.out
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.out
@@ -110,315 +110,12 @@ struct (_,)<A> {
   _0: A,
 }
 
-// Full name: test_crate::takes_fn
-fn takes_fn<'_0>(_1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '_0))
+struct (_, _)<A, B>
+where
+    TraitClause0: (A: Sized),
 {
-    let _0: (); // return
-    let _1: &'3 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4); // arg #1
-
-    storage_live(_0)
-    _0 = ()
-    _0 = ()
-    storage_dead(_1)
-    return
-}
-
-// Full name: test_crate::some_fn
-fn some_fn(x: u32) -> u32
-{
-    let _0: u32; // return
-    let x: u32; // arg #1
-
-    storage_live(_0)
-    _0 = copy x
-    storage_dead(x)
-    return
-}
-
-// Full name: test_crate::{impl FnOnce<(u32,)> for some_fn}::call_once
-fn {impl FnOnce<(u32,)> for some_fn}::call_once(state: some_fn, args: (u32,)) -> u32
-{
-    let _0: u32; // return
-    let state: some_fn; // arg #1
-    let args: (u32,); // arg #2
-
-    storage_live(_0)
-    _0 = some_fn(move args._0)
-    ↳⚡ storage_dead(args)
-        storage_dead(state)
-        unwind_continue
-    storage_dead(args)
-    storage_dead(state)
-    return
-}
-
-// Full name: test_crate::{impl FnOnce<(u32,)> for some_fn}::{vtable_method}
-extern "rust-call" fn {impl FnOnce<(u32,)> for some_fn}::{vtable_method}(_1: (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
-{
-    let _0: u32; // return
-    let _1: (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
-    let _2: (u32,); // arg #2
-    let _3: some_fn; // anonymous local
-
-    storage_live(_0)
-    storage_live(_3)
-    _3 = concretize<(dyn FnOnce<(u32,), Output = u32> + '1), some_fn>(move _1)
-    _0 = {impl FnOnce<(u32,)> for some_fn}::call_once(move _3, move _2)
-    ↳⚡ storage_dead(_3)
-        storage_dead(_2)
-        storage_dead(_1)
-        unwind_continue
-    storage_dead(_3)
-    storage_dead(_2)
-    storage_dead(_1)
-    return
-}
-
-// Full name: test_crate::{impl FnOnce<(u32,)> for some_fn}::{vtable_drop_shim}
-unsafe fn {impl FnOnce<(u32,)> for some_fn}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32>))
-{
-    let ret: (); // return
-    let dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
-    let target_self: &'_0 mut some_fn; // local
-
-    storage_live(ret)
-    ret = ()
-    storage_live(target_self)
-    target_self = concretize<&'_0 mut (dyn FnOnce<(u32,), Output = u32> + '1), &'_0 mut some_fn>(move dyn_self)
-    storage_dead(target_self)
-    storage_dead(dyn_self)
-    return
-}
-
-// Full name: test_crate::{impl FnOnce<(u32,)> for some_fn}::{vtable}
-fn {impl FnOnce<(u32,)> for some_fn}::{vtable}() -> core::ops::function::FnOnce::{vtable}<(u32,), u32>
-{
-    let ret: core::ops::function::FnOnce::{vtable}<(u32,), u32>; // return
-    let size: usize; // local
-    let align: usize; // local
-    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(u32,), Output = u32> + '1)); // anonymous local
-    let _4: extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32; // anonymous local
-    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
-
-    storage_live(ret)
-    storage_live(size)
-    size = size_of<some_fn>
-    storage_live(align)
-    align = align_of<some_fn>
-    storage_live(_3)
-    _3 = cast<for<'_0_1> {impl FnOnce<(u32,)> for some_fn}::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(u32,), Output = u32> + '1))>(const {impl FnOnce<(u32,)> for some_fn}::{vtable_drop_shim}<'0>)
-    storage_live(_4)
-    _4 = cast<{impl FnOnce<(u32,)> for some_fn}::{vtable_method}, extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32>(const {impl FnOnce<(u32,)> for some_fn}::{vtable_method})
-    storage_live(_5)
-    _5 = &core::marker::MetaSized::{vtable}<some_fn>
-    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: move _5 }
-    return
-}
-
-// Full name: test_crate::{impl FnOnce<(u32,)> for some_fn}::{vtable}
-static {impl FnOnce<(u32,)> for some_fn}::{vtable}: core::ops::function::FnOnce::{vtable}<(u32,), u32> = {impl FnOnce<(u32,)> for some_fn}::{vtable}()
-
-// Full name: test_crate::{impl FnMut<(u32,)> for some_fn}::call_mut
-fn {impl FnMut<(u32,)> for some_fn}::call_mut<'_0>(state: &'_0 mut some_fn, args: (u32,)) -> u32
-{
-    let _0: u32; // return
-    let state: &'_0 mut some_fn; // arg #1
-    let args: (u32,); // arg #2
-
-    storage_live(_0)
-    _0 = some_fn(move args._0)
-    ↳⚡ storage_dead(args)
-        storage_dead(state)
-        unwind_continue
-    storage_dead(args)
-    storage_dead(state)
-    return
-}
-
-// Full name: test_crate::{impl FnMut<(u32,)> for some_fn}::{vtable_method}
-extern "rust-call" fn {impl FnMut<(u32,)> for some_fn}::{vtable_method}<'_0>(_1: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
-{
-    let _0: u32; // return
-    let _1: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
-    let _2: (u32,); // arg #2
-    let _3: &'_0 mut some_fn; // anonymous local
-
-    storage_live(_0)
-    storage_live(_3)
-    _3 = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut some_fn>(move _1)
-    _0 = {impl FnMut<(u32,)> for some_fn}::call_mut<'_0>(move _3, move _2)
-    ↳⚡ storage_dead(_3)
-        storage_dead(_2)
-        storage_dead(_1)
-        unwind_continue
-    storage_dead(_3)
-    storage_dead(_2)
-    storage_dead(_1)
-    return
-}
-
-// Full name: test_crate::{impl FnMut<(u32,)> for some_fn}::{vtable_drop_shim}
-unsafe fn {impl FnMut<(u32,)> for some_fn}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>))
-{
-    let ret: (); // return
-    let dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
-    let target_self: &'_0 mut some_fn; // local
-
-    storage_live(ret)
-    ret = ()
-    storage_live(target_self)
-    target_self = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut some_fn>(move dyn_self)
-    storage_dead(target_self)
-    storage_dead(dyn_self)
-    return
-}
-
-// Full name: test_crate::{impl FnMut<(u32,)> for some_fn}::{vtable}
-fn {impl FnMut<(u32,)> for some_fn}::{vtable}() -> core::ops::function::FnMut::{vtable}<(u32,), u32>
-{
-    let ret: core::ops::function::FnMut::{vtable}<(u32,), u32>; // return
-    let size: usize; // local
-    let align: usize; // local
-    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1)); // anonymous local
-    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '3), (u32,)) -> u32; // anonymous local
-    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
-    let _6: &'static core::ops::function::FnOnce::{vtable}<(u32,), u32>; // anonymous local
-
-    storage_live(ret)
-    storage_live(size)
-    size = size_of<some_fn>
-    storage_live(align)
-    align = align_of<some_fn>
-    storage_live(_3)
-    _3 = cast<for<'_0_1> {impl FnMut<(u32,)> for some_fn}::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1))>(const {impl FnMut<(u32,)> for some_fn}::{vtable_drop_shim}<'0>)
-    storage_live(_4)
-    _4 = cast<for<'_0_1> {impl FnMut<(u32,)> for some_fn}::{vtable_method}<'2>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '3), (u32,)) -> u32>(const {impl FnMut<(u32,)> for some_fn}::{vtable_method}<'2>)
-    storage_live(_5)
-    _5 = &core::marker::MetaSized::{vtable}<some_fn>
-    storage_live(_6)
-    _6 = &{impl FnOnce<(u32,)> for some_fn}::{vtable}
-    ret = core::ops::function::FnMut::{vtable} { size: move size, align: move align, drop: move _3, method_call_mut: move _4, super_trait_0: move _5, super_trait_1: move _6 }
-    return
-}
-
-// Full name: test_crate::{impl FnMut<(u32,)> for some_fn}::{vtable}
-static {impl FnMut<(u32,)> for some_fn}::{vtable}: core::ops::function::FnMut::{vtable}<(u32,), u32> = {impl FnMut<(u32,)> for some_fn}::{vtable}()
-
-// Full name: test_crate::{impl Fn<(u32,)> for some_fn}::call
-fn {impl Fn<(u32,)> for some_fn}::call<'_0>(state: &'_0 some_fn, args: (u32,)) -> u32
-{
-    let _0: u32; // return
-    let state: &'_0 some_fn; // arg #1
-    let args: (u32,); // arg #2
-
-    storage_live(_0)
-    _0 = some_fn(move args._0)
-    ↳⚡ storage_dead(args)
-        storage_dead(state)
-        unwind_continue
-    storage_dead(args)
-    storage_dead(state)
-    return
-}
-
-// Full name: test_crate::{impl Fn<(u32,)> for some_fn}::{vtable_method}
-extern "rust-call" fn {impl Fn<(u32,)> for some_fn}::{vtable_method}<'_0>(_1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
-{
-    let _0: u32; // return
-    let _1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
-    let _2: (u32,); // arg #2
-    let _3: &'_0 some_fn; // anonymous local
-
-    storage_live(_0)
-    storage_live(_3)
-    _3 = concretize<&'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 some_fn>(move _1)
-    _0 = {impl Fn<(u32,)> for some_fn}::call<'_0>(move _3, move _2)
-    ↳⚡ storage_dead(_3)
-        storage_dead(_2)
-        storage_dead(_1)
-        unwind_continue
-    storage_dead(_3)
-    storage_dead(_2)
-    storage_dead(_1)
-    return
-}
-
-// Full name: test_crate::{impl Fn<(u32,)> for some_fn}::{vtable_drop_shim}
-unsafe fn {impl Fn<(u32,)> for some_fn}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>))
-{
-    let ret: (); // return
-    let dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
-    let target_self: &'_0 mut some_fn; // local
-
-    storage_live(ret)
-    ret = ()
-    storage_live(target_self)
-    target_self = concretize<&'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 mut some_fn>(move dyn_self)
-    storage_dead(target_self)
-    storage_dead(dyn_self)
-    return
-}
-
-// Full name: test_crate::{impl Fn<(u32,)> for some_fn}::{vtable}
-fn {impl Fn<(u32,)> for some_fn}::{vtable}() -> core::ops::function::Fn::{vtable}<(u32,), u32>
-{
-    let ret: core::ops::function::Fn::{vtable}<(u32,), u32>; // return
-    let size: usize; // local
-    let align: usize; // local
-    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1)); // anonymous local
-    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '3), (u32,)) -> u32; // anonymous local
-    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
-    let _6: &'static core::ops::function::FnMut::{vtable}<(u32,), u32>; // anonymous local
-
-    storage_live(ret)
-    storage_live(size)
-    size = size_of<some_fn>
-    storage_live(align)
-    align = align_of<some_fn>
-    storage_live(_3)
-    _3 = cast<for<'_0_1> {impl Fn<(u32,)> for some_fn}::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1))>(const {impl Fn<(u32,)> for some_fn}::{vtable_drop_shim}<'0>)
-    storage_live(_4)
-    _4 = cast<for<'_0_1> {impl Fn<(u32,)> for some_fn}::{vtable_method}<'2>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '3), (u32,)) -> u32>(const {impl Fn<(u32,)> for some_fn}::{vtable_method}<'2>)
-    storage_live(_5)
-    _5 = &core::marker::MetaSized::{vtable}<some_fn>
-    storage_live(_6)
-    _6 = &{impl FnMut<(u32,)> for some_fn}::{vtable}
-    ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move _3, method_call: move _4, super_trait_0: move _5, super_trait_1: move _6 }
-    return
-}
-
-// Full name: test_crate::{impl Fn<(u32,)> for some_fn}::{vtable}
-static {impl Fn<(u32,)> for some_fn}::{vtable}: core::ops::function::Fn::{vtable}<(u32,), u32> = {impl Fn<(u32,)> for some_fn}::{vtable}()
-
-// Full name: test_crate::{impl FnOnce<(u32,)> for some_fn}
-impl FnOnce<(u32,)> for some_fn {
-    proof ImpliedClause0: (some_fn: MetaSized) = {built_in impl MetaSized for some_fn}
-    proof ImpliedClause1: ((u32,): Sized) = {built_in impl Sized for (u32,)}
-    proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
-    proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
-    type Output = u32
-    fn call_once = {impl FnOnce<(u32,)> for some_fn}::call_once
-    vtable: {impl FnOnce<(u32,)> for some_fn}::{vtable}
-}
-
-// Full name: test_crate::{impl FnMut<(u32,)> for some_fn}
-impl FnMut<(u32,)> for some_fn {
-    proof ImpliedClause0: (some_fn: MetaSized) = {built_in impl MetaSized for some_fn}
-    proof ImpliedClause1: (some_fn: FnOnce<(u32,)>) = {impl FnOnce<(u32,)> for some_fn}
-    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
-    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
-    fn call_mut<'_0_1> = {impl FnMut<(u32,)> for some_fn}::call_mut<'_0_1>
-    vtable: {impl FnMut<(u32,)> for some_fn}::{vtable}
-}
-
-// Full name: test_crate::{impl Fn<(u32,)> for some_fn}
-impl Fn<(u32,)> for some_fn {
-    proof ImpliedClause0: (some_fn: MetaSized) = {built_in impl MetaSized for some_fn}
-    proof ImpliedClause1: (some_fn: FnMut<(u32,)>) = {impl FnMut<(u32,)> for some_fn}
-    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
-    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
-    fn call<'_0_1> = {impl Fn<(u32,)> for some_fn}::call<'_0_1>
-    vtable: {impl Fn<(u32,)> for some_fn}::{vtable}
+  _0: A,
+  _1: B,
 }
 
 // Full name: test_crate::main::{closure}
@@ -437,25 +134,33 @@ unsafe fn drop_glue<'_0>(_1: &'_0 mut {closure})
 }
 
 // Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::call
-fn impl_Fn_tuple_for_closure::call<'_0>(_1: &'_0 {closure}, tupled_args: (u32,)) -> u32
+fn call<'_0>(_1: &'_0 {closure}, tupled_args: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: &'1 {closure}; // arg #1
     let tupled_args: (u32,); // arg #2
-    let _3: u32; // anonymous local
+    let x: u32; // local
+    let _4: u32; // anonymous local
+    let _5: u32; // anonymous local
 
     storage_live(_0)
-    storage_live(_3)
-    _3 = move tupled_args._0
-    _0 = const 42u32
-    storage_dead(_3)
+    storage_live(x)
+    storage_live(_5)
+    x = move tupled_args._0
+    storage_live(_4)
+    _4 = copy x
+    _5 = copy _4 panic.+ const 1u32
+    _0 = move _5
+    storage_dead(_4)
+    storage_dead(_5)
+    storage_dead(x)
     storage_dead(tupled_args)
     storage_dead(_1)
     return
 }
 
 // Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::call_mut
-fn impl_FnMut_tuple_for_closure::call_mut<'_0>(state: &'_0 mut {closure}, args: (u32,)) -> u32
+fn call_mut<'_0>(state: &'_0 mut {closure}, args: (u32,)) -> u32
 {
     let _0: u32; // return
     let state: &'_0 mut {closure}; // arg #1
@@ -465,7 +170,7 @@ fn impl_FnMut_tuple_for_closure::call_mut<'_0>(state: &'_0 mut {closure}, args: 
     storage_live(_0)
     storage_live(_3)
     _3 = &(*state)
-    _0 = impl_Fn_tuple_for_closure::call<'2>(move _3, move args)
+    _0 = call<'2>(move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -477,7 +182,7 @@ fn impl_FnMut_tuple_for_closure::call_mut<'_0>(state: &'_0 mut {closure}, args: 
 }
 
 // Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::call_once
-fn impl_FnOnce_tuple_for_closure::call_once(_1: {closure}, _2: (u32,)) -> u32
+fn call_once(_1: {closure}, _2: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: {closure}; // arg #1
@@ -487,7 +192,7 @@ fn impl_FnOnce_tuple_for_closure::call_once(_1: {closure}, _2: (u32,)) -> u32
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = impl_FnMut_tuple_for_closure::call_mut<'2>(move _3, move _2)
+    _0 = call_mut<'2>(move _3, move _2)
     ↳⚡ drop[drop_glue<'3>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
@@ -519,7 +224,7 @@ extern "rust-call" fn impl_FnOnce_tuple_for_closure::{vtable_method}(_1: (dyn Fn
     storage_live(_0)
     storage_live(_3)
     _3 = concretize<(dyn FnOnce<(u32,), Output = u32> + '1), {closure}>(move _1)
-    _0 = impl_FnOnce_tuple_for_closure::call_once(move _3, move _2)
+    _0 = call_once(move _3, move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -589,7 +294,7 @@ extern "rust-call" fn impl_FnMut_tuple_for_closure::{vtable_method}<'_0>(_1: &'_
     storage_live(_0)
     storage_live(_3)
     _3 = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut {closure}>(move _1)
-    _0 = impl_FnMut_tuple_for_closure::call_mut<'_0>(move _3, move _2)
+    _0 = call_mut<'_0>(move _3, move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -662,7 +367,7 @@ extern "rust-call" fn impl_Fn_tuple_for_closure::{vtable_method}<'_0>(_1: &'_0 (
     storage_live(_0)
     storage_live(_3)
     _3 = concretize<&'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 {closure}>(move _1)
-    _0 = impl_Fn_tuple_for_closure::call<'_0>(move _3, move _2)
+    _0 = call<'_0>(move _3, move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -731,7 +436,7 @@ impl "impl_FnOnce_tuple_for_closure" FnOnce<(u32,)> for {closure} {
     proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
     proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
     type Output = u32
-    fn call_once = impl_FnOnce_tuple_for_closure::call_once
+    fn call_once = call_once
     vtable: impl_FnOnce_tuple_for_closure::{vtable}
 }
 
@@ -741,7 +446,7 @@ impl "impl_FnMut_tuple_for_closure" FnMut<(u32,)> for {closure} {
     proof ImpliedClause1: ({closure}: FnOnce<(u32,)>) = impl_FnOnce_tuple_for_closure
     proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
     proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
-    fn call_mut<'_0_1> = impl_FnMut_tuple_for_closure::call_mut<'_0_1>
+    fn call_mut<'_0_1> = call_mut<'_0_1>
     vtable: impl_FnMut_tuple_for_closure::{vtable}
 }
 
@@ -751,7 +456,7 @@ impl "impl_Fn_tuple_for_closure" Fn<(u32,)> for {closure} {
     proof ImpliedClause1: ({closure}: FnMut<(u32,)>) = impl_FnMut_tuple_for_closure
     proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
     proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
-    fn call<'_0_1> = impl_Fn_tuple_for_closure::call<'_0_1>
+    fn call<'_0_1> = call<'_0_1>
     vtable: impl_Fn_tuple_for_closure::{vtable}
 }
 
@@ -759,80 +464,55 @@ impl "impl_Fn_tuple_for_closure" Fn<(u32,)> for {closure} {
 fn main()
 {
     let _0: (); // return
-    let _1: (); // anonymous local
-    let _2: &'3 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4); // anonymous local
-    let _3: &'6 some_fn; // anonymous local
-    let _4: &'7 some_fn; // anonymous local
-    let _5: (); // anonymous local
-    let _6: &'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9); // anonymous local
-    let _7: &'11 {closure}; // anonymous local
-    let _8: &'12 {closure}; // anonymous local
-    let _9: &'13 {closure}; // anonymous local
-    let _10: &'14 some_fn; // anonymous local
-    let _11: &'15 some_fn; // anonymous local
-    let _12: &'20 {closure}; // anonymous local
-    let _13: &'25 some_fn; // anonymous local
-    let _14: some_fn; // anonymous local
-    let _15: &'26 {closure}; // anonymous local
-    let _16: {closure}; // anonymous local
+    let f: &'3 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4); // local
+    let _2: &'6 {closure}; // anonymous local
+    let _3: &'7 {closure}; // anonymous local
+    let _y: u32; // local
+    let _5: &'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9); // anonymous local
+    let _6: (u32,); // anonymous local
+    let _7: &'10 {closure}; // anonymous local
+    let _8: &'11 {closure}; // anonymous local
+    let _9: &'20 {closure}; // anonymous local
+    let _10: {closure}; // anonymous local
 
-    storage_live(_11)
-    storage_live(_13)
-    storage_live(_14)
-    _14 = const some_fn
-    _13 = &_14
-    _11 = move _13
-    storage_live(_0)
+    storage_live(_8)
     storage_live(_9)
     storage_live(_10)
+    _10 = {closure} {  }
+    _9 = &_10
+    _8 = move _9
+    storage_live(_0)
+    storage_live(_7)
     _0 = ()
-    storage_live(_1)
+    storage_live(f)
     storage_live(_2)
     storage_live(_3)
-    storage_live(_4)
-    _10 = move _11
-    _4 = &(*_10)
-    _3 = &(*_4)
-    _2 = unsize_cast<&'6 some_fn, &'16 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '17), &{impl Fn<(u32,)> for some_fn}::{vtable}>(move _3)
-    storage_dead(_3)
-    _1 = takes_fn<'19>(move _2)
-    ↳⚡ storage_dead(_10)
-        storage_dead(_9)
-        unwind_continue
-    storage_live(_12)
-    storage_live(_15)
-    storage_live(_16)
-    _16 = {closure} {  }
-    _15 = &_16
-    _12 = move _15
+    _7 = move _8
+    _3 = &(*_7)
+    _2 = &(*_3)
+    f = unsize_cast<&'6 {closure}, &'12 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '13), &impl_Fn_tuple_for_closure::{vtable}>(move _2)
     storage_dead(_2)
-    storage_dead(_4)
-    storage_dead(_1)
+    fake_read(f)
+    set_type(typeof(f) == &'14 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '15))
+    storage_dead(_3)
+    storage_live(_y)
     storage_live(_5)
+    _5 = &(*f) with_metadata(copy f.metadata)
     storage_live(_6)
-    storage_live(_7)
-    storage_live(_8)
-    _9 = move _12
-    _8 = &(*_9)
-    _7 = &(*_8)
-    _6 = unsize_cast<&'11 {closure}, &'21 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '22), &impl_Fn_tuple_for_closure::{vtable}>(move _7)
-    storage_dead(_7)
-    _5 = takes_fn<'24>(move _6)
-    ↳⚡ storage_dead(_10)
-        storage_dead(_9)
+    _6 = (const 1u32,)
+    _y = (copy (*_5.metadata).method_call)(move _5, move _6)
+    ↳⚡ storage_dead(_7)
         unwind_continue
     storage_dead(_6)
-    storage_dead(_8)
     storage_dead(_5)
+    fake_read(_y)
     _0 = ()
+    storage_dead(_y)
+    storage_dead(f)
+    storage_dead(_7)
     storage_dead(_10)
     storage_dead(_9)
-    storage_dead(_16)
-    storage_dead(_15)
-    storage_dead(_14)
-    storage_dead(_13)
-    storage_dead(_12)
-    storage_dead(_11)
+    storage_dead(_8)
     return
 }
 

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.out
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.out
@@ -44,7 +44,7 @@ struct core::ops::function::FnOnce::{vtable}<Args, Ty0> {
   size: usize,
   align: usize,
   drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Ty0>)),
-  method_call_once: extern "rust-call" fn((dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
+  method_call_once: extern "rust-call" fn(*mut (dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
   super_trait_0: &'static core::marker::MetaSized::{vtable},
 }
 
@@ -214,17 +214,17 @@ fn call_once(_1: {closure}, _2: (u32,)) -> u32
 }
 
 // Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::{vtable_method}
-extern "rust-call" fn impl_FnOnce_tuple_for_closure::{vtable_method}(_1: (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
+extern "rust-call" fn impl_FnOnce_tuple_for_closure::{vtable_method}(_1: *mut (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
 {
     let _0: u32; // return
-    let _1: (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
+    let _1: *mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
     let _2: (u32,); // arg #2
-    let _3: {closure}; // anonymous local
+    let _3: *mut {closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
-    _3 = concretize<(dyn FnOnce<(u32,), Output = u32> + '1), {closure}>(move _1)
-    _0 = call_once(move _3, move _2)
+    _3 = concretize<*mut (dyn FnOnce<(u32,), Output = u32> + '1), *mut {closure}>(move _1)
+    _0 = call_once(move (*_3), move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -262,7 +262,7 @@ fn impl_FnOnce_tuple_for_closure::{vtable}() -> core::ops::function::FnOnce::{vt
     let size: usize; // local
     let align: usize; // local
     let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(u32,), Output = u32> + '1)); // anonymous local
-    let _4: extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32; // anonymous local
+    let _4: extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32; // anonymous local
     let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
 
     storage_live(ret)
@@ -273,7 +273,7 @@ fn impl_FnOnce_tuple_for_closure::{vtable}() -> core::ops::function::FnOnce::{vt
     storage_live(_3)
     _3 = cast<for<'_0_1> impl_FnOnce_tuple_for_closure::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(u32,), Output = u32> + '1))>(const impl_FnOnce_tuple_for_closure::{vtable_drop_shim}<'0>)
     storage_live(_4)
-    _4 = cast<impl_FnOnce_tuple_for_closure::{vtable_method}, extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32>(const impl_FnOnce_tuple_for_closure::{vtable_method})
+    _4 = cast<impl_FnOnce_tuple_for_closure::{vtable_method}, extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '2), (u32,)) -> u32>(const impl_FnOnce_tuple_for_closure::{vtable_method})
     storage_live(_5)
     _5 = &core::marker::MetaSized::{vtable}<{closure}>
     ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: move _5 }

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.out
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.out
@@ -427,6 +427,339 @@ where
     non-dyn-compatible
 }
 
+struct test_crate::main::{closure#3} {}
+
+// Full name: test_crate::main::{closure#3}::{impl Destruct for test_crate::main::{closure#3}}::drop_glue
+unsafe fn {impl Destruct for test_crate::main::{closure#3}}::drop_glue<'_0>(_1: &'_0 mut test_crate::main::{closure#3})
+{
+    let _0: (); // return
+    let _1: &'1 mut test_crate::main::{closure#3}; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::call
+fn {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::call<'_0, '_1>(_1: &'_1 test_crate::main::{closure#3}, tupled_args: (&'_0 u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'1 test_crate::main::{closure#3}; // arg #1
+    let tupled_args: (&'_0 u32,); // arg #2
+    let x: &'2 u32; // local
+
+    storage_live(_0)
+    storage_live(x)
+    x = move tupled_args._0
+    _0 = copy (*x)
+    storage_dead(x)
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::call_mut
+fn {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::call_mut<'_0, '_1>(state: &'_1 mut test_crate::main::{closure#3}, args: (&'_0 u32,)) -> u32
+{
+    let _0: u32; // return
+    let state: &'_1 mut test_crate::main::{closure#3}; // arg #1
+    let args: (&'_0 u32,); // arg #2
+    let _3: &'0 test_crate::main::{closure#3}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &(*state)
+    _0 = {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::call<'_0, '2>(move _3, move args)
+    ↳⚡ storage_dead(_3)
+        storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::call_once
+fn {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::call_once<'_0>(_1: test_crate::main::{closure#3}, _2: (&'_0 u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: test_crate::main::{closure#3}; // arg #1
+    let _2: (&'0 u32,); // arg #2
+    let _3: &'2 mut test_crate::main::{closure#3}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::call_mut<'_0, '7>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::main::{closure#3}}::drop_glue<'8>] _1
+        ↳⚡ storage_dead(_3)
+            storage_dead(_2)
+            storage_dead(_1)
+            unwind_terminate
+        storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    drop[{impl Destruct for test_crate::main::{closure#3}}::drop_glue<'9>] _1
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}
+extern "rust-call" fn {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0>(_1: *mut (dyn FnOnce<(&'_ u32,), Output = u32>), _2: (&'_ u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: *mut (dyn FnOnce<(&'0 u32,), Output = u32> + '1); // arg #1
+    let _2: (&'3 u32,); // arg #2
+    let _3: *mut test_crate::main::{closure#3}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<*mut (dyn FnOnce<(&'4 u32,), Output = u32> + '5), *mut test_crate::main::{closure#3}>(move _1)
+    _0 = {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::call_once<'_0>(move (*_3), move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}
+unsafe fn {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '_1>(dyn_self: &'_1 mut (dyn FnOnce<(&'_ u32,), Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_1 mut (dyn FnOnce<(&'0 u32,), Output = u32> + '1); // arg #1
+    let target_self: &'_1 mut test_crate::main::{closure#3}; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_1 mut (dyn FnOnce<(&'3 u32,), Output = u32> + '4), &'_1 mut test_crate::main::{closure#3}>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure#3}}::drop_glue<'9>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}
+fn {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>() -> core::ops::function::FnOnce::{vtable}<(&'_ u32,), u32>
+{
+    let ret: core::ops::function::FnOnce::{vtable}<(&'0 u32,), u32>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(&'4 u32,), Output = u32> + '5)); // anonymous local
+    let _4: extern "rust-call" fn(*mut (dyn FnOnce<(&'7 u32,), Output = u32> + '8), (&'10 u32,)) -> u32; // anonymous local
+    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<test_crate::main::{closure#3}>
+    storage_live(align)
+    align = align_of<test_crate::main::{closure#3}>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '3>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<(&'4 u32,), Output = u32> + '5))>(const {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '3>)
+    storage_live(_4)
+    _4 = cast<{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0>, extern "rust-call" fn(*mut (dyn FnOnce<(&'7 u32,), Output = u32> + '8), (&'10 u32,)) -> u32>(const {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0>)
+    storage_live(_5)
+    _5 = &core::marker::MetaSized::{vtable}<test_crate::main::{closure#3}>
+    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: move _5 }
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}
+static {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>: core::ops::function::FnOnce::{vtable}<(&'_ u32,), u32> = {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>()
+
+// Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}
+extern "rust-call" fn {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0, '_1>(_1: &'_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32>), _2: (&'_ u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_1 mut (dyn FnMut<(&'0 u32,), ImpliedClause1::Output = u32> + '1); // arg #1
+    let _2: (&'4 u32,); // arg #2
+    let _3: &'_1 mut test_crate::main::{closure#3}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_1 mut (dyn FnMut<(&'5 u32,), ImpliedClause1::Output = u32> + '6), &'_1 mut test_crate::main::{closure#3}>(move _1)
+    _0 = {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::call_mut<'_0, '_1>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}
+unsafe fn {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '_1>(dyn_self: &'_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_1 mut (dyn FnMut<(&'0 u32,), ImpliedClause1::Output = u32> + '1); // arg #1
+    let target_self: &'_1 mut test_crate::main::{closure#3}; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_1 mut (dyn FnMut<(&'4 u32,), ImpliedClause1::Output = u32> + '5), &'_1 mut test_crate::main::{closure#3}>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure#3}}::drop_glue<'12>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}
+fn {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>() -> core::ops::function::FnMut::{vtable}<(&'_ u32,), u32>
+{
+    let ret: core::ops::function::FnMut::{vtable}<(&'0 u32,), u32>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<(&'4 u32,), ImpliedClause1::Output = u32> + '5)); // anonymous local
+    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(&'9 u32,), ImpliedClause1::Output = u32> + '10), (&'13 u32,)) -> u32; // anonymous local
+    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _6: &'static core::ops::function::FnOnce::{vtable}<(&'25 u32,), u32>; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<test_crate::main::{closure#3}>
+    storage_live(align)
+    align = align_of<test_crate::main::{closure#3}>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '3>, unsafe fn<'_0_1>(&'_0_1 mut (dyn FnMut<(&'4 u32,), ImpliedClause1::Output = u32> + '5))>(const {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '3>)
+    storage_live(_4)
+    _4 = cast<for<'_0_1> {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0, '8>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(&'9 u32,), ImpliedClause1::Output = u32> + '10), (&'13 u32,)) -> u32>(const {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0, '8>)
+    storage_live(_5)
+    _5 = &core::marker::MetaSized::{vtable}<test_crate::main::{closure#3}>
+    storage_live(_6)
+    _6 = &{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>
+    ret = core::ops::function::FnMut::{vtable} { size: move size, align: move align, drop: move _3, method_call_mut: move _4, super_trait_0: move _5, super_trait_1: move _6 }
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}
+static {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>: core::ops::function::FnMut::{vtable}<(&'_ u32,), u32> = {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>()
+
+// Full name: test_crate::main::{impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}
+extern "rust-call" fn {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0, '_1>(_1: &'_1 (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32>), _2: (&'_ u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_1 (dyn Fn<(&'0 u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1); // arg #1
+    let _2: (&'5 u32,); // arg #2
+    let _3: &'_1 test_crate::main::{closure#3}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_1 (dyn Fn<(&'6 u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '7), &'_1 test_crate::main::{closure#3}>(move _1)
+    _0 = {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::call<'_0, '_1>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}
+unsafe fn {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '_1>(dyn_self: &'_1 mut (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_1 mut (dyn Fn<(&'0 u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1); // arg #1
+    let target_self: &'_1 mut test_crate::main::{closure#3}; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_1 mut (dyn Fn<(&'5 u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '6), &'_1 mut test_crate::main::{closure#3}>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure#3}}::drop_glue<'15>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}
+fn {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>() -> core::ops::function::Fn::{vtable}<(&'_ u32,), u32>
+{
+    let ret: core::ops::function::Fn::{vtable}<(&'0 u32,), u32>; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(&'4 u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '5)); // anonymous local
+    let _4: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(&'10 u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '11), (&'15 u32,)) -> u32; // anonymous local
+    let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _6: &'static core::ops::function::FnMut::{vtable}<(&'35 u32,), u32>; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<test_crate::main::{closure#3}>
+    storage_live(align)
+    align = align_of<test_crate::main::{closure#3}>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '3>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Fn<(&'4 u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '5))>(const {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '3>)
+    storage_live(_4)
+    _4 = cast<for<'_0_1> {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0, '9>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(&'10 u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '11), (&'15 u32,)) -> u32>(const {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0, '9>)
+    storage_live(_5)
+    _5 = &core::marker::MetaSized::{vtable}<test_crate::main::{closure#3}>
+    storage_live(_6)
+    _6 = &{impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>
+    ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move _3, method_call: move _4, super_trait_0: move _5, super_trait_1: move _6 }
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}
+static {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>: core::ops::function::Fn::{vtable}<(&'_ u32,), u32> = {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>()
+
+// Full name: test_crate::main::{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}
+impl<'_0> FnOnce<(&'_ u32,)> for test_crate::main::{closure#3} {
+    proof ImpliedClause0: (test_crate::main::{closure#3}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#3}}
+    proof ImpliedClause1: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause2: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
+    type Output = u32
+    fn call_once = {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::call_once<'_0>
+    vtable: {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>
+}
+
+// Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}
+impl<'_0> FnMut<(&'_ u32,)> for test_crate::main::{closure#3} {
+    proof ImpliedClause0: (test_crate::main::{closure#3}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#3}}
+    proof ImpliedClause1: (test_crate::main::{closure#3}: FnOnce<(&'_ u32,)>) = {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}<'_0>
+    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::call_mut<'_0, '_0_1>
+    vtable: {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>
+}
+
+// Full name: test_crate::main::{impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}
+impl<'_0> Fn<(&'_ u32,)> for test_crate::main::{closure#3} {
+    proof ImpliedClause0: (test_crate::main::{closure#3}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#3}}
+    proof ImpliedClause1: (test_crate::main::{closure#3}: FnMut<(&'_ u32,)>) = {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}<'_0>
+    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    fn call<'_0_1> = {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::call<'_0, '_0_1>
+    vtable: {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>
+}
+
 struct test_crate::main::{closure#2} {
   _0: Droppable,
 }
@@ -1263,30 +1596,48 @@ fn main()
     let _18: Box<test_crate::main::{closure#2}>[{built_in impl MetaSized for test_crate::main::{closure#2}}, {built_in impl Sized for Global}]; // anonymous local
     let _19: test_crate::main::{closure#2}; // anonymous local
     let _w: Box<(dyn FnOnce<(), Output = u32> + '39)>[{built_in impl MetaSized for (dyn FnOnce<(), Output = u32> + '41)}, {built_in impl Sized for Global}]; // local
-    let _21: &'42 test_crate::main::{closure}; // anonymous local
-    let _22: &'43 test_crate::main::{closure}; // anonymous local
-    let _23: &'123 test_crate::main::{closure}; // anonymous local
-    let _24: test_crate::main::{closure}; // anonymous local
+    let k: &'49 (dyn for<'_0_2> Fn<(&'_0_2 u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '50); // local
+    let _22: &'53 test_crate::main::{closure#3}; // anonymous local
+    let _23: &'54 test_crate::main::{closure#3}; // anonymous local
+    let _y_24: u32; // local
+    let _25: &'55 (dyn for<'_0_2> Fn<(&'_0_2 u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '56); // anonymous local
+    let _26: (&'59 u32,); // anonymous local
+    let _27: &'60 u32; // anonymous local
+    let _28: &'61 u32; // anonymous local
+    let _29: &'62 u32; // anonymous local
+    let _30: &'63 test_crate::main::{closure#3}; // anonymous local
+    let _31: &'64 test_crate::main::{closure}; // anonymous local
+    let _32: &'65 test_crate::main::{closure}; // anonymous local
+    let _33: &'114 test_crate::main::{closure#3}; // anonymous local
+    let _34: &'127 u32; // anonymous local
+    let _35: &'191 test_crate::main::{closure}; // anonymous local
+    let _36: test_crate::main::{closure}; // anonymous local
+    let _37: &'192 test_crate::main::{closure#3}; // anonymous local
+    let _38: test_crate::main::{closure#3}; // anonymous local
+    let _39: &'193 u32; // anonymous local
+    let _40: u32; // anonymous local
 
-    storage_live(_22)
-    storage_live(_23)
-    storage_live(_24)
-    _24 = test_crate::main::{closure} {  }
-    _23 = &_24
-    _22 = move _23
+    storage_live(_32)
+    storage_live(_35)
+    storage_live(_36)
+    _36 = test_crate::main::{closure} {  }
+    _35 = &_36
+    _32 = move _35
     storage_live(_0)
-    storage_live(_21)
+    storage_live(_29)
+    storage_live(_30)
+    storage_live(_31)
     _0 = ()
     storage_live(f)
     storage_live(_2)
     storage_live(_3)
-    _21 = move _22
-    _3 = &(*_21)
+    _31 = move _32
+    _3 = &(*_31)
     _2 = &(*_3)
-    f = unsize_cast<&'6 test_crate::main::{closure}, &'44 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '45), &{impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}>(move _2)
+    f = unsize_cast<&'6 test_crate::main::{closure}, &'66 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '67), &{impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}>(move _2)
     storage_dead(_2)
     fake_read(f)
-    set_type(typeof(f) == &'46 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '47))
+    set_type(typeof(f) == &'68 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '69))
     storage_dead(_3)
     storage_live(_y_4)
     storage_live(_5)
@@ -1294,7 +1645,9 @@ fn main()
     storage_live(_6)
     _6 = (const 1u32,)
     _y_4 = (copy (*_5.metadata).method_call)(move _5, move _6)
-    ↳⚡ storage_dead(_21)
+    ↳⚡ storage_dead(_31)
+        storage_dead(_30)
+        storage_dead(_29)
         unwind_continue
     storage_dead(_6)
     storage_dead(_5)
@@ -1313,10 +1666,10 @@ fn main()
     storage_dead(_12)
     _10 = &_11
     _9 = &(*_10)
-    g = unsize_cast<&'15 test_crate::main::{closure#1}<'16>, &'54 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '55), &{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'61>>(move _9)
+    g = unsize_cast<&'15 test_crate::main::{closure#1}<'16>, &'76 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '77), &{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'83>>(move _9)
     storage_dead(_9)
     fake_read(g)
-    set_type(typeof(g) == &'62 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '63))
+    set_type(typeof(g) == &'84 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '85))
     storage_dead(_10)
     storage_live(_y_13)
     storage_live(_14)
@@ -1324,7 +1677,9 @@ fn main()
     storage_live(_15)
     _15 = (const 2u32,)
     _y_13 = (copy (*_14.metadata).method_call)(move _14, move _15)
-    ↳⚡ storage_dead(_21)
+    ↳⚡ storage_dead(_31)
+        storage_dead(_30)
+        storage_dead(_29)
         unwind_continue
     storage_dead(_15)
     storage_dead(_14)
@@ -1338,86 +1693,258 @@ fn main()
     storage_live(_19)
     _19 = test_crate::main::{closure#2} { _0: move d }
     _18 = new<test_crate::main::{closure#2}>[{built_in impl Sized for test_crate::main::{closure#2}}](move _19)
-    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'68>] _19
-        ↳⚡ storage_dead(_21)
-            storage_dead(_24)
-            storage_dead(_23)
-            storage_dead(_22)
+    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'90>] _19
+        ↳⚡ storage_dead(_31)
+            storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
             unwind_terminate
-        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'73>] d
-        ↳⚡ storage_dead(_21)
-            storage_dead(_24)
-            storage_dead(_23)
-            storage_dead(_22)
+        // A closure with a higher-ranked signature.
+        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'95>] d
+        ↳⚡ storage_dead(_31)
+            storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
             unwind_terminate
-        storage_dead(_21)
+        storage_dead(_31)
+        storage_dead(_30)
+        storage_dead(_29)
         unwind_continue
-    _h = unsize_cast<Box<test_crate::main::{closure#2}>[{built_in impl MetaSized for test_crate::main::{closure#2}}, {built_in impl Sized for Global}], Box<(dyn FnOnce<(), Output = Droppable> + '69)>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '71)}, {built_in impl Sized for Global}], &{impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable}>(move _18)
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'72, test_crate::main::{closure#2}, Global>[{built_in impl MetaSized for test_crate::main::{closure#2}}, {built_in impl Sized for Global}]] _18
-    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'68>] _19
-        ↳⚡ storage_dead(_21)
-            storage_dead(_24)
-            storage_dead(_23)
-            storage_dead(_22)
+    _h = unsize_cast<Box<test_crate::main::{closure#2}>[{built_in impl MetaSized for test_crate::main::{closure#2}}, {built_in impl Sized for Global}], Box<(dyn FnOnce<(), Output = Droppable> + '91)>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '93)}, {built_in impl Sized for Global}], &{impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable}>(move _18)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'94, test_crate::main::{closure#2}, Global>[{built_in impl MetaSized for test_crate::main::{closure#2}}, {built_in impl Sized for Global}]] _18
+    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'90>] _19
+        ↳⚡ storage_dead(_31)
+            storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
             unwind_terminate
-        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'73>] d
-        ↳⚡ storage_dead(_21)
-            storage_dead(_24)
-            storage_dead(_23)
-            storage_dead(_22)
+        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'95>] d
+        ↳⚡ storage_dead(_31)
+            storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
             unwind_terminate
-        storage_dead(_21)
+        storage_dead(_31)
+        storage_dead(_30)
+        storage_dead(_29)
         unwind_continue
     storage_dead(_19)
     storage_dead(_18)
     fake_read(_h)
-    set_type(typeof(_h) == Box<(dyn FnOnce<(), Output = Droppable> + '74)>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '76)}, {built_in impl Sized for Global}])
+    set_type(typeof(_h) == Box<(dyn FnOnce<(), Output = Droppable> + '96)>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '98)}, {built_in impl Sized for Global}])
     storage_live(_w)
     _w = wrap<u32>[{built_in impl Sized for u32}](const 3u32)
-    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'91, (dyn FnOnce<(), Output = Droppable> + '86), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '86)}, {built_in impl Sized for Global}]] _h
-        ↳⚡ storage_dead(_21)
-            storage_dead(_24)
-            storage_dead(_23)
-            storage_dead(_22)
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'113, (dyn FnOnce<(), Output = Droppable> + '108), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '108)}, {built_in impl Sized for Global}]] _h
+        ↳⚡ storage_dead(_31)
+            storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
             unwind_terminate
-        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'73>] d
-        ↳⚡ storage_dead(_21)
-            storage_dead(_24)
-            storage_dead(_23)
-            storage_dead(_22)
+        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'95>] d
+        ↳⚡ storage_dead(_31)
+            storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
             unwind_terminate
-        storage_dead(_21)
+        storage_dead(_31)
+        storage_dead(_30)
+        storage_dead(_29)
         unwind_continue
+    storage_live(_34)
+    storage_live(_39)
+    storage_live(_40)
+    _40 = const 4u32
+    _39 = &_40
+    _34 = move _39
+    storage_live(_33)
+    storage_live(_37)
+    storage_live(_38)
+    _38 = test_crate::main::{closure#3} {  }
+    _37 = &_38
+    _33 = move _37
     fake_read(_w)
+    storage_live(k)
+    storage_live(_22)
+    storage_live(_23)
+    _30 = move _33
+    _23 = &(*_30)
+    _22 = &(*_23)
+    k = unsize_cast<&'53 test_crate::main::{closure#3}, &'115 (dyn for<'_0_2> Fn<(&'_0_2 u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '116), &{impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'120>>(move _22)
+    storage_dead(_22)
+    fake_read(k)
+    set_type(typeof(k) == &'122 (dyn for<'_0_2> Fn<(&'_0_2 u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '123))
+    storage_dead(_23)
+    storage_live(_y_24)
+    storage_live(_25)
+    _25 = &(*k) with_metadata(copy k.metadata)
+    storage_live(_26)
+    storage_live(_27)
+    storage_live(_28)
+    _29 = move _34
+    _28 = &(*_29)
+    _27 = &(*_28)
+    _26 = (move _27,)
+    _y_24 = (copy (*_25.metadata).method_call)(move _25, move _26)
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'159, (dyn FnOnce<(), Output = u32> + '154), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = u32> + '154)}, {built_in impl Sized for Global}]] _w
+        ↳⚡ storage_dead(_31)
+            storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
+            unwind_terminate
+        conditional_drop[impl_Destruct_for_Box::drop_glue<'113, (dyn FnOnce<(), Output = Droppable> + '108), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '108)}, {built_in impl Sized for Global}]] _h
+        ↳⚡ storage_dead(_31)
+            storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
+            unwind_terminate
+        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'95>] d
+        ↳⚡ storage_dead(_31)
+            storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
+            unwind_terminate
+        storage_dead(_31)
+        storage_dead(_30)
+        storage_dead(_29)
+        unwind_continue
+    storage_dead(_27)
+    storage_dead(_26)
+    storage_dead(_25)
+    fake_read(_y_24)
+    storage_dead(_28)
     _0 = ()
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'106, (dyn FnOnce<(), Output = u32> + '101), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = u32> + '101)}, {built_in impl Sized for Global}]] _w
-    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'91, (dyn FnOnce<(), Output = Droppable> + '86), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '86)}, {built_in impl Sized for Global}]] _h
-        ↳⚡ storage_dead(_21)
-            storage_dead(_24)
-            storage_dead(_23)
-            storage_dead(_22)
+    storage_dead(_y_24)
+    storage_dead(k)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'174, (dyn FnOnce<(), Output = u32> + '169), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = u32> + '169)}, {built_in impl Sized for Global}]] _w
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'113, (dyn FnOnce<(), Output = Droppable> + '108), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '108)}, {built_in impl Sized for Global}]] _h
+        ↳⚡ storage_dead(_31)
+            storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
             unwind_terminate
-        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'73>] d
-        ↳⚡ storage_dead(_21)
-            storage_dead(_24)
-            storage_dead(_23)
-            storage_dead(_22)
+        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'95>] d
+        ↳⚡ storage_dead(_31)
+            storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
             unwind_terminate
-        storage_dead(_21)
+        storage_dead(_31)
+        storage_dead(_30)
+        storage_dead(_29)
         unwind_continue
     storage_dead(_w)
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'121, (dyn FnOnce<(), Output = Droppable> + '116), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '116)}, {built_in impl Sized for Global}]] _h
-    ↳⚡ conditional_drop[impl_Destruct_for_Droppable::drop_glue<'73>] d
-        ↳⚡ storage_dead(_21)
-            storage_dead(_24)
-            storage_dead(_23)
-            storage_dead(_22)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'189, (dyn FnOnce<(), Output = Droppable> + '184), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = Droppable> + '184)}, {built_in impl Sized for Global}]] _h
+    ↳⚡ conditional_drop[impl_Destruct_for_Droppable::drop_glue<'95>] d
+        ↳⚡ storage_dead(_31)
+            storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
             unwind_terminate
-        storage_dead(_21)
+        storage_dead(_31)
+        storage_dead(_30)
+        storage_dead(_29)
         unwind_continue
     storage_dead(_h)
-    conditional_drop[impl_Destruct_for_Droppable::drop_glue<'122>] d
-    ↳⚡ storage_dead(_21)
+    conditional_drop[impl_Destruct_for_Droppable::drop_glue<'190>] d
+    ↳⚡ storage_dead(_31)
+        storage_dead(_30)
+        storage_dead(_29)
         unwind_continue
     storage_dead(d)
     storage_dead(_y_13)
@@ -1426,10 +1953,18 @@ fn main()
     storage_dead(captured)
     storage_dead(_y_4)
     storage_dead(f)
-    storage_dead(_21)
-    storage_dead(_24)
-    storage_dead(_23)
-    storage_dead(_22)
+    storage_dead(_31)
+    storage_dead(_30)
+    storage_dead(_29)
+    storage_dead(_40)
+    storage_dead(_39)
+    storage_dead(_38)
+    storage_dead(_37)
+    storage_dead(_36)
+    storage_dead(_35)
+    storage_dead(_34)
+    storage_dead(_33)
+    storage_dead(_32)
     return
 }
 
@@ -1448,6 +1983,12 @@ impl<'_0> Destruct for test_crate::main::{closure#1}<'_0> {
 // Full name: test_crate::main::{closure#2}::{impl Destruct for test_crate::main::{closure#2}}
 impl Destruct for test_crate::main::{closure#2} {
     fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::{closure#2}}::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::main::{closure#3}::{impl Destruct for test_crate::main::{closure#3}}
+impl Destruct for test_crate::main::{closure#3} {
+    fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::{closure#3}}::drop_glue<'_0_1>
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.rs
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.rs
@@ -1,6 +1,24 @@
 //@ charon-args=--include=core::ops::function
 
+struct Droppable(u32);
+impl Drop for Droppable {
+    fn drop(&mut self) {}
+}
+
+// The vtable instance for a closure capturing a generic is itself generic.
+fn wrap<T: 'static>(x: T) -> Box<dyn FnOnce() -> T> {
+    Box::new(move || x)
+}
+
 fn main() {
     let f: &dyn Fn(u32) -> u32 = &|x| x + 1;
     let _y = f(1);
+    // A closure with captured state.
+    let captured = 10;
+    let g: &dyn Fn(u32) -> u32 = &|x| x + captured;
+    let _y = g(2);
+    // Built but not called: the drop shim must drop the captured state.
+    let d = Droppable(0);
+    let _h: Box<dyn FnOnce() -> Droppable> = Box::new(move || d);
+    let _w = wrap(3u32);
 }

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.rs
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.rs
@@ -21,4 +21,7 @@ fn main() {
     let d = Droppable(0);
     let _h: Box<dyn FnOnce() -> Droppable> = Box::new(move || d);
     let _w = wrap(3u32);
+    // A closure with a higher-ranked signature.
+    let k: &dyn Fn(&u32) -> u32 = &|x: &u32| *x;
+    let _y = k(&4);
 }

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.rs
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable-poly.rs
@@ -1,0 +1,6 @@
+//@ charon-args=--include=core::ops::function
+
+fn main() {
+    let f: &dyn Fn(u32) -> u32 = &|x| x + 1;
+    let _y = f(1);
+}

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable.out
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable.out
@@ -31,6 +31,11 @@ fn core::marker::MetaSized::{vtable}::<test_crate::main::{closure#2}>() -> core:
 
 static core::marker::MetaSized::{vtable}::<test_crate::main::{closure#2}>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<test_crate::main::{closure#2}>()
 
+fn core::marker::MetaSized::{vtable}::<test_crate::main::{closure#3}>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<test_crate::main::{closure#3}>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<test_crate::main::{closure#3}>()
+
 struct () {}
 
 // Full name: core::marker::Destruct
@@ -163,6 +168,10 @@ struct (_, _)::<u32, bool> {
   _1: bool,
 }
 
+struct (_,)::<&'_ u32> {
+  _0: &'_ u32,
+}
+
 // Full name: test_crate::{impl Drop for Droppable}::drop
 pub fn drop<'_0>(self: &'_0 mut Droppable)
 {
@@ -210,6 +219,370 @@ impl "impl_Destruct_for_Droppable" Destruct for Droppable {
 impl "impl_Drop_for_Droppable" Drop for Droppable {
     proof ImpliedClause0: (Droppable: MetaSized) = {built_in impl MetaSized for Droppable}
     vtable: impl_Drop_for_Droppable::{vtable}
+}
+
+struct test_crate::main::{closure#3} {}
+
+// Full name: test_crate::main::{closure#3}::{impl Destruct for test_crate::main::{closure#3}}::drop_glue
+unsafe fn {impl Destruct for test_crate::main::{closure#3}}::drop_glue<'_0>(_1: &'_0 mut test_crate::main::{closure#3})
+{
+    let _0: (); // return
+    let _1: &'1 mut test_crate::main::{closure#3}; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::call
+fn {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::call<'_0, '_1>(_1: &'_1 test_crate::main::{closure#3}, tupled_args: (&'_ u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'1 test_crate::main::{closure#3}; // arg #1
+    let tupled_args: (&'_ u32,); // arg #2
+    let x: &'3 u32; // local
+
+    storage_live(_0)
+    storage_live(x)
+    x = move tupled_args._0
+    _0 = copy (*x)
+    storage_dead(x)
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::call_mut
+fn {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::call_mut<'_0, '_1>(state: &'_1 mut test_crate::main::{closure#3}, args: (&'_ u32,)) -> u32
+{
+    let _0: u32; // return
+    let state: &'_1 mut test_crate::main::{closure#3}; // arg #1
+    let args: (&'_ u32,); // arg #2
+    let _3: &'0 test_crate::main::{closure#3}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &(*state)
+    _0 = {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::call<'_0, '2>(move _3, move args)
+    ↳⚡ storage_dead(_3)
+        storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::call_once
+fn {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::call_once<'_0>(_1: test_crate::main::{closure#3}, _2: (&'_ u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: test_crate::main::{closure#3}; // arg #1
+    let _2: (&'_ u32,); // arg #2
+    let _3: &'1 mut test_crate::main::{closure#3}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::call_mut<'_0, '4>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::main::{closure#3}}::drop_glue<'5>] _1
+        ↳⚡ storage_dead(_3)
+            storage_dead(_2)
+            storage_dead(_1)
+            unwind_terminate
+        storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    drop[{impl Destruct for test_crate::main::{closure#3}}::drop_glue<'6>] _1
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}
+extern "rust-call" fn {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0>(_1: *mut (dyn FnOnce<(&'_ u32,), Output = u32>), _2: (&'_ u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: *mut (dyn FnOnce<(&'_ u32,), Output = u32> + '0); // arg #1
+    let _2: (&'_ u32,); // arg #2
+    let _3: *mut test_crate::main::{closure#3}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '1), *mut test_crate::main::{closure#3}>(move _1)
+    _0 = {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::call_once<'_0>(move (*_3), move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}
+unsafe fn {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '_1>(dyn_self: &'_1 mut (dyn FnOnce<(&'_ u32,), Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_1 mut (dyn FnOnce<(&'_ u32,), Output = u32> + '0); // arg #1
+    let target_self: &'_1 mut test_crate::main::{closure#3}; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_1 mut (dyn FnOnce<(&'_ u32,), Output = u32> + '1), &'_1 mut test_crate::main::{closure#3}>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure#3}}::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}
+fn {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>() -> core::ops::function::FnOnce::{vtable}
+{
+    let ret: core::ops::function::FnOnce::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call_once: extern "rust-call" fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '1), (&'_ u32,)) -> u32; // local
+    let erased_call_once: *const (); // local
+    let _7: unsafe fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '8), (&'_ u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<test_crate::main::{closure#3}>
+    storage_live(align)
+    align = align_of<test_crate::main::{closure#3}>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '3>, unsafe fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '4))>(const {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call_once)
+    storage_live(erased_call_once)
+    storage_live(_8)
+    _8 = cast<{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0>, extern "rust-call" fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '8), (&'_ u32,)) -> u32>(const {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0>)
+    call_once = move _8
+    erased_call_once = cast<extern "rust-call" fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '9), (&'_ u32,)) -> u32, *const ()>(move call_once)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<test_crate::main::{closure#3}>
+    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_once: move erased_call_once, super_trait_0: move _9 }
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}
+static {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>: core::ops::function::FnOnce::{vtable} = {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>()
+
+// Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}
+extern "rust-call" fn {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0, '_1>(_1: &'_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32>), _2: (&'_ u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '0); // arg #1
+    let _2: (&'_ u32,); // arg #2
+    let _3: &'_1 mut test_crate::main::{closure#3}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '1), &'_1 mut test_crate::main::{closure#3}>(move _1)
+    _0 = {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::call_mut<'_0, '_1>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}
+unsafe fn {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '_1>(dyn_self: &'_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '0); // arg #1
+    let target_self: &'_1 mut test_crate::main::{closure#3}; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '1), &'_1 mut test_crate::main::{closure#3}>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure#3}}::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}
+fn {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>() -> core::ops::function::FnMut::{vtable}
+{
+    let ret: core::ops::function::FnMut::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call_mut: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '1), (&'_ u32,)) -> u32; // local
+    let erased_call_mut: *const (); // local
+    let _7: unsafe fn(*mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '9), (&'_ u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _10: &'static core::ops::function::FnOnce::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<test_crate::main::{closure#3}>
+    storage_live(align)
+    align = align_of<test_crate::main::{closure#3}>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<{impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '3>, unsafe fn(*mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '4))>(const {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call_mut)
+    storage_live(erased_call_mut)
+    storage_live(_8)
+    _8 = cast<for<'_0_1> {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0, '8>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '9), (&'_ u32,)) -> u32>(const {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0, '8>)
+    call_mut = move _8
+    erased_call_mut = cast<extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '10), (&'_ u32,)) -> u32, *const ()>(move call_mut)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<test_crate::main::{closure#3}>
+    storage_live(_10)
+    _10 = &{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>
+    ret = core::ops::function::FnMut::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_mut: move erased_call_mut, super_trait_0: move _9, super_trait_1: move _10 }
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}
+static {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>: core::ops::function::FnMut::{vtable} = {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>()
+
+// Full name: test_crate::main::{impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}
+extern "rust-call" fn {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0, '_1>(_1: &'_1 (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32>), _2: (&'_ u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_1 (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
+    let _2: (&'_ u32,); // arg #2
+    let _3: &'_1 test_crate::main::{closure#3}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_1 (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_1 test_crate::main::{closure#3}>(move _1)
+    _0 = {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::call<'_0, '_1>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}
+unsafe fn {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '_1>(dyn_self: &'_1 mut (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_1 mut (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
+    let target_self: &'_1 mut test_crate::main::{closure#3}; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_1 mut (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_1 mut test_crate::main::{closure#3}>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure#3}}::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}
+fn {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>() -> core::ops::function::Fn::{vtable}
+{
+    let ret: core::ops::function::Fn::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), (&'_ u32,)) -> u32; // local
+    let erased_call: *const (); // local
+    let _7: unsafe fn(*mut (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (&'_ u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _10: &'static core::ops::function::FnMut::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<test_crate::main::{closure#3}>
+    storage_live(align)
+    align = align_of<test_crate::main::{closure#3}>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<{impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '3>, unsafe fn(*mut (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4))>(const {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_drop_shim}<'_0, '3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call)
+    storage_live(erased_call)
+    storage_live(_8)
+    _8 = cast<for<'_0_1> {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0, '8>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (&'_ u32,)) -> u32>(const {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable_method}<'_0, '8>)
+    call = move _8
+    erased_call = cast<extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '10), (&'_ u32,)) -> u32, *const ()>(move call)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<test_crate::main::{closure#3}>
+    storage_live(_10)
+    _10 = &{impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>
+    ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call: move erased_call, super_trait_0: move _9, super_trait_1: move _10 }
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}
+static {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>: core::ops::function::Fn::{vtable} = {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>()
+
+// Full name: test_crate::main::{impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}
+impl<'_0> FnOnce<(&'_ u32,)> for test_crate::main::{closure#3} {
+    proof ImpliedClause0: (test_crate::main::{closure#3}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#3}}
+    proof ImpliedClause1: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause2: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    vtable: {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>
+}
+
+// Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}
+impl<'_0> FnMut<(&'_ u32,)> for test_crate::main::{closure#3} {
+    proof ImpliedClause0: (test_crate::main::{closure#3}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#3}}
+    proof ImpliedClause1: (test_crate::main::{closure#3}: FnOnce<(&'_ u32,)>) = {impl FnOnce<(&'_ u32,)> for test_crate::main::{closure#3}}<'_0>
+    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    vtable: {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>
+}
+
+// Full name: test_crate::main::{impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}
+impl<'_0> Fn<(&'_ u32,)> for test_crate::main::{closure#3} {
+    proof ImpliedClause0: (test_crate::main::{closure#3}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#3}}
+    proof ImpliedClause1: (test_crate::main::{closure#3}: FnMut<(&'_ u32,)>) = {impl FnMut<(&'_ u32,)> for test_crate::main::{closure#3}}<'_0>
+    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
+    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    vtable: {impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'_0>
 }
 
 // Full name: test_crate::main::{closure#2}::{impl Destruct for test_crate::main::{closure#2}}::drop_glue
@@ -1114,42 +1487,63 @@ fn main()
     let _h: Box::<(dyn FnOnce<(), Output = Droppable>), Global>; // local
     let _18: Box::<test_crate::main::{closure#2}, Global>; // anonymous local
     let _19: test_crate::main::{closure#2}; // anonymous local
-    let _20: &'24 test_crate::main::{closure}; // anonymous local
-    let _21: unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32; // anonymous local
-    let _22: unsafe fn(&'22 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '23), (u32,)) -> u32; // anonymous local
-    let _23: &'25 test_crate::main::{closure}; // anonymous local
-    let _24: &'53 test_crate::main::{closure}; // anonymous local
-    let _25: test_crate::main::{closure}; // anonymous local
+    let k: &'27 (dyn for<'_0_2> Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '28); // local
+    let _21: &'30 test_crate::main::{closure#3}; // anonymous local
+    let _22: &'31 test_crate::main::{closure#3}; // anonymous local
+    let _y_23: u32; // local
+    let _24: &'32 (dyn for<'_0_2> Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '33); // anonymous local
+    let _25: (&'_ u32,); // anonymous local
+    let _26: &'34 u32; // anonymous local
+    let _27: &'35 u32; // anonymous local
+    let _28: &'36 u32; // anonymous local
+    let _29: &'37 test_crate::main::{closure#3}; // anonymous local
+    let _30: &'38 test_crate::main::{closure}; // anonymous local
+    let _31: unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32; // anonymous local
+    let _32: unsafe fn(&'22 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '23), (u32,)) -> u32; // anonymous local
+    let _33: unsafe fn(&'32 (dyn for<'_0_3> Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '33), (&'_ u32,)) -> u32; // anonymous local
+    let _34: &'39 test_crate::main::{closure}; // anonymous local
+    let _35: &'65 test_crate::main::{closure#3}; // anonymous local
+    let _36: &'75 u32; // anonymous local
+    let _37: &'82 test_crate::main::{closure}; // anonymous local
+    let _38: test_crate::main::{closure}; // anonymous local
+    let _39: &'83 test_crate::main::{closure#3}; // anonymous local
+    let _40: test_crate::main::{closure#3}; // anonymous local
+    let _41: &'84 u32; // anonymous local
+    let _42: u32; // anonymous local
 
-    storage_live(_23)
-    storage_live(_24)
-    storage_live(_25)
-    _25 = test_crate::main::{closure} {  }
-    _24 = &_25
-    _23 = move _24
+    storage_live(_34)
+    storage_live(_37)
+    storage_live(_38)
+    _38 = test_crate::main::{closure} {  }
+    _37 = &_38
+    _34 = move _37
     storage_live(_0)
-    storage_live(_20)
+    storage_live(_28)
+    storage_live(_29)
+    storage_live(_30)
     _0 = ()
     storage_live(f)
     storage_live(_2)
     storage_live(_3)
-    _20 = move _23
-    _3 = &(*_20)
+    _30 = move _34
+    _3 = &(*_30)
     _2 = &(*_3)
-    f = unsize_cast<&'6 test_crate::main::{closure}, &'26 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '27), &{impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}>(move _2)
+    f = unsize_cast<&'6 test_crate::main::{closure}, &'40 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '41), &{impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}>(move _2)
     storage_dead(_2)
     fake_read(f)
-    set_type(typeof(f) == &'28 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '29))
+    set_type(typeof(f) == &'42 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '43))
     storage_dead(_3)
     storage_live(_y_4)
     storage_live(_5)
     _5 = &(*f) with_metadata(copy f.metadata)
     storage_live(_6)
     _6 = (const 1u32,)
-    storage_live(_21)
-    _21 = cast<*const (), unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(copy (*_5.metadata).method_call)
-    _y_4 = (copy _21)(move _5, move _6)
-    ↳⚡ storage_dead(_20)
+    storage_live(_31)
+    _31 = cast<*const (), unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(copy (*_5.metadata).method_call)
+    _y_4 = (copy _31)(move _5, move _6)
+    ↳⚡ storage_dead(_30)
+        storage_dead(_29)
+        storage_dead(_28)
         unwind_continue
     storage_dead(_6)
     storage_dead(_5)
@@ -1168,20 +1562,22 @@ fn main()
     storage_dead(_12)
     _10 = &_11
     _9 = &(*_10)
-    g = unsize_cast<&'15 test_crate::main::{closure#1}<'16>, &'36 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '37), &{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'41>>(move _9)
+    g = unsize_cast<&'15 test_crate::main::{closure#1}<'16>, &'50 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '51), &{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'55>>(move _9)
     storage_dead(_9)
     fake_read(g)
-    set_type(typeof(g) == &'42 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '43))
+    set_type(typeof(g) == &'56 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '57))
     storage_dead(_10)
     storage_live(_y_13)
     storage_live(_14)
     _14 = &(*g) with_metadata(copy g.metadata)
     storage_live(_15)
     _15 = (const 2u32,)
-    storage_live(_22)
-    _22 = cast<*const (), unsafe fn(&'22 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '23), (u32,)) -> u32>(copy (*_14.metadata).method_call)
-    _y_13 = (copy _22)(move _14, move _15)
-    ↳⚡ storage_dead(_20)
+    storage_live(_32)
+    _32 = cast<*const (), unsafe fn(&'22 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '23), (u32,)) -> u32>(copy (*_14.metadata).method_call)
+    _y_13 = (copy _32)(move _14, move _15)
+    ↳⚡ storage_dead(_30)
+        storage_dead(_29)
+        storage_dead(_28)
         unwind_continue
     storage_dead(_15)
     storage_dead(_14)
@@ -1195,63 +1591,198 @@ fn main()
     storage_live(_19)
     _19 = test_crate::main::{closure#2} { _0: move d }
     _18 = new::<test_crate::main::{closure#2}>(move _19)
-    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'48>] _19
-        ↳⚡ storage_dead(_20)
-            storage_dead(_25)
-            storage_dead(_24)
-            storage_dead(_23)
-            storage_dead(_22)
-            storage_dead(_21)
+    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'62>] _19
+        ↳⚡ storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_28)
+            storage_dead(_42)
+            storage_dead(_41)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
+            storage_dead(_31)
             unwind_terminate
-        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'50>] d
-        ↳⚡ storage_dead(_20)
-            storage_dead(_25)
-            storage_dead(_24)
-            storage_dead(_23)
-            storage_dead(_22)
-            storage_dead(_21)
+        // A closure with a higher-ranked signature.
+        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'64>] d
+        ↳⚡ storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_28)
+            storage_dead(_42)
+            storage_dead(_41)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
+            storage_dead(_31)
             unwind_terminate
-        storage_dead(_20)
+        storage_dead(_30)
+        storage_dead(_29)
+        storage_dead(_28)
         unwind_continue
     _h = unsize_cast<Box::<test_crate::main::{closure#2}, Global>, Box::<(dyn FnOnce<(), Output = Droppable>), Global>, &impl_FnOnce_unit_for_closure::{vtable}>(move _18)
-    conditional_drop[{impl Destruct for Box::<test_crate::main::{closure#2}, Global>}::drop_glue::<test_crate::main::{closure#2}, Global><'49>] _18
-    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'48>] _19
-        ↳⚡ storage_dead(_20)
-            storage_dead(_25)
-            storage_dead(_24)
-            storage_dead(_23)
-            storage_dead(_22)
-            storage_dead(_21)
+    conditional_drop[{impl Destruct for Box::<test_crate::main::{closure#2}, Global>}::drop_glue::<test_crate::main::{closure#2}, Global><'63>] _18
+    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'62>] _19
+        ↳⚡ storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_28)
+            storage_dead(_42)
+            storage_dead(_41)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
+            storage_dead(_31)
             unwind_terminate
-        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'50>] d
-        ↳⚡ storage_dead(_20)
-            storage_dead(_25)
-            storage_dead(_24)
-            storage_dead(_23)
-            storage_dead(_22)
-            storage_dead(_21)
+        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'64>] d
+        ↳⚡ storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_28)
+            storage_dead(_42)
+            storage_dead(_41)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
+            storage_dead(_31)
             unwind_terminate
-        storage_dead(_20)
+        storage_dead(_30)
+        storage_dead(_29)
+        storage_dead(_28)
         unwind_continue
+    storage_live(_36)
+    storage_live(_41)
+    storage_live(_42)
+    _42 = const 4u32
+    _41 = &_42
+    _36 = move _41
+    storage_live(_35)
+    storage_live(_39)
+    storage_live(_40)
+    _40 = test_crate::main::{closure#3} {  }
+    _39 = &_40
+    _35 = move _39
     storage_dead(_19)
     storage_dead(_18)
     fake_read(_h)
     set_type(typeof(_h) == Box::<(dyn FnOnce<(), Output = Droppable>), Global>)
-    _0 = ()
-    conditional_drop[{impl Destruct for Box::<(dyn FnOnce<(), Output = Droppable>), Global>}::drop_glue::<(dyn FnOnce<(), Output = Droppable>), Global><'51>] _h
-    ↳⚡ conditional_drop[impl_Destruct_for_Droppable::drop_glue<'50>] d
-        ↳⚡ storage_dead(_20)
-            storage_dead(_25)
-            storage_dead(_24)
-            storage_dead(_23)
-            storage_dead(_22)
-            storage_dead(_21)
+    storage_live(k)
+    storage_live(_21)
+    storage_live(_22)
+    _29 = move _35
+    _22 = &(*_29)
+    _21 = &(*_22)
+    k = unsize_cast<&'30 test_crate::main::{closure#3}, &'66 (dyn for<'_0_2> Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '67), &{impl Fn<(&'_ u32,)> for test_crate::main::{closure#3}}::{vtable}<'70>>(move _21)
+    storage_dead(_21)
+    fake_read(k)
+    set_type(typeof(k) == &'72 (dyn for<'_0_2> Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '73))
+    storage_dead(_22)
+    storage_live(_y_23)
+    storage_live(_24)
+    _24 = &(*k) with_metadata(copy k.metadata)
+    storage_live(_25)
+    storage_live(_26)
+    storage_live(_27)
+    _28 = move _36
+    _27 = &(*_28)
+    _26 = &(*_27)
+    _25 = (move _26,)
+    storage_live(_33)
+    _33 = cast<*const (), unsafe fn(&'32 (dyn for<'_0_3> Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '33), (&'_ u32,)) -> u32>(copy (*_24.metadata).method_call)
+    _y_23 = (copy _33)(move _24, move _25)
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn FnOnce<(), Output = Droppable>), Global>}::drop_glue::<(dyn FnOnce<(), Output = Droppable>), Global><'79>] _h
+        ↳⚡ storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_28)
+            storage_dead(_42)
+            storage_dead(_41)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
+            storage_dead(_31)
             unwind_terminate
-        storage_dead(_20)
+        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'64>] d
+        ↳⚡ storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_28)
+            storage_dead(_42)
+            storage_dead(_41)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
+            storage_dead(_31)
+            unwind_terminate
+        storage_dead(_30)
+        storage_dead(_29)
+        storage_dead(_28)
+        unwind_continue
+    storage_dead(_26)
+    storage_dead(_25)
+    storage_dead(_24)
+    fake_read(_y_23)
+    storage_dead(_27)
+    _0 = ()
+    storage_dead(_y_23)
+    storage_dead(k)
+    conditional_drop[{impl Destruct for Box::<(dyn FnOnce<(), Output = Droppable>), Global>}::drop_glue::<(dyn FnOnce<(), Output = Droppable>), Global><'80>] _h
+    ↳⚡ conditional_drop[impl_Destruct_for_Droppable::drop_glue<'64>] d
+        ↳⚡ storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_28)
+            storage_dead(_42)
+            storage_dead(_41)
+            storage_dead(_40)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
+            storage_dead(_31)
+            unwind_terminate
+        storage_dead(_30)
+        storage_dead(_29)
+        storage_dead(_28)
         unwind_continue
     storage_dead(_h)
-    conditional_drop[impl_Destruct_for_Droppable::drop_glue<'52>] d
-    ↳⚡ storage_dead(_20)
+    conditional_drop[impl_Destruct_for_Droppable::drop_glue<'81>] d
+    ↳⚡ storage_dead(_30)
+        storage_dead(_29)
+        storage_dead(_28)
         unwind_continue
     storage_dead(d)
     storage_dead(_y_13)
@@ -1260,12 +1791,21 @@ fn main()
     storage_dead(captured)
     storage_dead(_y_4)
     storage_dead(f)
-    storage_dead(_20)
-    storage_dead(_25)
-    storage_dead(_24)
-    storage_dead(_23)
-    storage_dead(_22)
-    storage_dead(_21)
+    storage_dead(_30)
+    storage_dead(_29)
+    storage_dead(_28)
+    storage_dead(_42)
+    storage_dead(_41)
+    storage_dead(_40)
+    storage_dead(_39)
+    storage_dead(_38)
+    storage_dead(_37)
+    storage_dead(_36)
+    storage_dead(_35)
+    storage_dead(_34)
+    storage_dead(_33)
+    storage_dead(_32)
+    storage_dead(_31)
     return
 }
 
@@ -1284,6 +1824,12 @@ impl<'_0> Destruct for test_crate::main::{closure#1}<'_0> {
 // Full name: test_crate::main::{closure#2}::{impl Destruct for test_crate::main::{closure#2}}
 impl Destruct for test_crate::main::{closure#2} {
     fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::{closure#2}}::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::main::{closure#3}::{impl Destruct for test_crate::main::{closure#3}}
+impl Destruct for test_crate::main::{closure#3} {
+    fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::{closure#3}}::drop_glue<'_0_1>
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable.out
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable.out
@@ -16,10 +16,20 @@ pub trait Sized<Self>
     non-dyn-compatible
 }
 
-fn core::marker::MetaSized::{vtable}::<{closure}>() -> core::marker::MetaSized::{vtable}
+fn core::marker::MetaSized::{vtable}::<test_crate::main::{closure}>() -> core::marker::MetaSized::{vtable}
 = <opaque>
 
-static core::marker::MetaSized::{vtable}::<{closure}>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<{closure}>()
+static core::marker::MetaSized::{vtable}::<test_crate::main::{closure}>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<test_crate::main::{closure}>()
+
+fn core::marker::MetaSized::{vtable}::<test_crate::main::{closure#1}<'_>>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<test_crate::main::{closure#1}<'_>>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<test_crate::main::{closure#1}<'_>>()
+
+fn core::marker::MetaSized::{vtable}::<test_crate::main::{closure#2}>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<test_crate::main::{closure#2}>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<test_crate::main::{closure#2}>()
 
 struct () {}
 
@@ -38,6 +48,16 @@ pub trait Tuple<Self>
 {
     proof ImpliedClause0: (Self: MetaSized)
     non-dyn-compatible
+}
+
+opaque type core::ops::drop::Drop::{vtable}
+
+// Full name: core::ops::drop::Drop
+#[lang_item(Drop)]
+pub trait Drop<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    vtable: core::ops::drop::Drop::{vtable}
 }
 
 struct core::ops::function::FnOnce::{vtable} {
@@ -101,6 +121,39 @@ pub trait Fn<Self, Args>
     vtable: core::ops::function::Fn::{vtable}
 }
 
+// Full name: alloc::boxed::Box::<test_crate::main::{closure#2}>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<test_crate::main::{closure#2}, Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<test_crate::main::{closure#2}, Global>}::drop_glue::<test_crate::main::{closure#2}, Global>
+unsafe fn {impl Destruct for Box::<test_crate::main::{closure#2}, Global>}::drop_glue::<test_crate::main::{closure#2}, Global><'_0>(_1: &'_0 mut Box::<test_crate::main::{closure#2}, Global>)
+= <opaque>
+
+// Full name: alloc::boxed::Box::<(dyn FnOnce<(), Output = Droppable>)>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<(dyn FnOnce<(), Output = Droppable>), Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<(dyn FnOnce<(), Output = Droppable>), Global>}::drop_glue::<(dyn FnOnce<(), Output = Droppable>), Global>
+unsafe fn {impl Destruct for Box::<(dyn FnOnce<(), Output = Droppable>), Global>}::drop_glue::<(dyn FnOnce<(), Output = Droppable>), Global><'_0>(_1: &'_0 mut Box::<(dyn FnOnce<(), Output = Droppable>), Global>)
+= <opaque>
+
+// Full name: test_crate::Droppable
+struct Droppable {
+  _0: u32,
+}
+
+struct test_crate::main::{closure#2} {
+  _0: Droppable,
+}
+
+// Full name: alloc::boxed::{Box::<test_crate::main::{closure#2}, Global>}::new::<test_crate::main::{closure#2}>
+#[track_caller]
+#[diagnostic_item("box_new")]
+pub fn new::<test_crate::main::{closure#2}>(_1: test_crate::main::{closure#2}) -> Box::<test_crate::main::{closure#2}, Global>
+= <opaque>
+
 struct (_,)::<u32> {
   _0: u32,
 }
@@ -110,14 +163,189 @@ struct (_, _)::<u32, bool> {
   _1: bool,
 }
 
-// Full name: test_crate::main::{closure}
-struct {closure} {}
-
-// Full name: test_crate::main::{closure}::{impl Destruct for {closure}}::drop_glue
-unsafe fn drop_glue<'_0>(_1: &'_0 mut {closure})
+// Full name: test_crate::{impl Drop for Droppable}::drop
+pub fn drop<'_0>(self: &'_0 mut Droppable)
 {
     let _0: (); // return
-    let _1: &'1 mut {closure}; // arg #1
+    let self: &'1 mut Droppable; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::Droppable::{impl Destruct for Droppable}::drop_glue
+unsafe fn impl_Destruct_for_Droppable::drop_glue<'_0>(_1: &'_0 mut Droppable)
+{
+    let _0: (); // return
+    let _1: &'1 mut Droppable; // arg #1
+    let _2: &'2 mut Droppable; // anonymous local
+    let _3: (); // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    storage_live(_3)
+    _0 = ()
+    _2 = &mut (*_1)
+    _3 = drop<'4>(move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::Droppable::{impl Destruct for Droppable}
+impl "impl_Destruct_for_Droppable" Destruct for Droppable {
+    fn drop_glue<'_0_1> = impl_Destruct_for_Droppable::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl Drop for Droppable}
+impl "impl_Drop_for_Droppable" Drop for Droppable {
+    proof ImpliedClause0: (Droppable: MetaSized) = {built_in impl MetaSized for Droppable}
+    vtable: impl_Drop_for_Droppable::{vtable}
+}
+
+// Full name: test_crate::main::{closure#2}::{impl Destruct for test_crate::main::{closure#2}}::drop_glue
+unsafe fn {impl Destruct for test_crate::main::{closure#2}}::drop_glue<'_0>(_1: &'_0 mut test_crate::main::{closure#2})
+{
+    let _0: (); // return
+    let _1: &'1 mut test_crate::main::{closure#2}; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    drop[impl_Destruct_for_Droppable::drop_glue<'2>] (*_1)._0
+    ↳⚡ storage_dead(_1)
+        unwind_continue
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<()> for test_crate::main::{closure#2}}::call_once
+fn impl_FnOnce_unit_for_closure::call_once(_1: test_crate::main::{closure#2}, tupled_args: ()) -> Droppable
+{
+    let _0: Droppable; // return
+    let _1: test_crate::main::{closure#2}; // arg #1
+    let tupled_args: (); // arg #2
+
+    storage_live(_0)
+    _0 = move _1._0
+    conditional_drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'0>] _1
+    ↳⚡ storage_dead(tupled_args)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable_method}
+extern "rust-call" fn impl_FnOnce_unit_for_closure::{vtable_method}(_1: *mut (dyn FnOnce<(), Output = Droppable>), _2: ()) -> Droppable
+{
+    let _0: Droppable; // return
+    let _1: *mut (dyn FnOnce<(), Output = Droppable> + '0); // arg #1
+    let _2: (); // arg #2
+    let _3: *mut test_crate::main::{closure#2}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<*mut (dyn FnOnce<(), Output = Droppable> + '1), *mut test_crate::main::{closure#2}>(move _1)
+    _0 = impl_FnOnce_unit_for_closure::call_once(move (*_3), move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable_drop_shim}
+unsafe fn impl_FnOnce_unit_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnOnce<(), Output = Droppable>))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnOnce<(), Output = Droppable> + '0); // arg #1
+    let target_self: &'_0 mut test_crate::main::{closure#2}; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnOnce<(), Output = Droppable> + '1), &'_0 mut test_crate::main::{closure#2}>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable}
+fn impl_FnOnce_unit_for_closure::{vtable}() -> core::ops::function::FnOnce::{vtable}
+{
+    let ret: core::ops::function::FnOnce::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn FnOnce<(), Output = Droppable> + '0)); // local
+    let erased_drop: *const (); // local
+    let call_once: extern "rust-call" fn(*mut (dyn FnOnce<(), Output = Droppable> + '1), ()) -> Droppable; // local
+    let erased_call_once: *const (); // local
+    let _7: unsafe fn(*mut (dyn FnOnce<(), Output = Droppable> + '4)); // anonymous local
+    let _8: extern "rust-call" fn(*mut (dyn FnOnce<(), Output = Droppable> + '8), ()) -> Droppable; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<test_crate::main::{closure#2}>
+    storage_live(align)
+    align = align_of<test_crate::main::{closure#2}>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<impl_FnOnce_unit_for_closure::{vtable_drop_shim}<'3>, unsafe fn(*mut (dyn FnOnce<(), Output = Droppable> + '4))>(const impl_FnOnce_unit_for_closure::{vtable_drop_shim}<'3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn FnOnce<(), Output = Droppable> + '5)), *const ()>(move drop)
+    storage_live(call_once)
+    storage_live(erased_call_once)
+    storage_live(_8)
+    _8 = cast<impl_FnOnce_unit_for_closure::{vtable_method}, extern "rust-call" fn(*mut (dyn FnOnce<(), Output = Droppable> + '8), ()) -> Droppable>(const impl_FnOnce_unit_for_closure::{vtable_method})
+    call_once = move _8
+    erased_call_once = cast<extern "rust-call" fn(*mut (dyn FnOnce<(), Output = Droppable> + '9), ()) -> Droppable, *const ()>(move call_once)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<test_crate::main::{closure#2}>
+    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_once: move erased_call_once, super_trait_0: move _9 }
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<()> for test_crate::main::{closure#2}}::{vtable}
+static impl_FnOnce_unit_for_closure::{vtable}: core::ops::function::FnOnce::{vtable} = impl_FnOnce_unit_for_closure::{vtable}()
+
+// Full name: test_crate::main::{impl FnOnce<()> for test_crate::main::{closure#2}}
+impl "impl_FnOnce_unit_for_closure" FnOnce<()> for test_crate::main::{closure#2} {
+    proof ImpliedClause0: (test_crate::main::{closure#2}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#2}}
+    proof ImpliedClause1: ((): Sized) = {built_in impl Sized for ()}
+    proof ImpliedClause2: ((): Tuple) = {built_in impl Tuple for ()}
+    vtable: impl_FnOnce_unit_for_closure::{vtable}
+}
+
+struct test_crate::main::{closure#1}<'_0> {
+  _0: &'_0 u32,
+}
+
+// Full name: test_crate::main::{closure#1}::{impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue
+unsafe fn {impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue<'_0, '_1>(_1: &'_1 mut test_crate::main::{closure#1}<'_0>)
+where
+    RegionOutlives0: '_0: '_1,
+{
+    let _0: (); // return
+    let _1: &'1 mut test_crate::main::{closure#1}<'_0>; // arg #1
 
     storage_live(_0)
     _0 = ()
@@ -125,11 +353,391 @@ unsafe fn drop_glue<'_0>(_1: &'_0 mut {closure})
     return
 }
 
-// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::call
-fn call<'_0>(_1: &'_0 {closure}, tupled_args: (u32,)) -> u32
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::call
+fn {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::call<'_0, '_1>(_1: &'_1 test_crate::main::{closure#1}<'_0>, tupled_args: (u32,)) -> u32
+where
+    RegionOutlives0: '_0: '_1,
 {
     let _0: u32; // return
-    let _1: &'1 {closure}; // arg #1
+    let _1: &'1 test_crate::main::{closure#1}<'_0>; // arg #1
+    let tupled_args: (u32,); // arg #2
+    let x: u32; // local
+    let _4: u32; // anonymous local
+    let _5: u32; // anonymous local
+    let _6: u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(x)
+    storage_live(_6)
+    x = move tupled_args._0
+    storage_live(_4)
+    _4 = copy x
+    storage_live(_5)
+    _5 = copy (*(*_1)._0)
+    _6 = copy _4 panic.+ copy _5
+    _0 = move _6
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_dead(_6)
+    storage_dead(x)
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_mut
+fn {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_mut<'_0, '_1>(state: &'_1 mut test_crate::main::{closure#1}<'_0>, args: (u32,)) -> u32
+where
+    RegionOutlives0: '_0: '_1,
+{
+    let _0: u32; // return
+    let state: &'_1 mut test_crate::main::{closure#1}<'_0>; // arg #1
+    let args: (u32,); // arg #2
+    let _3: &'0 test_crate::main::{closure#1}<'_0>; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &(*state)
+    _0 = {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::call<'_0, '2>(move _3, move args)
+    ↳⚡ storage_dead(_3)
+        storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_once
+fn {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_once<'_0>(_1: test_crate::main::{closure#1}<'_0>, _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: test_crate::main::{closure#1}<'_0>; // arg #1
+    let _2: (u32,); // arg #2
+    let _3: &'1 mut test_crate::main::{closure#1}<'_0>; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_mut<'_0, '4>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue<'_0, '7>] _1
+        ↳⚡ storage_dead(_3)
+            storage_dead(_2)
+            storage_dead(_1)
+            unwind_terminate
+        storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    drop[{impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue<'_0, '10>] _1
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}
+extern "rust-call" fn {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0>(_1: *mut (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: *mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
+    let _2: (u32,); // arg #2
+    let _3: *mut test_crate::main::{closure#1}<'_0>; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<*mut (dyn FnOnce<(u32,), Output = u32> + '1), *mut test_crate::main::{closure#1}<'_0>>(move _1)
+    _0 = {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_once<'_0>(move (*_3), move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}
+unsafe fn {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '_1>(dyn_self: &'_1 mut (dyn FnOnce<(u32,), Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_1 mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
+    let target_self: &'_1 mut test_crate::main::{closure#1}<'_0>; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_1 mut (dyn FnOnce<(u32,), Output = u32> + '1), &'_1 mut test_crate::main::{closure#1}<'_0>>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue<'_0, '3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}
+fn {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>() -> core::ops::function::FnOnce::{vtable}
+{
+    let ret: core::ops::function::FnOnce::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call_once: extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '1), (u32,)) -> u32; // local
+    let erased_call_once: *const (); // local
+    let _7: unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<test_crate::main::{closure#1}<'_0>>
+    storage_live(align)
+    align = align_of<test_crate::main::{closure#1}<'_0>>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '3>, unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '4))>(const {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call_once)
+    storage_live(erased_call_once)
+    storage_live(_8)
+    _8 = cast<{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0>, extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32>(const {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0>)
+    call_once = move _8
+    erased_call_once = cast<extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '9), (u32,)) -> u32, *const ()>(move call_once)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<test_crate::main::{closure#1}<'_>>
+    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_once: move erased_call_once, super_trait_0: move _9 }
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}
+static {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>: core::ops::function::FnOnce::{vtable} = {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>()
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}
+extern "rust-call" fn {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0, '_1>(_1: &'_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
+    let _2: (u32,); // arg #2
+    let _3: &'_1 mut test_crate::main::{closure#1}<'_0>; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_1 mut test_crate::main::{closure#1}<'_0>>(move _1)
+    _0 = {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::call_mut<'_0, '_1>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}
+unsafe fn {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '_1>(dyn_self: &'_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
+    let target_self: &'_1 mut test_crate::main::{closure#1}<'_0>; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_1 mut test_crate::main::{closure#1}<'_0>>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue<'_0, '3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}
+fn {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>() -> core::ops::function::FnMut::{vtable}
+{
+    let ret: core::ops::function::FnMut::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call_mut: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), (u32,)) -> u32; // local
+    let erased_call_mut: *const (); // local
+    let _7: unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '9), (u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _10: &'static core::ops::function::FnOnce::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<test_crate::main::{closure#1}<'_0>>
+    storage_live(align)
+    align = align_of<test_crate::main::{closure#1}<'_0>>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<{impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '3>, unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '4))>(const {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call_mut)
+    storage_live(erased_call_mut)
+    storage_live(_8)
+    _8 = cast<for<'_0_1> {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0, '8>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(const {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0, '8>)
+    call_mut = move _8
+    erased_call_mut = cast<extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '10), (u32,)) -> u32, *const ()>(move call_mut)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<test_crate::main::{closure#1}<'_>>
+    storage_live(_10)
+    _10 = &{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>
+    ret = core::ops::function::FnMut::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_mut: move erased_call_mut, super_trait_0: move _9, super_trait_1: move _10 }
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}
+static {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>: core::ops::function::FnMut::{vtable} = {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>()
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}
+extern "rust-call" fn {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0, '_1>(_1: &'_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
+    let _2: (u32,); // arg #2
+    let _3: &'_1 test_crate::main::{closure#1}<'_0>; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_1 test_crate::main::{closure#1}<'_0>>(move _1)
+    _0 = {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::call<'_0, '_1>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}
+unsafe fn {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '_1>(dyn_self: &'_1 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_1 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
+    let target_self: &'_1 mut test_crate::main::{closure#1}<'_0>; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_1 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_1 mut test_crate::main::{closure#1}<'_0>>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue<'_0, '3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}
+fn {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>() -> core::ops::function::Fn::{vtable}
+{
+    let ret: core::ops::function::Fn::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), (u32,)) -> u32; // local
+    let erased_call: *const (); // local
+    let _7: unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _10: &'static core::ops::function::FnMut::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<test_crate::main::{closure#1}<'_0>>
+    storage_live(align)
+    align = align_of<test_crate::main::{closure#1}<'_0>>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '3>, unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4))>(const {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_drop_shim}<'_0, '3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call)
+    storage_live(erased_call)
+    storage_live(_8)
+    _8 = cast<for<'_0_1> {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0, '8>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(const {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable_method}<'_0, '8>)
+    call = move _8
+    erased_call = cast<extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '10), (u32,)) -> u32, *const ()>(move call)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<test_crate::main::{closure#1}<'_>>
+    storage_live(_10)
+    _10 = &{impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>
+    ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call: move erased_call, super_trait_0: move _9, super_trait_1: move _10 }
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}
+static {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>: core::ops::function::Fn::{vtable} = {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>()
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}
+impl<'_0> FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0> {
+    proof ImpliedClause0: (test_crate::main::{closure#1}<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#1}<'_0>}
+    proof ImpliedClause1: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    vtable: {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}
+impl<'_0> FnMut<(u32,)> for test_crate::main::{closure#1}<'_0> {
+    proof ImpliedClause0: (test_crate::main::{closure#1}<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#1}<'_0>}
+    proof ImpliedClause1: (test_crate::main::{closure#1}<'_0>: FnOnce<(u32,)>) = {impl FnOnce<(u32,)> for test_crate::main::{closure#1}<'_0>}<'_0>
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    vtable: {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}
+impl<'_0> Fn<(u32,)> for test_crate::main::{closure#1}<'_0> {
+    proof ImpliedClause0: (test_crate::main::{closure#1}<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#1}<'_0>}
+    proof ImpliedClause1: (test_crate::main::{closure#1}<'_0>: FnMut<(u32,)>) = {impl FnMut<(u32,)> for test_crate::main::{closure#1}<'_0>}<'_0>
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    vtable: {impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'_0>
+}
+
+struct test_crate::main::{closure} {}
+
+// Full name: test_crate::main::{closure}::{impl Destruct for test_crate::main::{closure}}::drop_glue
+unsafe fn {impl Destruct for test_crate::main::{closure}}::drop_glue<'_0>(_1: &'_0 mut test_crate::main::{closure})
+{
+    let _0: (); // return
+    let _1: &'1 mut test_crate::main::{closure}; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure}}::call
+fn {impl Fn<(u32,)> for test_crate::main::{closure}}::call<'_0>(_1: &'_0 test_crate::main::{closure}, tupled_args: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'1 test_crate::main::{closure}; // arg #1
     let tupled_args: (u32,); // arg #2
     let x: u32; // local
     let _4: u32; // anonymous local
@@ -151,18 +759,18 @@ fn call<'_0>(_1: &'_0 {closure}, tupled_args: (u32,)) -> u32
     return
 }
 
-// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::call_mut
-fn call_mut<'_0>(state: &'_0 mut {closure}, args: (u32,)) -> u32
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure}}::call_mut
+fn {impl FnMut<(u32,)> for test_crate::main::{closure}}::call_mut<'_0>(state: &'_0 mut test_crate::main::{closure}, args: (u32,)) -> u32
 {
     let _0: u32; // return
-    let state: &'_0 mut {closure}; // arg #1
+    let state: &'_0 mut test_crate::main::{closure}; // arg #1
     let args: (u32,); // arg #2
-    let _3: &'0 {closure}; // anonymous local
+    let _3: &'0 test_crate::main::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &(*state)
-    _0 = call<'2>(move _3, move args)
+    _0 = {impl Fn<(u32,)> for test_crate::main::{closure}}::call<'2>(move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -173,19 +781,19 @@ fn call_mut<'_0>(state: &'_0 mut {closure}, args: (u32,)) -> u32
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::call_once
-fn call_once(_1: {closure}, _2: (u32,)) -> u32
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure}}::call_once
+fn {impl FnOnce<(u32,)> for test_crate::main::{closure}}::call_once(_1: test_crate::main::{closure}, _2: (u32,)) -> u32
 {
     let _0: u32; // return
-    let _1: {closure}; // arg #1
+    let _1: test_crate::main::{closure}; // arg #1
     let _2: (u32,); // arg #2
-    let _3: &'1 mut {closure}; // anonymous local
+    let _3: &'1 mut test_crate::main::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = call_mut<'3>(move _3, move _2)
-    ↳⚡ drop[drop_glue<'4>] _1
+    _0 = {impl FnMut<(u32,)> for test_crate::main::{closure}}::call_mut<'3>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::main::{closure}}::drop_glue<'4>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -194,7 +802,7 @@ fn call_once(_1: {closure}, _2: (u32,)) -> u32
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[drop_glue<'5>] _1
+    drop[{impl Destruct for test_crate::main::{closure}}::drop_glue<'5>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -205,18 +813,18 @@ fn call_once(_1: {closure}, _2: (u32,)) -> u32
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::{vtable_method}
-extern "rust-call" fn impl_FnOnce_for_closure::{vtable_method}(_1: *mut (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_method}
+extern "rust-call" fn {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_method}(_1: *mut (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: *mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
     let _2: (u32,); // arg #2
-    let _3: *mut {closure}; // anonymous local
+    let _3: *mut test_crate::main::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
-    _3 = concretize<*mut (dyn FnOnce<(u32,), Output = u32> + '1), *mut {closure}>(move _1)
-    _0 = call_once(move (*_3), move _2)
+    _3 = concretize<*mut (dyn FnOnce<(u32,), Output = u32> + '1), *mut test_crate::main::{closure}>(move _1)
+    _0 = {impl FnOnce<(u32,)> for test_crate::main::{closure}}::call_once(move (*_3), move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -227,18 +835,18 @@ extern "rust-call" fn impl_FnOnce_for_closure::{vtable_method}(_1: *mut (dyn FnO
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::{vtable_drop_shim}
-unsafe fn impl_FnOnce_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32>))
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}
+unsafe fn {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32>))
 {
     let ret: (); // return
     let dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
-    let target_self: &'_0 mut {closure}; // local
+    let target_self: &'_0 mut test_crate::main::{closure}; // local
 
     storage_live(ret)
     ret = ()
     storage_live(target_self)
-    target_self = concretize<&'_0 mut (dyn FnOnce<(u32,), Output = u32> + '1), &'_0 mut {closure}>(move dyn_self)
-    drop[drop_glue<'3>] (*target_self)
+    target_self = concretize<&'_0 mut (dyn FnOnce<(u32,), Output = u32> + '1), &'_0 mut test_crate::main::{closure}>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure}}::drop_glue<'3>] (*target_self)
     ↳⚡ storage_dead(target_self)
         storage_dead(dyn_self)
         unwind_continue
@@ -247,8 +855,8 @@ unsafe fn impl_FnOnce_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (d
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::{vtable}
-fn impl_FnOnce_for_closure::{vtable}() -> core::ops::function::FnOnce::{vtable}
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable}
+fn {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable}() -> core::ops::function::FnOnce::{vtable}
 {
     let ret: core::ops::function::FnOnce::{vtable}; // return
     let size: usize; // local
@@ -263,42 +871,42 @@ fn impl_FnOnce_for_closure::{vtable}() -> core::ops::function::FnOnce::{vtable}
 
     storage_live(ret)
     storage_live(size)
-    size = size_of<{closure}>
+    size = size_of<test_crate::main::{closure}>
     storage_live(align)
-    align = align_of<{closure}>
+    align = align_of<test_crate::main::{closure}>
     storage_live(drop)
     storage_live(erased_drop)
     storage_live(_7)
-    _7 = cast<impl_FnOnce_for_closure::{vtable_drop_shim}<'3>, unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '4))>(const impl_FnOnce_for_closure::{vtable_drop_shim}<'3>)
+    _7 = cast<{impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'3>, unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '4))>(const {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'3>)
     drop = move _7
     erased_drop = cast<unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '5)), *const ()>(move drop)
     storage_live(call_once)
     storage_live(erased_call_once)
     storage_live(_8)
-    _8 = cast<impl_FnOnce_for_closure::{vtable_method}, extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32>(const impl_FnOnce_for_closure::{vtable_method})
+    _8 = cast<{impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_method}, extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32>(const {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable_method})
     call_once = move _8
     erased_call_once = cast<extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '9), (u32,)) -> u32, *const ()>(move call_once)
     storage_live(_9)
-    _9 = &core::marker::MetaSized::{vtable}::<{closure}>
+    _9 = &core::marker::MetaSized::{vtable}::<test_crate::main::{closure}>
     ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_once: move erased_call_once, super_trait_0: move _9 }
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::{vtable}
-static impl_FnOnce_for_closure::{vtable}: core::ops::function::FnOnce::{vtable} = impl_FnOnce_for_closure::{vtable}()
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable}
+static {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable}: core::ops::function::FnOnce::{vtable} = {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable}()
 
-// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::{vtable_method}
-extern "rust-call" fn impl_FnMut_for_closure::{vtable_method}<'_0>(_1: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_method}
+extern "rust-call" fn {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_method}<'_0>(_1: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
     let _2: (u32,); // arg #2
-    let _3: &'_0 mut {closure}; // anonymous local
+    let _3: &'_0 mut test_crate::main::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
-    _3 = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut {closure}>(move _1)
-    _0 = call_mut<'_0>(move _3, move _2)
+    _3 = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut test_crate::main::{closure}>(move _1)
+    _0 = {impl FnMut<(u32,)> for test_crate::main::{closure}}::call_mut<'_0>(move _3, move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -309,18 +917,18 @@ extern "rust-call" fn impl_FnMut_for_closure::{vtable_method}<'_0>(_1: &'_0 mut 
     return
 }
 
-// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::{vtable_drop_shim}
-unsafe fn impl_FnMut_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>))
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}
+unsafe fn {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>))
 {
     let ret: (); // return
     let dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
-    let target_self: &'_0 mut {closure}; // local
+    let target_self: &'_0 mut test_crate::main::{closure}; // local
 
     storage_live(ret)
     ret = ()
     storage_live(target_self)
-    target_self = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut {closure}>(move dyn_self)
-    drop[drop_glue<'3>] (*target_self)
+    target_self = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut test_crate::main::{closure}>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure}}::drop_glue<'3>] (*target_self)
     ↳⚡ storage_dead(target_self)
         storage_dead(dyn_self)
         unwind_continue
@@ -329,8 +937,8 @@ unsafe fn impl_FnMut_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dy
     return
 }
 
-// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::{vtable}
-fn impl_FnMut_for_closure::{vtable}() -> core::ops::function::FnMut::{vtable}
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable}
+fn {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable}() -> core::ops::function::FnMut::{vtable}
 {
     let ret: core::ops::function::FnMut::{vtable}; // return
     let size: usize; // local
@@ -346,44 +954,44 @@ fn impl_FnMut_for_closure::{vtable}() -> core::ops::function::FnMut::{vtable}
 
     storage_live(ret)
     storage_live(size)
-    size = size_of<{closure}>
+    size = size_of<test_crate::main::{closure}>
     storage_live(align)
-    align = align_of<{closure}>
+    align = align_of<test_crate::main::{closure}>
     storage_live(drop)
     storage_live(erased_drop)
     storage_live(_7)
-    _7 = cast<impl_FnMut_for_closure::{vtable_drop_shim}<'3>, unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '4))>(const impl_FnMut_for_closure::{vtable_drop_shim}<'3>)
+    _7 = cast<{impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'3>, unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '4))>(const {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'3>)
     drop = move _7
     erased_drop = cast<unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '5)), *const ()>(move drop)
     storage_live(call_mut)
     storage_live(erased_call_mut)
     storage_live(_8)
-    _8 = cast<for<'_0_1> impl_FnMut_for_closure::{vtable_method}<'8>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(const impl_FnMut_for_closure::{vtable_method}<'8>)
+    _8 = cast<for<'_0_1> {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_method}<'8>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(const {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable_method}<'8>)
     call_mut = move _8
     erased_call_mut = cast<extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '10), (u32,)) -> u32, *const ()>(move call_mut)
     storage_live(_9)
-    _9 = &core::marker::MetaSized::{vtable}::<{closure}>
+    _9 = &core::marker::MetaSized::{vtable}::<test_crate::main::{closure}>
     storage_live(_10)
-    _10 = &impl_FnOnce_for_closure::{vtable}
+    _10 = &{impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable}
     ret = core::ops::function::FnMut::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_mut: move erased_call_mut, super_trait_0: move _9, super_trait_1: move _10 }
     return
 }
 
-// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::{vtable}
-static impl_FnMut_for_closure::{vtable}: core::ops::function::FnMut::{vtable} = impl_FnMut_for_closure::{vtable}()
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable}
+static {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable}: core::ops::function::FnMut::{vtable} = {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable}()
 
-// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::{vtable_method}
-extern "rust-call" fn impl_Fn_for_closure::{vtable_method}<'_0>(_1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_method}
+extern "rust-call" fn {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_method}<'_0>(_1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
 {
     let _0: u32; // return
     let _1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
     let _2: (u32,); // arg #2
-    let _3: &'_0 {closure}; // anonymous local
+    let _3: &'_0 test_crate::main::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
-    _3 = concretize<&'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 {closure}>(move _1)
-    _0 = call<'_0>(move _3, move _2)
+    _3 = concretize<&'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 test_crate::main::{closure}>(move _1)
+    _0 = {impl Fn<(u32,)> for test_crate::main::{closure}}::call<'_0>(move _3, move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -394,18 +1002,18 @@ extern "rust-call" fn impl_Fn_for_closure::{vtable_method}<'_0>(_1: &'_0 (dyn Fn
     return
 }
 
-// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::{vtable_drop_shim}
-unsafe fn impl_Fn_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>))
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}
+unsafe fn {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>))
 {
     let ret: (); // return
     let dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
-    let target_self: &'_0 mut {closure}; // local
+    let target_self: &'_0 mut test_crate::main::{closure}; // local
 
     storage_live(ret)
     ret = ()
     storage_live(target_self)
-    target_self = concretize<&'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 mut {closure}>(move dyn_self)
-    drop[drop_glue<'3>] (*target_self)
+    target_self = concretize<&'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 mut test_crate::main::{closure}>(move dyn_self)
+    drop[{impl Destruct for test_crate::main::{closure}}::drop_glue<'3>] (*target_self)
     ↳⚡ storage_dead(target_self)
         storage_dead(dyn_self)
         unwind_continue
@@ -414,8 +1022,8 @@ unsafe fn impl_Fn_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn F
     return
 }
 
-// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::{vtable}
-fn impl_Fn_for_closure::{vtable}() -> core::ops::function::Fn::{vtable}
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}
+fn {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}() -> core::ops::function::Fn::{vtable}
 {
     let ret: core::ops::function::Fn::{vtable}; // return
     let size: usize; // local
@@ -431,56 +1039,56 @@ fn impl_Fn_for_closure::{vtable}() -> core::ops::function::Fn::{vtable}
 
     storage_live(ret)
     storage_live(size)
-    size = size_of<{closure}>
+    size = size_of<test_crate::main::{closure}>
     storage_live(align)
-    align = align_of<{closure}>
+    align = align_of<test_crate::main::{closure}>
     storage_live(drop)
     storage_live(erased_drop)
     storage_live(_7)
-    _7 = cast<impl_Fn_for_closure::{vtable_drop_shim}<'3>, unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4))>(const impl_Fn_for_closure::{vtable_drop_shim}<'3>)
+    _7 = cast<{impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'3>, unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4))>(const {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_drop_shim}<'3>)
     drop = move _7
     erased_drop = cast<unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '5)), *const ()>(move drop)
     storage_live(call)
     storage_live(erased_call)
     storage_live(_8)
-    _8 = cast<for<'_0_1> impl_Fn_for_closure::{vtable_method}<'8>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(const impl_Fn_for_closure::{vtable_method}<'8>)
+    _8 = cast<for<'_0_1> {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_method}<'8>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(const {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable_method}<'8>)
     call = move _8
     erased_call = cast<extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '10), (u32,)) -> u32, *const ()>(move call)
     storage_live(_9)
-    _9 = &core::marker::MetaSized::{vtable}::<{closure}>
+    _9 = &core::marker::MetaSized::{vtable}::<test_crate::main::{closure}>
     storage_live(_10)
-    _10 = &impl_FnMut_for_closure::{vtable}
+    _10 = &{impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable}
     ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call: move erased_call, super_trait_0: move _9, super_trait_1: move _10 }
     return
 }
 
-// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::{vtable}
-static impl_Fn_for_closure::{vtable}: core::ops::function::Fn::{vtable} = impl_Fn_for_closure::{vtable}()
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}
+static {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}: core::ops::function::Fn::{vtable} = {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}()
 
-// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}
-impl "impl_FnOnce_for_closure" FnOnce<(u32,)> for {closure} {
-    proof ImpliedClause0: ({closure}: MetaSized) = {built_in impl MetaSized for {closure}}
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for test_crate::main::{closure}}
+impl FnOnce<(u32,)> for test_crate::main::{closure} {
+    proof ImpliedClause0: (test_crate::main::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure}}
     proof ImpliedClause1: ((u32,): Sized) = {built_in impl Sized for (u32,)}
     proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
-    vtable: impl_FnOnce_for_closure::{vtable}
+    vtable: {impl FnOnce<(u32,)> for test_crate::main::{closure}}::{vtable}
 }
 
-// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}
-impl "impl_FnMut_for_closure" FnMut<(u32,)> for {closure} {
-    proof ImpliedClause0: ({closure}: MetaSized) = {built_in impl MetaSized for {closure}}
-    proof ImpliedClause1: ({closure}: FnOnce<(u32,)>) = impl_FnOnce_for_closure
+// Full name: test_crate::main::{impl FnMut<(u32,)> for test_crate::main::{closure}}
+impl FnMut<(u32,)> for test_crate::main::{closure} {
+    proof ImpliedClause0: (test_crate::main::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure}}
+    proof ImpliedClause1: (test_crate::main::{closure}: FnOnce<(u32,)>) = {impl FnOnce<(u32,)> for test_crate::main::{closure}}
     proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
     proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
-    vtable: impl_FnMut_for_closure::{vtable}
+    vtable: {impl FnMut<(u32,)> for test_crate::main::{closure}}::{vtable}
 }
 
-// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}
-impl "impl_Fn_for_closure" Fn<(u32,)> for {closure} {
-    proof ImpliedClause0: ({closure}: MetaSized) = {built_in impl MetaSized for {closure}}
-    proof ImpliedClause1: ({closure}: FnMut<(u32,)>) = impl_FnMut_for_closure
+// Full name: test_crate::main::{impl Fn<(u32,)> for test_crate::main::{closure}}
+impl Fn<(u32,)> for test_crate::main::{closure} {
+    proof ImpliedClause0: (test_crate::main::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure}}
+    proof ImpliedClause1: (test_crate::main::{closure}: FnMut<(u32,)>) = {impl FnMut<(u32,)> for test_crate::main::{closure}}
     proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
     proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
-    vtable: impl_Fn_for_closure::{vtable}
+    vtable: {impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}
 }
 
 // Full name: test_crate::main
@@ -488,64 +1096,194 @@ fn main()
 {
     let _0: (); // return
     let f: &'3 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4); // local
-    let _2: &'6 {closure}; // anonymous local
-    let _3: &'7 {closure}; // anonymous local
-    let _y: u32; // local
+    let _2: &'6 test_crate::main::{closure}; // anonymous local
+    let _3: &'7 test_crate::main::{closure}; // anonymous local
+    let _y_4: u32; // local
     let _5: &'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9); // anonymous local
     let _6: (u32,); // anonymous local
-    let _7: &'10 {closure}; // anonymous local
-    let _8: unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32; // anonymous local
-    let _9: &'11 {closure}; // anonymous local
-    let _10: &'20 {closure}; // anonymous local
-    let _11: {closure}; // anonymous local
+    let captured: u32; // local
+    let g: &'10 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '11); // local
+    let _9: &'15 test_crate::main::{closure#1}<'16>; // anonymous local
+    let _10: &'17 test_crate::main::{closure#1}<'18>; // anonymous local
+    let _11: test_crate::main::{closure#1}<'19>; // anonymous local
+    let _12: &'21 u32; // anonymous local
+    let _y_13: u32; // local
+    let _14: &'22 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '23); // anonymous local
+    let _15: (u32,); // anonymous local
+    let d: Droppable; // local
+    let _h: Box::<(dyn FnOnce<(), Output = Droppable>), Global>; // local
+    let _18: Box::<test_crate::main::{closure#2}, Global>; // anonymous local
+    let _19: test_crate::main::{closure#2}; // anonymous local
+    let _20: &'24 test_crate::main::{closure}; // anonymous local
+    let _21: unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32; // anonymous local
+    let _22: unsafe fn(&'22 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '23), (u32,)) -> u32; // anonymous local
+    let _23: &'25 test_crate::main::{closure}; // anonymous local
+    let _24: &'53 test_crate::main::{closure}; // anonymous local
+    let _25: test_crate::main::{closure}; // anonymous local
 
-    storage_live(_9)
-    storage_live(_10)
-    storage_live(_11)
-    _11 = {closure} {  }
-    _10 = &_11
-    _9 = move _10
+    storage_live(_23)
+    storage_live(_24)
+    storage_live(_25)
+    _25 = test_crate::main::{closure} {  }
+    _24 = &_25
+    _23 = move _24
     storage_live(_0)
-    storage_live(_7)
+    storage_live(_20)
     _0 = ()
     storage_live(f)
     storage_live(_2)
     storage_live(_3)
-    _7 = move _9
-    _3 = &(*_7)
+    _20 = move _23
+    _3 = &(*_20)
     _2 = &(*_3)
-    f = unsize_cast<&'6 {closure}, &'12 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '13), &impl_Fn_for_closure::{vtable}>(move _2)
+    f = unsize_cast<&'6 test_crate::main::{closure}, &'26 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '27), &{impl Fn<(u32,)> for test_crate::main::{closure}}::{vtable}>(move _2)
     storage_dead(_2)
     fake_read(f)
-    set_type(typeof(f) == &'14 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '15))
+    set_type(typeof(f) == &'28 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '29))
     storage_dead(_3)
-    storage_live(_y)
+    storage_live(_y_4)
     storage_live(_5)
     _5 = &(*f) with_metadata(copy f.metadata)
     storage_live(_6)
     _6 = (const 1u32,)
-    storage_live(_8)
-    _8 = cast<*const (), unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(copy (*_5.metadata).method_call)
-    _y = (copy _8)(move _5, move _6)
-    ↳⚡ storage_dead(_7)
+    storage_live(_21)
+    _21 = cast<*const (), unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(copy (*_5.metadata).method_call)
+    _y_4 = (copy _21)(move _5, move _6)
+    ↳⚡ storage_dead(_20)
         unwind_continue
     storage_dead(_6)
     storage_dead(_5)
-    fake_read(_y)
-    _0 = ()
-    storage_dead(_y)
-    storage_dead(f)
-    storage_dead(_7)
-    storage_dead(_11)
-    storage_dead(_10)
+    fake_read(_y_4)
+    storage_live(captured)
+    // A closure with captured state.
+    captured = const 10u32
+    fake_read(captured)
+    storage_live(g)
+    storage_live(_9)
+    storage_live(_10)
+    storage_live(_11)
+    storage_live(_12)
+    _12 = &captured
+    _11 = test_crate::main::{closure#1} { _0: move _12 }
+    storage_dead(_12)
+    _10 = &_11
+    _9 = &(*_10)
+    g = unsize_cast<&'15 test_crate::main::{closure#1}<'16>, &'36 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '37), &{impl Fn<(u32,)> for test_crate::main::{closure#1}<'_0>}::{vtable}<'41>>(move _9)
     storage_dead(_9)
-    storage_dead(_8)
+    fake_read(g)
+    set_type(typeof(g) == &'42 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '43))
+    storage_dead(_10)
+    storage_live(_y_13)
+    storage_live(_14)
+    _14 = &(*g) with_metadata(copy g.metadata)
+    storage_live(_15)
+    _15 = (const 2u32,)
+    storage_live(_22)
+    _22 = cast<*const (), unsafe fn(&'22 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '23), (u32,)) -> u32>(copy (*_14.metadata).method_call)
+    _y_13 = (copy _22)(move _14, move _15)
+    ↳⚡ storage_dead(_20)
+        unwind_continue
+    storage_dead(_15)
+    storage_dead(_14)
+    fake_read(_y_13)
+    storage_live(d)
+    // Built but not called: the drop shim must drop the captured state.
+    d = Droppable { _0: const 0u32 }
+    fake_read(d)
+    storage_live(_h)
+    storage_live(_18)
+    storage_live(_19)
+    _19 = test_crate::main::{closure#2} { _0: move d }
+    _18 = new::<test_crate::main::{closure#2}>(move _19)
+    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'48>] _19
+        ↳⚡ storage_dead(_20)
+            storage_dead(_25)
+            storage_dead(_24)
+            storage_dead(_23)
+            storage_dead(_22)
+            storage_dead(_21)
+            unwind_terminate
+        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'50>] d
+        ↳⚡ storage_dead(_20)
+            storage_dead(_25)
+            storage_dead(_24)
+            storage_dead(_23)
+            storage_dead(_22)
+            storage_dead(_21)
+            unwind_terminate
+        storage_dead(_20)
+        unwind_continue
+    _h = unsize_cast<Box::<test_crate::main::{closure#2}, Global>, Box::<(dyn FnOnce<(), Output = Droppable>), Global>, &impl_FnOnce_unit_for_closure::{vtable}>(move _18)
+    conditional_drop[{impl Destruct for Box::<test_crate::main::{closure#2}, Global>}::drop_glue::<test_crate::main::{closure#2}, Global><'49>] _18
+    ↳⚡ conditional_drop[{impl Destruct for test_crate::main::{closure#2}}::drop_glue<'48>] _19
+        ↳⚡ storage_dead(_20)
+            storage_dead(_25)
+            storage_dead(_24)
+            storage_dead(_23)
+            storage_dead(_22)
+            storage_dead(_21)
+            unwind_terminate
+        conditional_drop[impl_Destruct_for_Droppable::drop_glue<'50>] d
+        ↳⚡ storage_dead(_20)
+            storage_dead(_25)
+            storage_dead(_24)
+            storage_dead(_23)
+            storage_dead(_22)
+            storage_dead(_21)
+            unwind_terminate
+        storage_dead(_20)
+        unwind_continue
+    storage_dead(_19)
+    storage_dead(_18)
+    fake_read(_h)
+    set_type(typeof(_h) == Box::<(dyn FnOnce<(), Output = Droppable>), Global>)
+    _0 = ()
+    conditional_drop[{impl Destruct for Box::<(dyn FnOnce<(), Output = Droppable>), Global>}::drop_glue::<(dyn FnOnce<(), Output = Droppable>), Global><'51>] _h
+    ↳⚡ conditional_drop[impl_Destruct_for_Droppable::drop_glue<'50>] d
+        ↳⚡ storage_dead(_20)
+            storage_dead(_25)
+            storage_dead(_24)
+            storage_dead(_23)
+            storage_dead(_22)
+            storage_dead(_21)
+            unwind_terminate
+        storage_dead(_20)
+        unwind_continue
+    storage_dead(_h)
+    conditional_drop[impl_Destruct_for_Droppable::drop_glue<'52>] d
+    ↳⚡ storage_dead(_20)
+        unwind_continue
+    storage_dead(d)
+    storage_dead(_y_13)
+    storage_dead(_11)
+    storage_dead(g)
+    storage_dead(captured)
+    storage_dead(_y_4)
+    storage_dead(f)
+    storage_dead(_20)
+    storage_dead(_25)
+    storage_dead(_24)
+    storage_dead(_23)
+    storage_dead(_22)
+    storage_dead(_21)
     return
 }
 
-// Full name: test_crate::main::{closure}::{impl Destruct for {closure}}
-impl "impl_Destruct_for_closure" Destruct for {closure} {
-    fn drop_glue<'_0_1> = drop_glue<'_0_1>
+// Full name: test_crate::main::{closure}::{impl Destruct for test_crate::main::{closure}}
+impl Destruct for test_crate::main::{closure} {
+    fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::{closure}}::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::main::{closure#1}::{impl Destruct for test_crate::main::{closure#1}<'_0>}
+impl<'_0> Destruct for test_crate::main::{closure#1}<'_0> {
+    fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::{closure#1}<'_0>}::drop_glue<'_0, '_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::main::{closure#2}::{impl Destruct for test_crate::main::{closure#2}}
+impl Destruct for test_crate::main::{closure#2} {
+    fn drop_glue<'_0_1> = {impl Destruct for test_crate::main::{closure#2}}::drop_glue<'_0_1>
     non-dyn-compatible
 }
 

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable.out
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable.out
@@ -206,17 +206,17 @@ fn call_once(_1: {closure}, _2: (u32,)) -> u32
 }
 
 // Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::{vtable_method}
-extern "rust-call" fn impl_FnOnce_for_closure::{vtable_method}(_1: (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
+extern "rust-call" fn impl_FnOnce_for_closure::{vtable_method}(_1: *mut (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
 {
     let _0: u32; // return
-    let _1: (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
+    let _1: *mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
     let _2: (u32,); // arg #2
-    let _3: {closure}; // anonymous local
+    let _3: *mut {closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
-    _3 = concretize<(dyn FnOnce<(u32,), Output = u32> + '1), {closure}>(move _1)
-    _0 = call_once(move _3, move _2)
+    _3 = concretize<*mut (dyn FnOnce<(u32,), Output = u32> + '1), *mut {closure}>(move _1)
+    _0 = call_once(move (*_3), move _2)
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -255,10 +255,10 @@ fn impl_FnOnce_for_closure::{vtable}() -> core::ops::function::FnOnce::{vtable}
     let align: usize; // local
     let drop: unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '0)); // local
     let erased_drop: *const (); // local
-    let call_once: extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '1), (u32,)) -> u32; // local
+    let call_once: extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '1), (u32,)) -> u32; // local
     let erased_call_once: *const (); // local
     let _7: unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '4)); // anonymous local
-    let _8: extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32; // anonymous local
+    let _8: extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32; // anonymous local
     let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
 
     storage_live(ret)
@@ -275,9 +275,9 @@ fn impl_FnOnce_for_closure::{vtable}() -> core::ops::function::FnOnce::{vtable}
     storage_live(call_once)
     storage_live(erased_call_once)
     storage_live(_8)
-    _8 = cast<impl_FnOnce_for_closure::{vtable_method}, extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32>(const impl_FnOnce_for_closure::{vtable_method})
+    _8 = cast<impl_FnOnce_for_closure::{vtable_method}, extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32>(const impl_FnOnce_for_closure::{vtable_method})
     call_once = move _8
-    erased_call_once = cast<extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '9), (u32,)) -> u32, *const ()>(move call_once)
+    erased_call_once = cast<extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '9), (u32,)) -> u32, *const ()>(move call_once)
     storage_live(_9)
     _9 = &core::marker::MetaSized::{vtable}::<{closure}>
     ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_once: move erased_call_once, super_trait_0: move _9 }

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable.out
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable.out
@@ -1,0 +1,553 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+fn core::marker::MetaSized::{vtable}::<{closure}>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<{closure}>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<{closure}>()
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Tuple
+#[fundamental]
+#[lang_item(Tuple)]
+pub trait Tuple<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct core::ops::function::FnOnce::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  method_call_once: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+struct core::ops::function::FnMut::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  method_call_mut: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+  super_trait_1: &'static core::ops::function::FnOnce::{vtable},
+}
+
+struct core::ops::function::Fn::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  method_call: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+  super_trait_1: &'static core::ops::function::FnMut::{vtable},
+}
+
+// Full name: core::ops::function::FnOnce
+#[fundamental]
+#[lang_item(FnOnce)]
+pub trait FnOnce<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    vtable: core::ops::function::FnOnce::{vtable}
+}
+
+// Full name: core::ops::function::FnMut
+#[fundamental]
+#[lang_item(FnMut)]
+pub trait FnMut<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    vtable: core::ops::function::FnMut::{vtable}
+}
+
+// Full name: core::ops::function::Fn
+#[fundamental]
+#[lang_item(Fn)]
+pub trait Fn<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    vtable: core::ops::function::Fn::{vtable}
+}
+
+struct (_,)::<u32> {
+  _0: u32,
+}
+
+struct (_, _)::<u32, bool> {
+  _0: u32,
+  _1: bool,
+}
+
+// Full name: test_crate::main::{closure}
+struct {closure} {}
+
+// Full name: test_crate::main::{closure}::{impl Destruct for {closure}}::drop_glue
+unsafe fn drop_glue<'_0>(_1: &'_0 mut {closure})
+{
+    let _0: (); // return
+    let _1: &'1 mut {closure}; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::call
+fn call<'_0>(_1: &'_0 {closure}, tupled_args: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'1 {closure}; // arg #1
+    let tupled_args: (u32,); // arg #2
+    let x: u32; // local
+    let _4: u32; // anonymous local
+    let _5: u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(x)
+    storage_live(_5)
+    x = move tupled_args._0
+    storage_live(_4)
+    _4 = copy x
+    _5 = copy _4 panic.+ const 1u32
+    _0 = move _5
+    storage_dead(_4)
+    storage_dead(_5)
+    storage_dead(x)
+    storage_dead(tupled_args)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::call_mut
+fn call_mut<'_0>(state: &'_0 mut {closure}, args: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let state: &'_0 mut {closure}; // arg #1
+    let args: (u32,); // arg #2
+    let _3: &'0 {closure}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &(*state)
+    _0 = call<'2>(move _3, move args)
+    ↳⚡ storage_dead(_3)
+        storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::call_once
+fn call_once(_1: {closure}, _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: {closure}; // arg #1
+    let _2: (u32,); // arg #2
+    let _3: &'1 mut {closure}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = &mut _1
+    _0 = call_mut<'3>(move _3, move _2)
+    ↳⚡ drop[drop_glue<'4>] _1
+        ↳⚡ storage_dead(_3)
+            storage_dead(_2)
+            storage_dead(_1)
+            unwind_terminate
+        storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    drop[drop_glue<'5>] _1
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::{vtable_method}
+extern "rust-call" fn impl_FnOnce_for_closure::{vtable_method}(_1: (dyn FnOnce<(u32,), Output = u32>), _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
+    let _2: (u32,); // arg #2
+    let _3: {closure}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<(dyn FnOnce<(u32,), Output = u32> + '1), {closure}>(move _1)
+    _0 = call_once(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::{vtable_drop_shim}
+unsafe fn impl_FnOnce_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
+    let target_self: &'_0 mut {closure}; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnOnce<(u32,), Output = u32> + '1), &'_0 mut {closure}>(move dyn_self)
+    drop[drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::{vtable}
+fn impl_FnOnce_for_closure::{vtable}() -> core::ops::function::FnOnce::{vtable}
+{
+    let ret: core::ops::function::FnOnce::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call_once: extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '1), (u32,)) -> u32; // local
+    let erased_call_once: *const (); // local
+    let _7: unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<{closure}>
+    storage_live(align)
+    align = align_of<{closure}>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<impl_FnOnce_for_closure::{vtable_drop_shim}<'3>, unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '4))>(const impl_FnOnce_for_closure::{vtable_drop_shim}<'3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call_once)
+    storage_live(erased_call_once)
+    storage_live(_8)
+    _8 = cast<impl_FnOnce_for_closure::{vtable_method}, extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32>(const impl_FnOnce_for_closure::{vtable_method})
+    call_once = move _8
+    erased_call_once = cast<extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '9), (u32,)) -> u32, *const ()>(move call_once)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<{closure}>
+    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_once: move erased_call_once, super_trait_0: move _9 }
+    return
+}
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}::{vtable}
+static impl_FnOnce_for_closure::{vtable}: core::ops::function::FnOnce::{vtable} = impl_FnOnce_for_closure::{vtable}()
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::{vtable_method}
+extern "rust-call" fn impl_FnMut_for_closure::{vtable_method}<'_0>(_1: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
+    let _2: (u32,); // arg #2
+    let _3: &'_0 mut {closure}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut {closure}>(move _1)
+    _0 = call_mut<'_0>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::{vtable_drop_shim}
+unsafe fn impl_FnMut_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
+    let target_self: &'_0 mut {closure}; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut {closure}>(move dyn_self)
+    drop[drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::{vtable}
+fn impl_FnMut_for_closure::{vtable}() -> core::ops::function::FnMut::{vtable}
+{
+    let ret: core::ops::function::FnMut::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call_mut: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), (u32,)) -> u32; // local
+    let erased_call_mut: *const (); // local
+    let _7: unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '9), (u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _10: &'static core::ops::function::FnOnce::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<{closure}>
+    storage_live(align)
+    align = align_of<{closure}>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<impl_FnMut_for_closure::{vtable_drop_shim}<'3>, unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '4))>(const impl_FnMut_for_closure::{vtable_drop_shim}<'3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call_mut)
+    storage_live(erased_call_mut)
+    storage_live(_8)
+    _8 = cast<for<'_0_1> impl_FnMut_for_closure::{vtable_method}<'8>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(const impl_FnMut_for_closure::{vtable_method}<'8>)
+    call_mut = move _8
+    erased_call_mut = cast<extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '10), (u32,)) -> u32, *const ()>(move call_mut)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<{closure}>
+    storage_live(_10)
+    _10 = &impl_FnOnce_for_closure::{vtable}
+    ret = core::ops::function::FnMut::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_mut: move erased_call_mut, super_trait_0: move _9, super_trait_1: move _10 }
+    return
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}::{vtable}
+static impl_FnMut_for_closure::{vtable}: core::ops::function::FnMut::{vtable} = impl_FnMut_for_closure::{vtable}()
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::{vtable_method}
+extern "rust-call" fn impl_Fn_for_closure::{vtable_method}<'_0>(_1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>), _2: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
+    let _2: (u32,); // arg #2
+    let _3: &'_0 {closure}; // anonymous local
+
+    storage_live(_0)
+    storage_live(_3)
+    _3 = concretize<&'_0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 {closure}>(move _1)
+    _0 = call<'_0>(move _3, move _2)
+    ↳⚡ storage_dead(_3)
+        storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::{vtable_drop_shim}
+unsafe fn impl_Fn_for_closure::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
+    let target_self: &'_0 mut {closure}; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 mut {closure}>(move dyn_self)
+    drop[drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::{vtable}
+fn impl_Fn_for_closure::{vtable}() -> core::ops::function::Fn::{vtable}
+{
+    let ret: core::ops::function::Fn::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), (u32,)) -> u32; // local
+    let erased_call: *const (); // local
+    let _7: unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _10: &'static core::ops::function::FnMut::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<{closure}>
+    storage_live(align)
+    align = align_of<{closure}>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<impl_Fn_for_closure::{vtable_drop_shim}<'3>, unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4))>(const impl_Fn_for_closure::{vtable_drop_shim}<'3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call)
+    storage_live(erased_call)
+    storage_live(_8)
+    _8 = cast<for<'_0_1> impl_Fn_for_closure::{vtable_method}<'8>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(const impl_Fn_for_closure::{vtable_method}<'8>)
+    call = move _8
+    erased_call = cast<extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '10), (u32,)) -> u32, *const ()>(move call)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<{closure}>
+    storage_live(_10)
+    _10 = &impl_FnMut_for_closure::{vtable}
+    ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call: move erased_call, super_trait_0: move _9, super_trait_1: move _10 }
+    return
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}::{vtable}
+static impl_Fn_for_closure::{vtable}: core::ops::function::Fn::{vtable} = impl_Fn_for_closure::{vtable}()
+
+// Full name: test_crate::main::{impl FnOnce<(u32,)> for {closure}}
+impl "impl_FnOnce_for_closure" FnOnce<(u32,)> for {closure} {
+    proof ImpliedClause0: ({closure}: MetaSized) = {built_in impl MetaSized for {closure}}
+    proof ImpliedClause1: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause2: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    vtable: impl_FnOnce_for_closure::{vtable}
+}
+
+// Full name: test_crate::main::{impl FnMut<(u32,)> for {closure}}
+impl "impl_FnMut_for_closure" FnMut<(u32,)> for {closure} {
+    proof ImpliedClause0: ({closure}: MetaSized) = {built_in impl MetaSized for {closure}}
+    proof ImpliedClause1: ({closure}: FnOnce<(u32,)>) = impl_FnOnce_for_closure
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    vtable: impl_FnMut_for_closure::{vtable}
+}
+
+// Full name: test_crate::main::{impl Fn<(u32,)> for {closure}}
+impl "impl_Fn_for_closure" Fn<(u32,)> for {closure} {
+    proof ImpliedClause0: ({closure}: MetaSized) = {built_in impl MetaSized for {closure}}
+    proof ImpliedClause1: ({closure}: FnMut<(u32,)>) = impl_FnMut_for_closure
+    proof ImpliedClause2: ((u32,): Sized) = {built_in impl Sized for (u32,)}
+    proof ImpliedClause3: ((u32,): Tuple) = {built_in impl Tuple for (u32,)}
+    vtable: impl_Fn_for_closure::{vtable}
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let f: &'3 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4); // local
+    let _2: &'6 {closure}; // anonymous local
+    let _3: &'7 {closure}; // anonymous local
+    let _y: u32; // local
+    let _5: &'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9); // anonymous local
+    let _6: (u32,); // anonymous local
+    let _7: &'10 {closure}; // anonymous local
+    let _8: unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32; // anonymous local
+    let _9: &'11 {closure}; // anonymous local
+    let _10: &'20 {closure}; // anonymous local
+    let _11: {closure}; // anonymous local
+
+    storage_live(_9)
+    storage_live(_10)
+    storage_live(_11)
+    _11 = {closure} {  }
+    _10 = &_11
+    _9 = move _10
+    storage_live(_0)
+    storage_live(_7)
+    _0 = ()
+    storage_live(f)
+    storage_live(_2)
+    storage_live(_3)
+    _7 = move _9
+    _3 = &(*_7)
+    _2 = &(*_3)
+    f = unsize_cast<&'6 {closure}, &'12 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '13), &impl_Fn_for_closure::{vtable}>(move _2)
+    storage_dead(_2)
+    fake_read(f)
+    set_type(typeof(f) == &'14 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '15))
+    storage_dead(_3)
+    storage_live(_y)
+    storage_live(_5)
+    _5 = &(*f) with_metadata(copy f.metadata)
+    storage_live(_6)
+    _6 = (const 1u32,)
+    storage_live(_8)
+    _8 = cast<*const (), unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(copy (*_5.metadata).method_call)
+    _y = (copy _8)(move _5, move _6)
+    ↳⚡ storage_dead(_7)
+        unwind_continue
+    storage_dead(_6)
+    storage_dead(_5)
+    fake_read(_y)
+    _0 = ()
+    storage_dead(_y)
+    storage_dead(f)
+    storage_dead(_7)
+    storage_dead(_11)
+    storage_dead(_10)
+    storage_dead(_9)
+    storage_dead(_8)
+    return
+}
+
+// Full name: test_crate::main::{closure}::{impl Destruct for {closure}}
+impl "impl_Destruct_for_closure" Destruct for {closure} {
+    fn drop_glue<'_0_1> = drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+
+

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable.rs
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable.rs
@@ -1,7 +1,19 @@
 //@ charon-args=--monomorphize
 //@ charon-args=--include=core::ops::function
 
+struct Droppable(u32);
+impl Drop for Droppable {
+    fn drop(&mut self) {}
+}
+
 fn main() {
     let f: &dyn Fn(u32) -> u32 = &|x| x + 1;
     let _y = f(1);
+    // A closure with captured state.
+    let captured = 10;
+    let g: &dyn Fn(u32) -> u32 = &|x| x + captured;
+    let _y = g(2);
+    // Built but not called: the drop shim must drop the captured state.
+    let d = Droppable(0);
+    let _h: Box<dyn FnOnce() -> Droppable> = Box::new(move || d);
 }

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable.rs
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable.rs
@@ -16,4 +16,7 @@ fn main() {
     // Built but not called: the drop shim must drop the captured state.
     let d = Droppable(0);
     let _h: Box<dyn FnOnce() -> Droppable> = Box::new(move || d);
+    // A closure with a higher-ranked signature.
+    let k: &dyn Fn(&u32) -> u32 = &|x: &u32| *x;
+    let _y = k(&4);
 }

--- a/charon/tests/ui/dyn/issue-1264-closure-vtable.rs
+++ b/charon/tests/ui/dyn/issue-1264-closure-vtable.rs
@@ -1,0 +1,7 @@
+//@ charon-args=--monomorphize
+//@ charon-args=--include=core::ops::function
+
+fn main() {
+    let f: &dyn Fn(u32) -> u32 = &|x| x + 1;
+    let _y = f(1);
+}

--- a/charon/tests/ui/dyn/mono-by-value-self-vtable.out
+++ b/charon/tests/ui/dyn/mono-by-value-self-vtable.out
@@ -1,0 +1,524 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+fn core::marker::MetaSized::{vtable}::<S>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<S>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<S>()
+
+fn core::marker::MetaSized::{vtable}::<*mut u32>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<*mut u32>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<*mut u32>()
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+// Full name: alloc::boxed::Box::<S>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<S, Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<S, Global>}::drop_glue::<S, Global>
+unsafe fn {impl Destruct for Box::<S, Global>}::drop_glue::<S, Global><'_0>(_1: &'_0 mut Box::<S, Global>)
+= <opaque>
+
+// Full name: alloc::boxed::Box::<*mut u32>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<*mut u32, Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<*mut u32, Global>}::drop_glue::<*mut u32, Global>
+unsafe fn {impl Destruct for Box::<*mut u32, Global>}::drop_glue::<*mut u32, Global><'_0>(_1: &'_0 mut Box::<*mut u32, Global>)
+= <opaque>
+
+// Full name: alloc::boxed::Box::<(dyn Consume)>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<(dyn Consume), Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global>
+unsafe fn {impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'_0>(_1: &'_0 mut Box::<(dyn Consume), Global>)
+= <opaque>
+
+// Full name: test_crate::S
+struct S {
+  _0: u32,
+}
+
+#[track_caller]
+#[diagnostic_item("box_new")]
+pub fn alloc::boxed::{Box::<S, Global>}::new::<S>(_1: S) -> Box::<S, Global>
+= <opaque>
+
+#[track_caller]
+#[diagnostic_item("box_new")]
+pub fn alloc::boxed::{Box::<*mut u32, Global>}::new::<*mut u32>(_1: *mut u32) -> Box::<*mut u32, Global>
+= <opaque>
+
+struct test_crate::Consume::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  method_consume: *const (),
+  method_read: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+// Full name: test_crate::Consume
+trait Consume<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    vtable: test_crate::Consume::{vtable}
+}
+
+// Full name: test_crate::S::{impl Destruct for S}::drop_glue
+unsafe fn impl_Destruct_for_S::drop_glue<'_0>(_1: &'_0 mut S)
+{
+    let _0: (); // return
+    let _1: &'1 mut S; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::S::{impl Destruct for S}
+impl "impl_Destruct_for_S" Destruct for S {
+    fn drop_glue<'_0_1> = impl_Destruct_for_S::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl Consume for S}::read
+fn impl_Consume_for_S::read<'_0>(self: &'_0 S) -> u32
+{
+    let _0: u32; // return
+    let self: &'1 S; // arg #1
+
+    storage_live(_0)
+    _0 = copy (*self)._0
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::read::{vtable_method}
+fn impl_Consume_for_S::read::{vtable_method}<'_0>(_1: &'_0 (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_0 (dyn Consume + '0); // arg #1
+    let _2: &'_0 S; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<&'_0 (dyn Consume + '1), &'_0 S>(move _1)
+    _0 = impl_Consume_for_S::read<'_0>(move _2)
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::consume
+fn impl_Consume_for_S::consume(self: S) -> u32
+{
+    let _0: u32; // return
+    let self: S; // arg #1
+
+    storage_live(_0)
+    _0 = copy self._0
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::consume::{vtable_method}
+fn impl_Consume_for_S::consume::{vtable_method}(_1: *mut (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: *mut (dyn Consume + '0); // arg #1
+    let _2: *mut S; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<*mut (dyn Consume + '1), *mut S>(move _1)
+    _0 = impl_Consume_for_S::consume(move (*_2))
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::{vtable_drop_shim}
+unsafe fn impl_Consume_for_S::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Consume))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Consume + '0); // arg #1
+    let target_self: &'_0 mut S; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Consume + '1), &'_0 mut S>(move dyn_self)
+    drop[impl_Destruct_for_S::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::{vtable}
+fn impl_Consume_for_S::{vtable}() -> test_crate::Consume::{vtable}
+{
+    let ret: test_crate::Consume::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn Consume + '0)); // local
+    let erased_drop: *const (); // local
+    let consume: fn(*mut (dyn Consume + '1)) -> u32; // local
+    let erased_consume: *const (); // local
+    let read: fn<'_0_1>(&'_0_1 (dyn Consume + '2)) -> u32; // local
+    let erased_read: *const (); // local
+    let _9: unsafe fn(*mut (dyn Consume + '5)); // anonymous local
+    let _10: fn(*mut (dyn Consume + '9)) -> u32; // anonymous local
+    let _11: fn<'_0_1>(&'_0_1 (dyn Consume + '14)) -> u32; // anonymous local
+    let _12: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<S>
+    storage_live(align)
+    align = align_of<S>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_9)
+    _9 = cast<impl_Consume_for_S::{vtable_drop_shim}<'4>, unsafe fn(*mut (dyn Consume + '5))>(const impl_Consume_for_S::{vtable_drop_shim}<'4>)
+    drop = move _9
+    erased_drop = cast<unsafe fn(*mut (dyn Consume + '6)), *const ()>(move drop)
+    storage_live(consume)
+    storage_live(erased_consume)
+    storage_live(_10)
+    _10 = cast<impl_Consume_for_S::consume::{vtable_method}, fn(*mut (dyn Consume + '9)) -> u32>(const impl_Consume_for_S::consume::{vtable_method})
+    consume = move _10
+    erased_consume = cast<fn(*mut (dyn Consume + '10)) -> u32, *const ()>(move consume)
+    storage_live(read)
+    storage_live(erased_read)
+    storage_live(_11)
+    _11 = cast<for<'_0_1> impl_Consume_for_S::read::{vtable_method}<'13>, fn<'_0_1>(&'_0_1 (dyn Consume + '14)) -> u32>(const impl_Consume_for_S::read::{vtable_method}<'13>)
+    read = move _11
+    erased_read = cast<fn<'_0_1>(&'_0_1 (dyn Consume + '15)) -> u32, *const ()>(move read)
+    storage_live(_12)
+    _12 = &core::marker::MetaSized::{vtable}::<S>
+    ret = test_crate::Consume::{vtable} { size: move size, align: move align, drop: move erased_drop, method_consume: move erased_consume, method_read: move erased_read, super_trait_0: move _12 }
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::{vtable}
+static impl_Consume_for_S::{vtable}: test_crate::Consume::{vtable} = impl_Consume_for_S::{vtable}()
+
+// Full name: test_crate::{impl Consume for S}
+impl "impl_Consume_for_S" Consume for S {
+    proof ImpliedClause0: (S: MetaSized) = {built_in impl MetaSized for S}
+    vtable: impl_Consume_for_S::{vtable}
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::read
+fn {impl Consume for *mut u32}::read<'_0>(self: &'_0 *mut u32) -> u32
+{
+    let _0: u32; // return
+    let self: &'1 *mut u32; // arg #1
+
+    storage_live(_0)
+    _0 = copy (*(*self))
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::read::{vtable_method}
+fn {impl Consume for *mut u32}::read::{vtable_method}<'_0>(_1: &'_0 (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_0 (dyn Consume + '0); // arg #1
+    let _2: &'_0 *mut u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<&'_0 (dyn Consume + '1), &'_0 *mut u32>(move _1)
+    _0 = {impl Consume for *mut u32}::read<'_0>(move _2)
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::consume
+fn {impl Consume for *mut u32}::consume(self: *mut u32) -> u32
+{
+    let _0: u32; // return
+    let self: *mut u32; // arg #1
+
+    storage_live(_0)
+    _0 = copy (*self)
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::consume::{vtable_method}
+fn {impl Consume for *mut u32}::consume::{vtable_method}(_1: *mut (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: *mut (dyn Consume + '0); // arg #1
+    let _2: *mut *mut u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<*mut (dyn Consume + '1), *mut *mut u32>(move _1)
+    _0 = {impl Consume for *mut u32}::consume(move (*_2))
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::{vtable_drop_shim}
+unsafe fn {impl Consume for *mut u32}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Consume))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Consume + '0); // arg #1
+    let target_self: &'_0 mut *mut u32; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Consume + '1), &'_0 mut *mut u32>(move dyn_self)
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::{vtable}
+fn {impl Consume for *mut u32}::{vtable}() -> test_crate::Consume::{vtable}
+{
+    let ret: test_crate::Consume::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn Consume + '0)); // local
+    let erased_drop: *const (); // local
+    let consume: fn(*mut (dyn Consume + '1)) -> u32; // local
+    let erased_consume: *const (); // local
+    let read: fn<'_0_1>(&'_0_1 (dyn Consume + '2)) -> u32; // local
+    let erased_read: *const (); // local
+    let _9: unsafe fn(*mut (dyn Consume + '5)); // anonymous local
+    let _10: fn(*mut (dyn Consume + '9)) -> u32; // anonymous local
+    let _11: fn<'_0_1>(&'_0_1 (dyn Consume + '14)) -> u32; // anonymous local
+    let _12: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<*mut u32>
+    storage_live(align)
+    align = align_of<*mut u32>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_9)
+    _9 = cast<{impl Consume for *mut u32}::{vtable_drop_shim}<'4>, unsafe fn(*mut (dyn Consume + '5))>(const {impl Consume for *mut u32}::{vtable_drop_shim}<'4>)
+    drop = move _9
+    erased_drop = cast<unsafe fn(*mut (dyn Consume + '6)), *const ()>(move drop)
+    storage_live(consume)
+    storage_live(erased_consume)
+    storage_live(_10)
+    _10 = cast<{impl Consume for *mut u32}::consume::{vtable_method}, fn(*mut (dyn Consume + '9)) -> u32>(const {impl Consume for *mut u32}::consume::{vtable_method})
+    consume = move _10
+    erased_consume = cast<fn(*mut (dyn Consume + '10)) -> u32, *const ()>(move consume)
+    storage_live(read)
+    storage_live(erased_read)
+    storage_live(_11)
+    _11 = cast<for<'_0_1> {impl Consume for *mut u32}::read::{vtable_method}<'13>, fn<'_0_1>(&'_0_1 (dyn Consume + '14)) -> u32>(const {impl Consume for *mut u32}::read::{vtable_method}<'13>)
+    read = move _11
+    erased_read = cast<fn<'_0_1>(&'_0_1 (dyn Consume + '15)) -> u32, *const ()>(move read)
+    storage_live(_12)
+    _12 = &core::marker::MetaSized::{vtable}::<*mut u32>
+    ret = test_crate::Consume::{vtable} { size: move size, align: move align, drop: move erased_drop, method_consume: move erased_consume, method_read: move erased_read, super_trait_0: move _12 }
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::{vtable}
+static {impl Consume for *mut u32}::{vtable}: test_crate::Consume::{vtable} = {impl Consume for *mut u32}::{vtable}()
+
+// Full name: test_crate::{impl Consume for *mut u32}
+impl Consume for *mut u32 {
+    proof ImpliedClause0: (*mut u32: MetaSized) = {built_in impl MetaSized for *mut u32}
+    vtable: {impl Consume for *mut u32}::{vtable}
+}
+
+// Full name: test_crate::mk
+fn mk() -> Box::<(dyn Consume), Global>
+{
+    let _0: Box::<(dyn Consume), Global>; // return
+    let _1: Box::<(dyn Consume), Global>; // anonymous local
+    let _2: Box::<S, Global>; // anonymous local
+    let _3: S; // anonymous local
+
+    storage_live(_0)
+    storage_live(_1)
+    storage_live(_2)
+    storage_live(_3)
+    _3 = S { _0: const 42u32 }
+    _2 = alloc::boxed::{Box::<S, Global>}::new::<S>(move _3)
+    ↳⚡ unwind_continue
+    _1 = unsize_cast<Box::<S, Global>, Box::<(dyn Consume), Global>, &impl_Consume_for_S::{vtable}>(move _2)
+    conditional_drop[{impl Destruct for Box::<S, Global>}::drop_glue::<S, Global><'0>] _2
+    ↳⚡ unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    _0 = unsize_cast<Box::<(dyn Consume), Global>, Box::<(dyn Consume), Global>,  at []>(move _1)
+    conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'1>] _1
+    ↳⚡ unwind_continue
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::mk_ptr
+fn mk_ptr(x: *mut u32) -> Box::<(dyn Consume), Global>
+{
+    let _0: Box::<(dyn Consume), Global>; // return
+    let x: *mut u32; // arg #1
+    let _2: Box::<(dyn Consume), Global>; // anonymous local
+    let _3: Box::<*mut u32, Global>; // anonymous local
+    let _4: *mut u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    storage_live(_3)
+    storage_live(_4)
+    _4 = copy x
+    _3 = alloc::boxed::{Box::<*mut u32, Global>}::new::<*mut u32>(move _4)
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    _2 = unsize_cast<Box::<*mut u32, Global>, Box::<(dyn Consume), Global>, &{impl Consume for *mut u32}::{vtable}>(move _3)
+    conditional_drop[{impl Destruct for Box::<*mut u32, Global>}::drop_glue::<*mut u32, Global><'0>] _3
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    storage_dead(_4)
+    storage_dead(_3)
+    _0 = unsize_cast<Box::<(dyn Consume), Global>, Box::<(dyn Consume), Global>,  at []>(move _2)
+    conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'1>] _2
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(x)
+    return
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let x: Box::<(dyn Consume), Global>; // local
+    let _v_2: u32; // local
+    let _3: &'3 (dyn Consume + '4); // anonymous local
+    let n: u32; // local
+    let p: Box::<(dyn Consume), Global>; // local
+    let _6: *mut u32; // anonymous local
+    let _7: &'6 mut u32; // anonymous local
+    let _v_8: u32; // local
+    let _9: &'7 (dyn Consume + '8); // anonymous local
+    let _10: unsafe fn(&'3 (dyn Consume + '4)) -> u32; // anonymous local
+    let _11: unsafe fn(&'7 (dyn Consume + '8)) -> u32; // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(x)
+    x = mk()
+    ↳⚡ unwind_continue
+    fake_read(x)
+    storage_live(_v_2)
+    storage_live(_3)
+    _3 = &(*x) with_metadata(copy x.metadata)
+    storage_live(_10)
+    _10 = cast<*const (), unsafe fn(&'3 (dyn Consume + '4)) -> u32>(copy (*_3.metadata).method_read)
+    _v_2 = (copy _10)(move _3)
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'13>] x
+        ↳⚡ storage_dead(_11)
+            storage_dead(_10)
+            unwind_terminate
+        unwind_continue
+    storage_dead(_3)
+    fake_read(_v_2)
+    storage_live(n)
+    n = const 5u32
+    fake_read(n)
+    storage_live(p)
+    storage_live(_6)
+    storage_live(_7)
+    _7 = &mut n
+    _6 = &raw mut (*_7)
+    p = mk_ptr(move _6)
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'13>] x
+        ↳⚡ storage_dead(_11)
+            storage_dead(_10)
+            unwind_terminate
+        unwind_continue
+    storage_dead(_6)
+    fake_read(p)
+    storage_dead(_7)
+    storage_live(_v_8)
+    storage_live(_9)
+    _9 = &(*p) with_metadata(copy p.metadata)
+    storage_live(_11)
+    _11 = cast<*const (), unsafe fn(&'7 (dyn Consume + '8)) -> u32>(copy (*_9.metadata).method_read)
+    _v_8 = (copy _11)(move _9)
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'18>] p
+        ↳⚡ storage_dead(_11)
+            storage_dead(_10)
+            unwind_terminate
+        conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'13>] x
+        ↳⚡ storage_dead(_11)
+            storage_dead(_10)
+            unwind_terminate
+        unwind_continue
+    storage_dead(_9)
+    fake_read(_v_8)
+    _0 = ()
+    storage_dead(_v_8)
+    conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'19>] p
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'13>] x
+        ↳⚡ storage_dead(_11)
+            storage_dead(_10)
+            unwind_terminate
+        unwind_continue
+    storage_dead(p)
+    storage_dead(n)
+    storage_dead(_v_2)
+    conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'20>] x
+    ↳⚡ unwind_continue
+    storage_dead(x)
+    storage_dead(_11)
+    storage_dead(_10)
+    return
+}
+
+
+

--- a/charon/tests/ui/dyn/mono-by-value-self-vtable.rs
+++ b/charon/tests/ui/dyn/mono-by-value-self-vtable.rs
@@ -1,6 +1,5 @@
-//! A trait method taking `self: Self` by value is still dyn-compatible; its vtable shim must
-//! take the receiver via `*mut Self` (like rustc's `ShimKind::VTable`) since a `dyn Trait`
-//! value can't be passed directly.
+//@ charon-args=--monomorphize
+//! Monomorphized variant of `by-value-self-vtable.rs`.
 trait Consume {
     fn consume(self) -> u32;
     fn read(&self) -> u32;

--- a/charon/tests/ui/dyn/mono-dyn-call-by-value.out
+++ b/charon/tests/ui/dyn/mono-dyn-call-by-value.out
@@ -1,0 +1,247 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+fn core::marker::MetaSized::{vtable}::<()>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<()>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<()>()
+
+// Full name: alloc::boxed::Box::<(), Global>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<(), Global>
+
+struct () {}
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<(), Global>}::drop_glue::<(), Global>
+unsafe fn {impl Destruct for Box::<(), Global>}::drop_glue::<(), Global><'_0>(_1: &'_0 mut Box::<(), Global>)
+= <opaque>
+
+// Full name: alloc::boxed::Box::<(dyn T), Global>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<(dyn T), Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global>
+unsafe fn {impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'_0>(_1: &'_0 mut Box::<(dyn T), Global>)
+= <opaque>
+
+// Full name: alloc::boxed::{Box::<(), Global>}::new::<()>
+#[track_caller]
+#[diagnostic_item("box_new")]
+pub fn new::<()>(_1: ()) -> Box::<(), Global>
+= <opaque>
+
+struct test_crate::T::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  method_by_ref: *const (),
+  method_by_val: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+// Full name: test_crate::T
+trait T<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    vtable: test_crate::T::{vtable}
+}
+
+// Full name: test_crate::{impl T for ()}::by_val
+fn by_val(self: ())
+{
+    let _0: (); // return
+    let self: (); // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::{impl T for ()}::by_val::{vtable_method}
+fn impl_T_for_unit::by_val::{vtable_method}(_1: *mut (dyn T))
+{
+    let _0: (); // return
+    let _1: *mut (dyn T + '0); // arg #1
+    let _2: *mut (); // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(_2)
+    _2 = concretize<*mut (dyn T + '1), *mut ()>(move _1)
+    _0 = by_val(move (*_2))
+    ↳⚡ unwind_continue
+    return
+}
+
+// Full name: test_crate::{impl T for ()}::by_ref
+fn by_ref<'_0>(self: &'_0 ())
+{
+    let _0: (); // return
+    let self: &'1 (); // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::{impl T for ()}::by_ref::{vtable_method}
+fn impl_T_for_unit::by_ref::{vtable_method}<'_0>(_1: &'_0 (dyn T))
+{
+    let _0: (); // return
+    let _1: &'_0 (dyn T + '0); // arg #1
+    let _2: &'_0 (); // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(_2)
+    _2 = concretize<&'_0 (dyn T + '1), &'_0 ()>(move _1)
+    _0 = by_ref<'_0>(move _2)
+    ↳⚡ unwind_continue
+    return
+}
+
+// Full name: test_crate::{impl T for ()}::{vtable_drop_shim}
+unsafe fn {vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn T))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn T + '0); // arg #1
+    let target_self: &'_0 mut (); // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn T + '1), &'_0 mut ()>(move dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl T for ()}::{vtable}
+fn impl_T_for_unit::{vtable}() -> test_crate::T::{vtable}
+{
+    let ret: test_crate::T::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn T + '0)); // local
+    let erased_drop: *const (); // local
+    let by_ref: fn<'_0_1>(&'_0_1 (dyn T + '1)); // local
+    let erased_by_ref: *const (); // local
+    let by_val: fn(*mut (dyn T + '2)); // local
+    let erased_by_val: *const (); // local
+    let _9: unsafe fn(*mut (dyn T + '5)); // anonymous local
+    let _10: fn<'_0_1>(&'_0_1 (dyn T + '10)); // anonymous local
+    let _11: fn(*mut (dyn T + '14)); // anonymous local
+    let _12: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<()>
+    storage_live(align)
+    align = align_of<()>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_9)
+    _9 = cast<{vtable_drop_shim}<'4>, unsafe fn(*mut (dyn T + '5))>(const {vtable_drop_shim}<'4>)
+    drop = move _9
+    erased_drop = cast<unsafe fn(*mut (dyn T + '6)), *const ()>(move drop)
+    storage_live(by_ref)
+    storage_live(erased_by_ref)
+    storage_live(_10)
+    _10 = cast<for<'_0_1> impl_T_for_unit::by_ref::{vtable_method}<'9>, fn<'_0_1>(&'_0_1 (dyn T + '10))>(const impl_T_for_unit::by_ref::{vtable_method}<'9>)
+    by_ref = move _10
+    erased_by_ref = cast<fn<'_0_1>(&'_0_1 (dyn T + '11)), *const ()>(move by_ref)
+    storage_live(by_val)
+    storage_live(erased_by_val)
+    storage_live(_11)
+    _11 = cast<impl_T_for_unit::by_val::{vtable_method}, fn(*mut (dyn T + '14))>(const impl_T_for_unit::by_val::{vtable_method})
+    by_val = move _11
+    erased_by_val = cast<fn(*mut (dyn T + '15)), *const ()>(move by_val)
+    storage_live(_12)
+    _12 = &core::marker::MetaSized::{vtable}::<()>
+    ret = test_crate::T::{vtable} { size: move size, align: move align, drop: move erased_drop, method_by_ref: move erased_by_ref, method_by_val: move erased_by_val, super_trait_0: move _12 }
+    return
+}
+
+// Full name: test_crate::{impl T for ()}::{vtable}
+static impl_T_for_unit::{vtable}: test_crate::T::{vtable} = impl_T_for_unit::{vtable}()
+
+// Full name: test_crate::{impl T for ()}
+impl "impl_T_for_unit" T for () {
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    vtable: impl_T_for_unit::{vtable}
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let b: Box::<(dyn T), Global>; // local
+    let _2: Box::<(), Global>; // anonymous local
+    let _3: (); // anonymous local
+    let _4: (); // anonymous local
+    let _5: &'3 (dyn T + '4); // anonymous local
+    let _6: (); // anonymous local
+    let _7: Box::<(dyn T), Global>; // anonymous local
+    let _8: unsafe fn(&'3 (dyn T + '4)); // anonymous local
+    let _9: unsafe fn((dyn T + '13)); // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(b)
+    storage_live(_2)
+    storage_live(_3)
+    _3 = ()
+    _2 = new::<()>(move _3)
+    ↳⚡ unwind_continue
+    b = unsize_cast<Box::<(), Global>, Box::<(dyn T), Global>, &impl_T_for_unit::{vtable}>(move _2)
+    conditional_drop[{impl Destruct for Box::<(), Global>}::drop_glue::<(), Global><'5>] _2
+    ↳⚡ unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    fake_read(b)
+    set_type(typeof(b) == Box::<(dyn T), Global>)
+    storage_live(_4)
+    storage_live(_5)
+    _5 = &(*b) with_metadata(copy b.metadata)
+    storage_live(_8)
+    _8 = cast<*const (), unsafe fn(&'3 (dyn T + '4))>(copy (*_5.metadata).method_by_ref)
+    _4 = (copy _8)(move _5)
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'10>] b
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_live(_6)
+    storage_live(_7)
+    _7 = move b
+    storage_live(_9)
+    _9 = cast<*const (), unsafe fn((dyn T + '13))>(copy (*_7.metadata).method_by_val)
+    _6 = (copy _9)(move (*_7))
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'14>] _7
+        ↳⚡ unwind_terminate
+        conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'10>] b
+        ↳⚡ unwind_terminate
+        unwind_continue
+    conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'15>] _7
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'10>] b
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_7)
+    storage_dead(_6)
+    _0 = ()
+    conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'16>] b
+    ↳⚡ unwind_continue
+    storage_dead(b)
+    return
+}
+
+
+

--- a/charon/tests/ui/dyn/mono-dyn-call-by-value.rs
+++ b/charon/tests/ui/dyn/mono-dyn-call-by-value.rs
@@ -1,0 +1,20 @@
+//@ no-default-options
+//@ charon-args=--monomorphize
+
+// this could be Box<dyn FnOnce> but it would make the output a pain
+// to read, so we re-do it by hand instead.
+
+#![feature(unsized_fn_params)]
+trait T {
+    fn by_ref(&self);
+    fn by_val(self);
+}
+impl T for () {
+    fn by_ref(&self) {}
+    fn by_val(self) {}
+}
+fn main() {
+    let b: Box<dyn T> = Box::new(());
+    b.by_ref();
+    (*b).by_val();
+}

--- a/charon/tests/ui/dyn/mono-fn-pointer-vtable.out
+++ b/charon/tests/ui/dyn/mono-fn-pointer-vtable.out
@@ -1,0 +1,488 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+fn core::marker::MetaSized::{vtable}::<fn(u32) -> u32>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<fn(u32) -> u32>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<fn(u32) -> u32>()
+
+// Full name: core::marker::Tuple
+#[fundamental]
+#[lang_item(Tuple)]
+pub trait Tuple<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+struct core::ops::function::FnOnce::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  method_call_once: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+struct core::ops::function::FnMut::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  method_call_mut: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+  super_trait_1: &'static core::ops::function::FnOnce::{vtable},
+}
+
+struct core::ops::function::Fn::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  method_call: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+  super_trait_1: &'static core::ops::function::FnMut::{vtable},
+}
+
+// Full name: core::ops::function::FnOnce
+#[fundamental]
+#[lang_item(FnOnce)]
+pub trait FnOnce<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    vtable: core::ops::function::FnOnce::{vtable}
+}
+
+// Full name: core::ops::function::FnMut
+#[fundamental]
+#[lang_item(FnMut)]
+pub trait FnMut<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    vtable: core::ops::function::FnMut::{vtable}
+}
+
+// Full name: core::ops::function::Fn
+#[fundamental]
+#[lang_item(Fn)]
+pub trait Fn<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnMut<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    vtable: core::ops::function::Fn::{vtable}
+}
+
+struct (_,)::<u32> {
+  _0: u32,
+}
+
+extern "rust-call" fn core::ops::function::FnOnce::{vtable_method}::<fn(u32) -> u32, (u32,)>(shim_self: (dyn FnOnce<(u32,), Output = u32>), args: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let shim_self: (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
+    let args: (u32,); // arg #2
+    let target_self: fn(u32) -> u32; // local
+
+    storage_live(_0)
+    storage_live(target_self)
+    target_self = concretize<(dyn FnOnce<(u32,), Output = u32> + '1), fn(u32) -> u32>(move shim_self)
+    _0 = (copy target_self)(move args._0)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(args)
+        storage_dead(shim_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(args)
+    storage_dead(shim_self)
+    return
+}
+
+unsafe fn core::ops::function::FnOnce::{vtable_drop_shim}::<fn(u32) -> u32, (u32,)><'_0>(dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
+    let target_self: &'_0 mut fn(u32) -> u32; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnOnce<(u32,), Output = u32> + '1), &'_0 mut fn(u32) -> u32>(move dyn_self)
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+fn core::ops::function::FnOnce::{vtable}::<fn(u32) -> u32, (u32,)>() -> core::ops::function::FnOnce::{vtable}
+{
+    let ret: core::ops::function::FnOnce::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call_once: extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '1), (u32,)) -> u32; // local
+    let erased_call_once: *const (); // local
+    let _7: unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<fn(u32) -> u32>
+    storage_live(align)
+    align = align_of<fn(u32) -> u32>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<core::ops::function::FnOnce::{vtable_drop_shim}::<fn(u32) -> u32, (u32,)><'3>, unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '4))>(const core::ops::function::FnOnce::{vtable_drop_shim}::<fn(u32) -> u32, (u32,)><'3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call_once)
+    storage_live(erased_call_once)
+    storage_live(_8)
+    _8 = cast<core::ops::function::FnOnce::{vtable_method}::<fn(u32) -> u32, (u32,)>, extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32>(const core::ops::function::FnOnce::{vtable_method}::<fn(u32) -> u32, (u32,)>)
+    call_once = move _8
+    erased_call_once = cast<extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '9), (u32,)) -> u32, *const ()>(move call_once)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<fn(u32) -> u32>
+    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_once: move erased_call_once, super_trait_0: move _9 }
+    return
+}
+
+static core::ops::function::FnOnce::{vtable}::<fn(u32) -> u32, (u32,)>: core::ops::function::FnOnce::{vtable} = core::ops::function::FnOnce::{vtable}::<fn(u32) -> u32, (u32,)>()
+
+extern "rust-call" fn core::ops::function::FnMut::{vtable_method}::<fn(u32) -> u32, (u32,)>(shim_self: &'_ mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>), args: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let shim_self: &'0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1); // arg #1
+    let args: (u32,); // arg #2
+    let target_self: &'2 mut fn(u32) -> u32; // local
+
+    storage_live(_0)
+    storage_live(target_self)
+    target_self = concretize<&'4 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '5), &'6 mut fn(u32) -> u32>(move shim_self)
+    _0 = (copy (*target_self))(move args._0)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(args)
+        storage_dead(shim_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(args)
+    storage_dead(shim_self)
+    return
+}
+
+unsafe fn core::ops::function::FnMut::{vtable_drop_shim}::<fn(u32) -> u32, (u32,)><'_0>(dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0); // arg #1
+    let target_self: &'_0 mut fn(u32) -> u32; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut fn(u32) -> u32>(move dyn_self)
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+fn core::ops::function::FnMut::{vtable}::<fn(u32) -> u32, (u32,)>() -> core::ops::function::FnMut::{vtable}
+{
+    let ret: core::ops::function::FnMut::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call_mut: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '1), (u32,)) -> u32; // local
+    let erased_call_mut: *const (); // local
+    let _7: unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '8), (u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _10: &'static core::ops::function::FnOnce::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<fn(u32) -> u32>
+    storage_live(align)
+    align = align_of<fn(u32) -> u32>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<core::ops::function::FnMut::{vtable_drop_shim}::<fn(u32) -> u32, (u32,)><'3>, unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '4))>(const core::ops::function::FnMut::{vtable_drop_shim}::<fn(u32) -> u32, (u32,)><'3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call_mut)
+    storage_live(erased_call_mut)
+    storage_live(_8)
+    _8 = cast<for<'_0_1> core::ops::function::FnMut::{vtable_method}::<fn(u32) -> u32, (u32,)>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '8), (u32,)) -> u32>(const core::ops::function::FnMut::{vtable_method}::<fn(u32) -> u32, (u32,)>)
+    call_mut = move _8
+    erased_call_mut = cast<extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '9), (u32,)) -> u32, *const ()>(move call_mut)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<fn(u32) -> u32>
+    storage_live(_10)
+    _10 = &core::ops::function::FnOnce::{vtable}::<fn(u32) -> u32, (u32,)>
+    ret = core::ops::function::FnMut::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_mut: move erased_call_mut, super_trait_0: move _9, super_trait_1: move _10 }
+    return
+}
+
+static core::ops::function::FnMut::{vtable}::<fn(u32) -> u32, (u32,)>: core::ops::function::FnMut::{vtable} = core::ops::function::FnMut::{vtable}::<fn(u32) -> u32, (u32,)>()
+
+extern "rust-call" fn core::ops::function::Fn::{vtable_method}::<fn(u32) -> u32, (u32,)>(shim_self: &'_ (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>), args: (u32,)) -> u32
+{
+    let _0: u32; // return
+    let shim_self: &'0 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1); // arg #1
+    let args: (u32,); // arg #2
+    let target_self: &'2 fn(u32) -> u32; // local
+
+    storage_live(_0)
+    storage_live(target_self)
+    target_self = concretize<&'4 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '5), &'6 fn(u32) -> u32>(move shim_self)
+    _0 = (copy (*target_self))(move args._0)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(args)
+        storage_dead(shim_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(args)
+    storage_dead(shim_self)
+    return
+}
+
+unsafe fn core::ops::function::Fn::{vtable_drop_shim}::<fn(u32) -> u32, (u32,)><'_0>(dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
+    let target_self: &'_0 mut fn(u32) -> u32; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 mut fn(u32) -> u32>(move dyn_self)
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+fn core::ops::function::Fn::{vtable}::<fn(u32) -> u32, (u32,)>() -> core::ops::function::Fn::{vtable}
+{
+    let ret: core::ops::function::Fn::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), (u32,)) -> u32; // local
+    let erased_call: *const (); // local
+    let _7: unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '8), (u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _10: &'static core::ops::function::FnMut::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<fn(u32) -> u32>
+    storage_live(align)
+    align = align_of<fn(u32) -> u32>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<core::ops::function::Fn::{vtable_drop_shim}::<fn(u32) -> u32, (u32,)><'3>, unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4))>(const core::ops::function::Fn::{vtable_drop_shim}::<fn(u32) -> u32, (u32,)><'3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call)
+    storage_live(erased_call)
+    storage_live(_8)
+    _8 = cast<for<'_0_1> core::ops::function::Fn::{vtable_method}::<fn(u32) -> u32, (u32,)>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '8), (u32,)) -> u32>(const core::ops::function::Fn::{vtable_method}::<fn(u32) -> u32, (u32,)>)
+    call = move _8
+    erased_call = cast<extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32, *const ()>(move call)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<fn(u32) -> u32>
+    storage_live(_10)
+    _10 = &core::ops::function::FnMut::{vtable}::<fn(u32) -> u32, (u32,)>
+    ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call: move erased_call, super_trait_0: move _9, super_trait_1: move _10 }
+    return
+}
+
+static core::ops::function::Fn::{vtable}::<fn(u32) -> u32, (u32,)>: core::ops::function::Fn::{vtable} = core::ops::function::Fn::{vtable}::<fn(u32) -> u32, (u32,)>()
+
+// Full name: alloc::boxed::Box::<(dyn FnOnce<(u32,), Output = u32>)>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<(dyn FnOnce<(u32,), Output = u32>), Global>
+
+// Full name: alloc::boxed::Box::<(dyn FnOnce<(u32,), Output = u32>)>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<(dyn FnOnce<(u32,), Output = u32>), Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<(dyn FnOnce<(u32,), Output = u32>), Global>}::drop_glue::<(dyn FnOnce<(u32,), Output = u32>), Global>
+unsafe fn {impl Destruct for Box::<(dyn FnOnce<(u32,), Output = u32>), Global>}::drop_glue::<(dyn FnOnce<(u32,), Output = u32>), Global><'_0>(_1: &'_0 mut Box::<(dyn FnOnce<(u32,), Output = u32>), Global>)
+= <opaque>
+
+// Full name: alloc::boxed::Box::<fn(u32) -> u32>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<fn(u32) -> u32, Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<fn(u32) -> u32, Global>}::drop_glue::<fn(u32) -> u32, Global>
+unsafe fn {impl Destruct for Box::<fn(u32) -> u32, Global>}::drop_glue::<fn(u32) -> u32, Global><'_0>(_1: &'_0 mut Box::<fn(u32) -> u32, Global>)
+= <opaque>
+
+// Full name: alloc::boxed::{Box::<fn(u32) -> u32, Global>}::new::<fn(u32) -> u32>
+#[track_caller]
+#[diagnostic_item("box_new")]
+pub fn new::<fn(u32) -> u32>(_1: fn(u32) -> u32) -> Box::<fn(u32) -> u32, Global>
+= <opaque>
+
+// Full name: test_crate::foo
+fn foo(x: u32) -> u32
+{
+    let _0: u32; // return
+    let x: u32; // arg #1
+
+    storage_live(_0)
+    _0 = copy x
+    storage_dead(x)
+    return
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let f: &'3 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4); // local
+    let _2: &'6 fn(u32) -> u32; // anonymous local
+    let _3: &'7 fn(u32) -> u32; // anonymous local
+    let _4: u32; // anonymous local
+    let _5: &'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9); // anonymous local
+    let _6: (u32,); // anonymous local
+    let g: &'13 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '14); // local
+    let _8: &'16 mut fn(u32) -> u32; // anonymous local
+    let _9: &'17 mut fn(u32) -> u32; // anonymous local
+    let _10: fn(u32) -> u32; // anonymous local
+    let _11: u32; // anonymous local
+    let _12: &'18 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '19); // anonymous local
+    let _13: (u32,); // anonymous local
+    let _h: Box::<(dyn FnOnce<(u32,), Output = u32>), Global>; // local
+    let _15: Box::<fn(u32) -> u32, Global>; // anonymous local
+    let _16: fn(u32) -> u32; // anonymous local
+    let _17: &'20 fn(u32) -> u32; // anonymous local
+    let _18: unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32; // anonymous local
+    let _19: unsafe fn(&'18 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '19), (u32,)) -> u32; // anonymous local
+    let _20: &'21 fn(u32) -> u32; // anonymous local
+    let _21: &'40 fn(u32) -> u32; // anonymous local
+    let _22: fn(u32) -> u32; // anonymous local
+
+    storage_live(_20)
+    storage_live(_21)
+    storage_live(_22)
+    _22 = cast<foo, fn(u32) -> u32>(const foo)
+    _21 = &_22
+    _20 = move _21
+    storage_live(_0)
+    storage_live(_17)
+    _0 = ()
+    storage_live(f)
+    storage_live(_2)
+    storage_live(_3)
+    _17 = move _20
+    _3 = &(*_17)
+    _2 = &(*_3)
+    f = unsize_cast<&'6 fn(u32) -> u32, &'22 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '23), &core::ops::function::Fn::{vtable}::<fn(u32) -> u32, (u32,)>>(move _2)
+    storage_dead(_2)
+    fake_read(f)
+    set_type(typeof(f) == &'24 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '25))
+    storage_dead(_3)
+    storage_live(_4)
+    storage_live(_5)
+    _5 = &(*f) with_metadata(copy f.metadata)
+    storage_live(_6)
+    _6 = (const 1u32,)
+    storage_live(_18)
+    _18 = cast<*const (), unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(copy (*_5.metadata).method_call)
+    _4 = (copy _18)(move _5, move _6)
+    ↳⚡ storage_dead(_17)
+        unwind_continue
+    storage_dead(_6)
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_live(g)
+    storage_live(_8)
+    storage_live(_9)
+    storage_live(_10)
+    _10 = cast<foo, fn(u32) -> u32>(const foo)
+    _9 = &mut _10
+    _8 = &mut (*_9)
+    g = unsize_cast<&'16 mut fn(u32) -> u32, &'30 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '31), &core::ops::function::FnMut::{vtable}::<fn(u32) -> u32, (u32,)>>(move _8)
+    storage_dead(_8)
+    fake_read(g)
+    set_type(typeof(g) == &'32 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '33))
+    storage_dead(_9)
+    storage_live(_11)
+    storage_live(_12)
+    _12 = &mut (*g) with_metadata(copy g.metadata)
+    storage_live(_13)
+    _13 = (const 2u32,)
+    storage_live(_19)
+    _19 = cast<*const (), unsafe fn(&'18 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '19), (u32,)) -> u32>(copy (*_12.metadata).method_call_mut)
+    _11 = (copy _19)(move _12, move _13)
+    ↳⚡ storage_dead(_17)
+        unwind_continue
+    storage_dead(_13)
+    storage_dead(_12)
+    storage_dead(_11)
+    storage_live(_h)
+    storage_live(_15)
+    storage_live(_16)
+    // Built but not called: calling a by-value `dyn` receiver is a separate issue.
+    _16 = cast<foo, fn(u32) -> u32>(const foo)
+    _15 = new::<fn(u32) -> u32>(move _16)
+    ↳⚡ storage_dead(_17)
+        unwind_continue
+    _h = unsize_cast<Box::<fn(u32) -> u32, Global>, Box::<(dyn FnOnce<(u32,), Output = u32>), Global>, &core::ops::function::FnOnce::{vtable}::<fn(u32) -> u32, (u32,)>>(move _15)
+    conditional_drop[{impl Destruct for Box::<fn(u32) -> u32, Global>}::drop_glue::<fn(u32) -> u32, Global><'38>] _15
+    ↳⚡ storage_dead(_17)
+        unwind_continue
+    storage_dead(_16)
+    storage_dead(_15)
+    fake_read(_h)
+    set_type(typeof(_h) == Box::<(dyn FnOnce<(u32,), Output = u32>), Global>)
+    _0 = ()
+    conditional_drop[{impl Destruct for Box::<(dyn FnOnce<(u32,), Output = u32>), Global>}::drop_glue::<(dyn FnOnce<(u32,), Output = u32>), Global><'39>] _h
+    ↳⚡ storage_dead(_17)
+        unwind_continue
+    storage_dead(_h)
+    storage_dead(_10)
+    storage_dead(g)
+    storage_dead(f)
+    storage_dead(_17)
+    storage_dead(_22)
+    storage_dead(_21)
+    storage_dead(_20)
+    storage_dead(_19)
+    storage_dead(_18)
+    return
+}
+
+
+

--- a/charon/tests/ui/dyn/mono-fn-pointer-vtable.out
+++ b/charon/tests/ui/dyn/mono-fn-pointer-vtable.out
@@ -97,17 +97,17 @@ struct (_,)::<u32> {
   _0: u32,
 }
 
-extern "rust-call" fn core::ops::function::FnOnce::{vtable_method}::<fn(u32) -> u32, (u32,)>(shim_self: (dyn FnOnce<(u32,), Output = u32>), args: (u32,)) -> u32
+extern "rust-call" fn core::ops::function::FnOnce::{vtable_method}::<fn(u32) -> u32, (u32,)>(shim_self: *mut (dyn FnOnce<(u32,), Output = u32>), args: (u32,)) -> u32
 {
     let _0: u32; // return
-    let shim_self: (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
+    let shim_self: *mut (dyn FnOnce<(u32,), Output = u32> + '0); // arg #1
     let args: (u32,); // arg #2
-    let target_self: fn(u32) -> u32; // local
+    let target_self: *mut fn(u32) -> u32; // local
 
     storage_live(_0)
     storage_live(target_self)
-    target_self = concretize<(dyn FnOnce<(u32,), Output = u32> + '1), fn(u32) -> u32>(move shim_self)
-    _0 = (copy target_self)(move args._0)
+    target_self = concretize<*mut (dyn FnOnce<(u32,), Output = u32> + '1), *mut fn(u32) -> u32>(move shim_self)
+    _0 = (copy (*target_self))(move args._0)
     ↳⚡ storage_dead(target_self)
         storage_dead(args)
         storage_dead(shim_self)
@@ -140,10 +140,10 @@ fn core::ops::function::FnOnce::{vtable}::<fn(u32) -> u32, (u32,)>() -> core::op
     let align: usize; // local
     let drop: unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '0)); // local
     let erased_drop: *const (); // local
-    let call_once: extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '1), (u32,)) -> u32; // local
+    let call_once: extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '1), (u32,)) -> u32; // local
     let erased_call_once: *const (); // local
     let _7: unsafe fn(*mut (dyn FnOnce<(u32,), Output = u32> + '4)); // anonymous local
-    let _8: extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32; // anonymous local
+    let _8: extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32; // anonymous local
     let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
 
     storage_live(ret)
@@ -160,9 +160,9 @@ fn core::ops::function::FnOnce::{vtable}::<fn(u32) -> u32, (u32,)>() -> core::op
     storage_live(call_once)
     storage_live(erased_call_once)
     storage_live(_8)
-    _8 = cast<core::ops::function::FnOnce::{vtable_method}::<fn(u32) -> u32, (u32,)>, extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32>(const core::ops::function::FnOnce::{vtable_method}::<fn(u32) -> u32, (u32,)>)
+    _8 = cast<core::ops::function::FnOnce::{vtable_method}::<fn(u32) -> u32, (u32,)>, extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '8), (u32,)) -> u32>(const core::ops::function::FnOnce::{vtable_method}::<fn(u32) -> u32, (u32,)>)
     call_once = move _8
-    erased_call_once = cast<extern "rust-call" fn((dyn FnOnce<(u32,), Output = u32> + '9), (u32,)) -> u32, *const ()>(move call_once)
+    erased_call_once = cast<extern "rust-call" fn(*mut (dyn FnOnce<(u32,), Output = u32> + '9), (u32,)) -> u32, *const ()>(move call_once)
     storage_live(_9)
     _9 = &core::marker::MetaSized::{vtable}::<fn(u32) -> u32>
     ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_once: move erased_call_once, super_trait_0: move _9 }
@@ -324,11 +324,6 @@ fn core::ops::function::Fn::{vtable}::<fn(u32) -> u32, (u32,)>() -> core::ops::f
 }
 
 static core::ops::function::Fn::{vtable}::<fn(u32) -> u32, (u32,)>: core::ops::function::Fn::{vtable} = core::ops::function::Fn::{vtable}::<fn(u32) -> u32, (u32,)>()
-
-// Full name: alloc::boxed::Box::<(dyn FnOnce<(u32,), Output = u32>)>
-#[fundamental]
-#[lang_item(OwnedBox)]
-pub opaque type Box::<(dyn FnOnce<(u32,), Output = u32>), Global>
 
 // Full name: alloc::boxed::Box::<(dyn FnOnce<(u32,), Output = u32>)>
 #[fundamental]

--- a/charon/tests/ui/dyn/mono-fn-pointer-vtable.out
+++ b/charon/tests/ui/dyn/mono-fn-pointer-vtable.out
@@ -21,6 +21,11 @@ fn core::marker::MetaSized::{vtable}::<fn(u32) -> u32>() -> core::marker::MetaSi
 
 static core::marker::MetaSized::{vtable}::<fn(u32) -> u32>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<fn(u32) -> u32>()
 
+fn core::marker::MetaSized::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32>()
+
 // Full name: core::marker::Tuple
 #[fundamental]
 #[lang_item(Tuple)]
@@ -325,6 +330,238 @@ fn core::ops::function::Fn::{vtable}::<fn(u32) -> u32, (u32,)>() -> core::ops::f
 
 static core::ops::function::Fn::{vtable}::<fn(u32) -> u32, (u32,)>: core::ops::function::Fn::{vtable} = core::ops::function::Fn::{vtable}::<fn(u32) -> u32, (u32,)>()
 
+struct (_,)::<&'_ u32> {
+  _0: &'_ u32,
+}
+
+extern "rust-call" fn core::ops::function::FnOnce::{vtable_method}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>(shim_self: *mut (dyn FnOnce<(&'_ u32,), Output = u32>), args: (&'_ u32,)) -> u32
+{
+    let _0: u32; // return
+    let shim_self: *mut (dyn FnOnce<(&'_ u32,), Output = u32> + '0); // arg #1
+    let args: (&'_ u32,); // arg #2
+    let target_self: *mut fn<'_0_1>(&'_0_1 u32) -> u32; // local
+
+    storage_live(_0)
+    storage_live(target_self)
+    target_self = concretize<*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '1), *mut fn<'_0_1>(&'_0_1 u32) -> u32>(move shim_self)
+    _0 = (copy (*target_self))(move args._0)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(args)
+        storage_dead(shim_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(args)
+    storage_dead(shim_self)
+    return
+}
+
+unsafe fn core::ops::function::FnOnce::{vtable_drop_shim}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)><'_0>(dyn_self: &'_0 mut (dyn FnOnce<(&'_ u32,), Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnOnce<(&'_ u32,), Output = u32> + '0); // arg #1
+    let target_self: &'_0 mut fn<'_0_1>(&'_0_1 u32) -> u32; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnOnce<(&'_ u32,), Output = u32> + '1), &'_0 mut fn<'_0_1>(&'_0_1 u32) -> u32>(move dyn_self)
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+fn core::ops::function::FnOnce::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>() -> core::ops::function::FnOnce::{vtable}
+{
+    let ret: core::ops::function::FnOnce::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call_once: extern "rust-call" fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '1), (&'_ u32,)) -> u32; // local
+    let erased_call_once: *const (); // local
+    let _7: unsafe fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '8), (&'_ u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<fn<'_0_1>(&'_0_1 u32) -> u32>
+    storage_live(align)
+    align = align_of<fn<'_0_1>(&'_0_1 u32) -> u32>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<core::ops::function::FnOnce::{vtable_drop_shim}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)><'3>, unsafe fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '4))>(const core::ops::function::FnOnce::{vtable_drop_shim}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)><'3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call_once)
+    storage_live(erased_call_once)
+    storage_live(_8)
+    _8 = cast<core::ops::function::FnOnce::{vtable_method}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>, extern "rust-call" fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '8), (&'_ u32,)) -> u32>(const core::ops::function::FnOnce::{vtable_method}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>)
+    call_once = move _8
+    erased_call_once = cast<extern "rust-call" fn(*mut (dyn FnOnce<(&'_ u32,), Output = u32> + '9), (&'_ u32,)) -> u32, *const ()>(move call_once)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32>
+    ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_once: move erased_call_once, super_trait_0: move _9 }
+    return
+}
+
+static core::ops::function::FnOnce::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>: core::ops::function::FnOnce::{vtable} = core::ops::function::FnOnce::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>()
+
+extern "rust-call" fn core::ops::function::FnMut::{vtable_method}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>(shim_self: &'_ mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32>), args: (&'_ u32,)) -> u32
+{
+    let _0: u32; // return
+    let shim_self: &'0 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '1); // arg #1
+    let args: (&'_ u32,); // arg #2
+    let target_self: &'2 mut fn<'_0_1>(&'_0_1 u32) -> u32; // local
+
+    storage_live(_0)
+    storage_live(target_self)
+    target_self = concretize<&'4 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '5), &'6 mut fn<'_0_1>(&'_0_1 u32) -> u32>(move shim_self)
+    _0 = (copy (*target_self))(move args._0)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(args)
+        storage_dead(shim_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(args)
+    storage_dead(shim_self)
+    return
+}
+
+unsafe fn core::ops::function::FnMut::{vtable_drop_shim}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)><'_0>(dyn_self: &'_0 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '0); // arg #1
+    let target_self: &'_0 mut fn<'_0_1>(&'_0_1 u32) -> u32; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '1), &'_0 mut fn<'_0_1>(&'_0_1 u32) -> u32>(move dyn_self)
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+fn core::ops::function::FnMut::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>() -> core::ops::function::FnMut::{vtable}
+{
+    let ret: core::ops::function::FnMut::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call_mut: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '1), (&'_ u32,)) -> u32; // local
+    let erased_call_mut: *const (); // local
+    let _7: unsafe fn(*mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '8), (&'_ u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _10: &'static core::ops::function::FnOnce::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<fn<'_0_1>(&'_0_1 u32) -> u32>
+    storage_live(align)
+    align = align_of<fn<'_0_1>(&'_0_1 u32) -> u32>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<core::ops::function::FnMut::{vtable_drop_shim}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)><'3>, unsafe fn(*mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '4))>(const core::ops::function::FnMut::{vtable_drop_shim}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)><'3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call_mut)
+    storage_live(erased_call_mut)
+    storage_live(_8)
+    _8 = cast<for<'_0_1> core::ops::function::FnMut::{vtable_method}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>, extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '8), (&'_ u32,)) -> u32>(const core::ops::function::FnMut::{vtable_method}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>)
+    call_mut = move _8
+    erased_call_mut = cast<extern "rust-call" fn<'_0_1>(&'_0_1 mut (dyn FnMut<(&'_ u32,), ImpliedClause1::Output = u32> + '9), (&'_ u32,)) -> u32, *const ()>(move call_mut)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32>
+    storage_live(_10)
+    _10 = &core::ops::function::FnOnce::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>
+    ret = core::ops::function::FnMut::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call_mut: move erased_call_mut, super_trait_0: move _9, super_trait_1: move _10 }
+    return
+}
+
+static core::ops::function::FnMut::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>: core::ops::function::FnMut::{vtable} = core::ops::function::FnMut::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>()
+
+extern "rust-call" fn core::ops::function::Fn::{vtable_method}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>(shim_self: &'_ (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32>), args: (&'_ u32,)) -> u32
+{
+    let _0: u32; // return
+    let shim_self: &'0 (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1); // arg #1
+    let args: (&'_ u32,); // arg #2
+    let target_self: &'2 fn<'_0_1>(&'_0_1 u32) -> u32; // local
+
+    storage_live(_0)
+    storage_live(target_self)
+    target_self = concretize<&'4 (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '5), &'6 fn<'_0_1>(&'_0_1 u32) -> u32>(move shim_self)
+    _0 = (copy (*target_self))(move args._0)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(args)
+        storage_dead(shim_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(args)
+    storage_dead(shim_self)
+    return
+}
+
+unsafe fn core::ops::function::Fn::{vtable_drop_shim}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)><'_0>(dyn_self: &'_0 mut (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32>))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0); // arg #1
+    let target_self: &'_0 mut fn<'_0_1>(&'_0_1 u32) -> u32; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), &'_0 mut fn<'_0_1>(&'_0_1 u32) -> u32>(move dyn_self)
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+fn core::ops::function::Fn::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>() -> core::ops::function::Fn::{vtable}
+{
+    let ret: core::ops::function::Fn::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '0)); // local
+    let erased_drop: *const (); // local
+    let call: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '1), (&'_ u32,)) -> u32; // local
+    let erased_call: *const (); // local
+    let _7: unsafe fn(*mut (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4)); // anonymous local
+    let _8: extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '8), (&'_ u32,)) -> u32; // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+    let _10: &'static core::ops::function::FnMut::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<fn<'_0_1>(&'_0_1 u32) -> u32>
+    storage_live(align)
+    align = align_of<fn<'_0_1>(&'_0_1 u32) -> u32>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<core::ops::function::Fn::{vtable_drop_shim}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)><'3>, unsafe fn(*mut (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '4))>(const core::ops::function::Fn::{vtable_drop_shim}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)><'3>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '5)), *const ()>(move drop)
+    storage_live(call)
+    storage_live(erased_call)
+    storage_live(_8)
+    _8 = cast<for<'_0_1> core::ops::function::Fn::{vtable_method}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>, extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '8), (&'_ u32,)) -> u32>(const core::ops::function::Fn::{vtable_method}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>)
+    call = move _8
+    erased_call = cast<extern "rust-call" fn<'_0_1>(&'_0_1 (dyn Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (&'_ u32,)) -> u32, *const ()>(move call)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32>
+    storage_live(_10)
+    _10 = &core::ops::function::FnMut::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>
+    ret = core::ops::function::Fn::{vtable} { size: move size, align: move align, drop: move erased_drop, method_call: move erased_call, super_trait_0: move _9, super_trait_1: move _10 }
+    return
+}
+
+static core::ops::function::Fn::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>: core::ops::function::Fn::{vtable} = core::ops::function::Fn::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>()
+
 // Full name: alloc::boxed::Box::<(dyn FnOnce<(u32,), Output = u32>)>
 #[fundamental]
 #[lang_item(OwnedBox)]
@@ -361,6 +598,18 @@ fn foo(x: u32) -> u32
     return
 }
 
+// Full name: test_crate::bar
+fn bar<'_0>(x: &'_0 u32) -> u32
+{
+    let _0: u32; // return
+    let x: &'1 u32; // arg #1
+
+    storage_live(_0)
+    _0 = copy (*x)
+    storage_dead(x)
+    return
+}
+
 // Full name: test_crate::main
 fn main()
 {
@@ -381,42 +630,63 @@ fn main()
     let _h: Box::<(dyn FnOnce<(u32,), Output = u32>), Global>; // local
     let _15: Box::<fn(u32) -> u32, Global>; // anonymous local
     let _16: fn(u32) -> u32; // anonymous local
-    let _17: &'20 fn(u32) -> u32; // anonymous local
-    let _18: unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32; // anonymous local
-    let _19: unsafe fn(&'18 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '19), (u32,)) -> u32; // anonymous local
-    let _20: &'21 fn(u32) -> u32; // anonymous local
-    let _21: &'40 fn(u32) -> u32; // anonymous local
-    let _22: fn(u32) -> u32; // anonymous local
+    let h: &'23 (dyn for<'a> Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '24); // local
+    let _18: &'26 fn<'_0_1>(&'_0_1 u32) -> u32; // anonymous local
+    let _19: &'27 fn<'_0_1>(&'_0_1 u32) -> u32; // anonymous local
+    let _20: u32; // anonymous local
+    let _21: &'28 (dyn for<'a> Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '29); // anonymous local
+    let _22: (&'_ u32,); // anonymous local
+    let _23: &'31 u32; // anonymous local
+    let _24: &'32 u32; // anonymous local
+    let _25: &'33 u32; // anonymous local
+    let _26: &'34 fn<'_0_1>(&'_0_1 u32) -> u32; // anonymous local
+    let _27: &'35 fn(u32) -> u32; // anonymous local
+    let _28: unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32; // anonymous local
+    let _29: unsafe fn(&'18 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '19), (u32,)) -> u32; // anonymous local
+    let _30: unsafe fn(&'28 (dyn for<'a> Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '29), (&'_ u32,)) -> u32; // anonymous local
+    let _31: &'36 fn(u32) -> u32; // anonymous local
+    let _32: &'54 fn<'_0_1>(&'_0_1 u32) -> u32; // anonymous local
+    let _33: &'63 u32; // anonymous local
+    let _34: &'69 fn(u32) -> u32; // anonymous local
+    let _35: fn(u32) -> u32; // anonymous local
+    let _36: &'70 fn<'_0_1>(&'_0_1 u32) -> u32; // anonymous local
+    let _37: fn<'_0_1>(&'_0_1 u32) -> u32; // anonymous local
+    let _38: &'74 u32; // anonymous local
+    let _39: u32; // anonymous local
 
-    storage_live(_20)
-    storage_live(_21)
-    storage_live(_22)
-    _22 = cast<foo, fn(u32) -> u32>(const foo)
-    _21 = &_22
-    _20 = move _21
+    storage_live(_31)
+    storage_live(_34)
+    storage_live(_35)
+    _35 = cast<foo, fn(u32) -> u32>(const foo)
+    _34 = &_35
+    _31 = move _34
     storage_live(_0)
-    storage_live(_17)
+    storage_live(_25)
+    storage_live(_26)
+    storage_live(_27)
     _0 = ()
     storage_live(f)
     storage_live(_2)
     storage_live(_3)
-    _17 = move _20
-    _3 = &(*_17)
+    _27 = move _31
+    _3 = &(*_27)
     _2 = &(*_3)
-    f = unsize_cast<&'6 fn(u32) -> u32, &'22 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '23), &core::ops::function::Fn::{vtable}::<fn(u32) -> u32, (u32,)>>(move _2)
+    f = unsize_cast<&'6 fn(u32) -> u32, &'37 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '38), &core::ops::function::Fn::{vtable}::<fn(u32) -> u32, (u32,)>>(move _2)
     storage_dead(_2)
     fake_read(f)
-    set_type(typeof(f) == &'24 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '25))
+    set_type(typeof(f) == &'39 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '40))
     storage_dead(_3)
     storage_live(_4)
     storage_live(_5)
     _5 = &(*f) with_metadata(copy f.metadata)
     storage_live(_6)
     _6 = (const 1u32,)
-    storage_live(_18)
-    _18 = cast<*const (), unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(copy (*_5.metadata).method_call)
-    _4 = (copy _18)(move _5, move _6)
-    ↳⚡ storage_dead(_17)
+    storage_live(_28)
+    _28 = cast<*const (), unsafe fn(&'8 (dyn Fn<(u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '9), (u32,)) -> u32>(copy (*_5.metadata).method_call)
+    _4 = (copy _28)(move _5, move _6)
+    ↳⚡ storage_dead(_27)
+        storage_dead(_26)
+        storage_dead(_25)
         unwind_continue
     storage_dead(_6)
     storage_dead(_5)
@@ -428,20 +698,22 @@ fn main()
     _10 = cast<foo, fn(u32) -> u32>(const foo)
     _9 = &mut _10
     _8 = &mut (*_9)
-    g = unsize_cast<&'16 mut fn(u32) -> u32, &'30 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '31), &core::ops::function::FnMut::{vtable}::<fn(u32) -> u32, (u32,)>>(move _8)
+    g = unsize_cast<&'16 mut fn(u32) -> u32, &'45 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '46), &core::ops::function::FnMut::{vtable}::<fn(u32) -> u32, (u32,)>>(move _8)
     storage_dead(_8)
     fake_read(g)
-    set_type(typeof(g) == &'32 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '33))
+    set_type(typeof(g) == &'47 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '48))
     storage_dead(_9)
     storage_live(_11)
     storage_live(_12)
     _12 = &mut (*g) with_metadata(copy g.metadata)
     storage_live(_13)
     _13 = (const 2u32,)
-    storage_live(_19)
-    _19 = cast<*const (), unsafe fn(&'18 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '19), (u32,)) -> u32>(copy (*_12.metadata).method_call_mut)
-    _11 = (copy _19)(move _12, move _13)
-    ↳⚡ storage_dead(_17)
+    storage_live(_29)
+    _29 = cast<*const (), unsafe fn(&'18 mut (dyn FnMut<(u32,), ImpliedClause1::Output = u32> + '19), (u32,)) -> u32>(copy (*_12.metadata).method_call_mut)
+    _11 = (copy _29)(move _12, move _13)
+    ↳⚡ storage_dead(_27)
+        storage_dead(_26)
+        storage_dead(_25)
         unwind_continue
     storage_dead(_13)
     storage_dead(_12)
@@ -452,30 +724,109 @@ fn main()
     // Built but not called: calling a by-value `dyn` receiver is a separate issue.
     _16 = cast<foo, fn(u32) -> u32>(const foo)
     _15 = new::<fn(u32) -> u32>(move _16)
-    ↳⚡ storage_dead(_17)
+    ↳⚡ storage_dead(_27)
+        storage_dead(_26)
+        storage_dead(_25)
         unwind_continue
     _h = unsize_cast<Box::<fn(u32) -> u32, Global>, Box::<(dyn FnOnce<(u32,), Output = u32>), Global>, &core::ops::function::FnOnce::{vtable}::<fn(u32) -> u32, (u32,)>>(move _15)
-    conditional_drop[{impl Destruct for Box::<fn(u32) -> u32, Global>}::drop_glue::<fn(u32) -> u32, Global><'38>] _15
-    ↳⚡ storage_dead(_17)
+    conditional_drop[{impl Destruct for Box::<fn(u32) -> u32, Global>}::drop_glue::<fn(u32) -> u32, Global><'53>] _15
+    ↳⚡ storage_dead(_27)
+        storage_dead(_26)
+        storage_dead(_25)
         unwind_continue
+    storage_live(_33)
+    storage_live(_38)
+    storage_live(_39)
+    // A higher-ranked fn pointer.
+    _39 = const 3u32
+    _38 = &_39
+    _33 = move _38
+    storage_live(_32)
+    storage_live(_36)
+    storage_live(_37)
+    _37 = cast<for<'_0_1> bar<'_0_1>, fn<'_0_1>(&'_0_1 u32) -> u32>(const bar<'73>)
+    _36 = &_37
+    _32 = move _36
     storage_dead(_16)
     storage_dead(_15)
     fake_read(_h)
     set_type(typeof(_h) == Box::<(dyn FnOnce<(u32,), Output = u32>), Global>)
+    storage_live(h)
+    storage_live(_18)
+    storage_live(_19)
+    _26 = move _32
+    _19 = &(*_26)
+    _18 = &(*_19)
+    h = unsize_cast<&'26 fn<'_0_1>(&'_0_1 u32) -> u32, &'55 (dyn for<'a> Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '56), &core::ops::function::Fn::{vtable}::<fn<'_0_1>(&'_0_1 u32) -> u32, (&'_ u32,)>>(move _18)
+    storage_dead(_18)
+    fake_read(h)
+    set_type(typeof(h) == &'60 (dyn for<'a> Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '61))
+    storage_dead(_19)
+    storage_live(_20)
+    storage_live(_21)
+    _21 = &(*h) with_metadata(copy h.metadata)
+    storage_live(_22)
+    storage_live(_23)
+    storage_live(_24)
+    _25 = move _33
+    _24 = &(*_25)
+    _23 = &(*_24)
+    _22 = (move _23,)
+    storage_live(_30)
+    _30 = cast<*const (), unsafe fn(&'28 (dyn for<'a> Fn<(&'_ u32,), ImpliedClause1::ImpliedClause1::Output = u32> + '29), (&'_ u32,)) -> u32>(copy (*_21.metadata).method_call)
+    _20 = (copy _30)(move _21, move _22)
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn FnOnce<(u32,), Output = u32>), Global>}::drop_glue::<(dyn FnOnce<(u32,), Output = u32>), Global><'67>] _h
+        ↳⚡ storage_dead(_27)
+            storage_dead(_26)
+            storage_dead(_25)
+            storage_dead(_39)
+            storage_dead(_38)
+            storage_dead(_37)
+            storage_dead(_36)
+            storage_dead(_35)
+            storage_dead(_34)
+            storage_dead(_33)
+            storage_dead(_32)
+            storage_dead(_31)
+            storage_dead(_30)
+            storage_dead(_29)
+            storage_dead(_28)
+            unwind_terminate
+        storage_dead(_27)
+        storage_dead(_26)
+        storage_dead(_25)
+        unwind_continue
+    storage_dead(_23)
+    storage_dead(_22)
+    storage_dead(_21)
+    storage_dead(_24)
+    storage_dead(_20)
     _0 = ()
-    conditional_drop[{impl Destruct for Box::<(dyn FnOnce<(u32,), Output = u32>), Global>}::drop_glue::<(dyn FnOnce<(u32,), Output = u32>), Global><'39>] _h
-    ↳⚡ storage_dead(_17)
+    storage_dead(h)
+    conditional_drop[{impl Destruct for Box::<(dyn FnOnce<(u32,), Output = u32>), Global>}::drop_glue::<(dyn FnOnce<(u32,), Output = u32>), Global><'68>] _h
+    ↳⚡ storage_dead(_27)
+        storage_dead(_26)
+        storage_dead(_25)
         unwind_continue
     storage_dead(_h)
     storage_dead(_10)
     storage_dead(g)
     storage_dead(f)
-    storage_dead(_17)
-    storage_dead(_22)
-    storage_dead(_21)
-    storage_dead(_20)
-    storage_dead(_19)
-    storage_dead(_18)
+    storage_dead(_27)
+    storage_dead(_26)
+    storage_dead(_25)
+    storage_dead(_39)
+    storage_dead(_38)
+    storage_dead(_37)
+    storage_dead(_36)
+    storage_dead(_35)
+    storage_dead(_34)
+    storage_dead(_33)
+    storage_dead(_32)
+    storage_dead(_31)
+    storage_dead(_30)
+    storage_dead(_29)
+    storage_dead(_28)
     return
 }
 

--- a/charon/tests/ui/dyn/mono-fn-pointer-vtable.rs
+++ b/charon/tests/ui/dyn/mono-fn-pointer-vtable.rs
@@ -1,11 +1,5 @@
 //@ charon-args=--monomorphize --include=core::ops::function
-//! Function *pointers* coerced to `dyn Fn`/`dyn FnMut`/`dyn FnOnce`. The builtin
-//! `Fn*` impls of a `fn(..)` type have no impl items to take the vtable method
-//! from, so the shim concretizes the receiver to the `fn(..)` type and calls
-//! through it, untupling the arguments itself.
-//!
-//! `builtin-vtables.rs` covers the fn *item* and closure cases; `fn-pointer-vtable.rs` covers the
-//! polymorphic mode, where the shim forwards through the `Self: Fn*<Args>` clause instead.
+
 fn foo(x: u32) -> u32 {
     x
 }

--- a/charon/tests/ui/dyn/mono-fn-pointer-vtable.rs
+++ b/charon/tests/ui/dyn/mono-fn-pointer-vtable.rs
@@ -4,6 +4,10 @@ fn foo(x: u32) -> u32 {
     x
 }
 
+fn bar(x: &u32) -> u32 {
+    *x
+}
+
 fn main() {
     let f: &dyn Fn(u32) -> u32 = &(foo as fn(u32) -> u32);
     let _ = f(1);
@@ -11,4 +15,7 @@ fn main() {
     let _ = g(2);
     // Built but not called: calling a by-value `dyn` receiver is a separate issue.
     let _h: Box<dyn FnOnce(u32) -> u32> = Box::new(foo as fn(u32) -> u32);
+    // A higher-ranked fn pointer.
+    let h: &dyn for<'a> Fn(&'a u32) -> u32 = &(bar as fn(&u32) -> u32);
+    let _ = h(&3);
 }

--- a/charon/tests/ui/dyn/mono-fn-pointer-vtable.rs
+++ b/charon/tests/ui/dyn/mono-fn-pointer-vtable.rs
@@ -1,0 +1,20 @@
+//@ charon-args=--monomorphize --include=core::ops::function
+//! Function *pointers* coerced to `dyn Fn`/`dyn FnMut`/`dyn FnOnce`. The builtin
+//! `Fn*` impls of a `fn(..)` type have no impl items to take the vtable method
+//! from, so the shim concretizes the receiver to the `fn(..)` type and calls
+//! through it, untupling the arguments itself.
+//!
+//! `builtin-vtables.rs` covers the fn *item* and closure cases; `fn-pointer-vtable.rs` shows why
+//! this needs `--monomorphize`.
+fn foo(x: u32) -> u32 {
+    x
+}
+
+fn main() {
+    let f: &dyn Fn(u32) -> u32 = &(foo as fn(u32) -> u32);
+    let _ = f(1);
+    let g: &mut dyn FnMut(u32) -> u32 = &mut (foo as fn(u32) -> u32);
+    let _ = g(2);
+    // Built but not called: calling a by-value `dyn` receiver is a separate issue.
+    let _h: Box<dyn FnOnce(u32) -> u32> = Box::new(foo as fn(u32) -> u32);
+}

--- a/charon/tests/ui/dyn/mono-fn-pointer-vtable.rs
+++ b/charon/tests/ui/dyn/mono-fn-pointer-vtable.rs
@@ -4,8 +4,8 @@
 //! from, so the shim concretizes the receiver to the `fn(..)` type and calls
 //! through it, untupling the arguments itself.
 //!
-//! `builtin-vtables.rs` covers the fn *item* and closure cases; `fn-pointer-vtable.rs` shows why
-//! this needs `--monomorphize`.
+//! `builtin-vtables.rs` covers the fn *item* and closure cases; `fn-pointer-vtable.rs` covers the
+//! polymorphic mode, where the shim forwards through the `Self: Fn*<Args>` clause instead.
 fn foo(x: u32) -> u32 {
     x
 }

--- a/charon/tests/ui/dyn/vtables.out
+++ b/charon/tests/ui/dyn/vtables.out
@@ -1285,100 +1285,100 @@ fn main()
     let _15: String; // anonymous local
     let _16: &'23 str; // anonymous local
     let _17: &'24 str; // anonymous local
-    let _18: (&'32 i32, &'33 i32); // anonymous local
-    let _19: &'37 i32; // anonymous local
+    let _18: (&'33 i32, &'34 i32); // anonymous local
+    let _19: &'38 i32; // anonymous local
     let _20: i32; // anonymous local
-    let _21: &'38 mut (dyn Modifiable<i32> + '39); // anonymous local
-    let _22: &'40 i32; // anonymous local
-    let _23: &'41 mut i32; // anonymous local
+    let _21: &'39 mut (dyn Modifiable<i32> + '40); // anonymous local
+    let _22: &'41 i32; // anonymous local
+    let _23: &'42 mut i32; // anonymous local
     let _24: i32; // anonymous local
-    let _25: &'42 i32; // anonymous local
-    let left_val_26: &'43 i32; // local
-    let right_val_27: &'44 i32; // local
+    let _25: &'43 i32; // anonymous local
+    let left_val_26: &'44 i32; // local
+    let right_val_27: &'45 i32; // local
     let _28: bool; // anonymous local
     let _29: i32; // anonymous local
     let _30: i32; // anonymous local
     let kind_31: AssertKind; // local
     let _32: AssertKind; // anonymous local
-    let _33: &'45 i32; // anonymous local
-    let _34: &'46 i32; // anonymous local
-    let _35: &'47 i32; // anonymous local
-    let _36: &'48 i32; // anonymous local
-    let _37: Option<Arguments<'56>>[{built_in impl Sized for Arguments<'56>}]; // anonymous local
-    let z: &'63 (dyn NoParam + '64); // local
-    let _39: &'65 (dyn NoParam + '66); // anonymous local
-    let _40: &'67 (dyn NoParam + '68); // anonymous local
-    let _41: &'69 i32; // anonymous local
-    let _42: &'70 i32; // anonymous local
+    let _33: &'46 i32; // anonymous local
+    let _34: &'47 i32; // anonymous local
+    let _35: &'48 i32; // anonymous local
+    let _36: &'49 i32; // anonymous local
+    let _37: Option<Arguments<'58>>[{built_in impl Sized for Arguments<'58>}]; // anonymous local
+    let z: &'65 (dyn NoParam + '66); // local
+    let _39: &'67 (dyn NoParam + '68); // anonymous local
+    let _40: &'69 (dyn NoParam + '70); // anonymous local
+    let _41: &'71 i32; // anonymous local
+    let _42: &'72 i32; // anonymous local
     let _43: (); // anonymous local
-    let _44: &'71 (dyn NoParam + '72); // anonymous local
-    let a: &'76 (dyn Both32And64 + '77); // local
-    let _46: &'78 i32; // anonymous local
-    let _47: &'79 i32; // anonymous local
+    let _44: &'73 (dyn NoParam + '74); // anonymous local
+    let a: &'78 (dyn Both32And64 + '79); // local
+    let _46: &'80 i32; // anonymous local
+    let _47: &'81 i32; // anonymous local
     let _48: (); // anonymous local
-    let _49: &'80 (dyn Both32And64 + '81); // anonymous local
-    let _50: &'82 i32; // anonymous local
-    let _51: &'83 i32; // anonymous local
-    let _52: &'85 i64; // anonymous local
-    let _53: &'86 i64; // anonymous local
-    let b: &'90 (dyn LifetimeTrait<Ty = i32> + '91); // local
-    let _55: &'92 i32; // anonymous local
-    let _56: &'93 i32; // anonymous local
-    let _57: (&'94 i32, &'95 i32); // anonymous local
-    let _58: &'99 i32; // anonymous local
-    let _59: &'100 i32; // anonymous local
-    let _60: &'101 (dyn LifetimeTrait<Ty = i32> + '102); // anonymous local
-    let _61: &'103 (dyn LifetimeTrait<Ty = i32> + '104); // anonymous local
-    let _62: &'105 i32; // anonymous local
-    let _63: &'106 i32; // anonymous local
-    let _64: &'107 i32; // anonymous local
-    let left_val_65: &'108 i32; // local
-    let right_val_66: &'109 i32; // local
+    let _49: &'82 (dyn Both32And64 + '83); // anonymous local
+    let _50: &'84 i32; // anonymous local
+    let _51: &'85 i32; // anonymous local
+    let _52: &'87 i64; // anonymous local
+    let _53: &'88 i64; // anonymous local
+    let b: &'92 (dyn LifetimeTrait<Ty = i32> + '93); // local
+    let _55: &'94 i32; // anonymous local
+    let _56: &'95 i32; // anonymous local
+    let _57: (&'96 i32, &'97 i32); // anonymous local
+    let _58: &'101 i32; // anonymous local
+    let _59: &'102 i32; // anonymous local
+    let _60: &'103 (dyn LifetimeTrait<Ty = i32> + '104); // anonymous local
+    let _61: &'105 (dyn LifetimeTrait<Ty = i32> + '106); // anonymous local
+    let _62: &'107 i32; // anonymous local
+    let _63: &'108 i32; // anonymous local
+    let _64: &'109 i32; // anonymous local
+    let left_val_65: &'110 i32; // local
+    let right_val_66: &'111 i32; // local
     let _67: bool; // anonymous local
     let _68: i32; // anonymous local
     let _69: i32; // anonymous local
     let kind_70: AssertKind; // local
     let _71: AssertKind; // anonymous local
-    let _72: &'110 i32; // anonymous local
-    let _73: &'111 i32; // anonymous local
-    let _74: &'112 i32; // anonymous local
-    let _75: &'113 i32; // anonymous local
-    let _76: Option<Arguments<'114>>[{built_in impl Sized for Arguments<'114>}]; // anonymous local
-    let _77: &'118 i32; // anonymous local
-    let _78: &'119 i32; // anonymous local
-    let _79: &'120 i32; // anonymous local
-    let _80: &'121 i64; // anonymous local
-    let _81: &'122 i32; // anonymous local
-    let _82: &'123 i32; // anonymous local
-    let _83: &'124 i32; // anonymous local
-    let _84: &'125 i32; // anonymous local
-    let _85: &'126 i32; // anonymous local
-    let _86: &'127 i32; // anonymous local
-    let _87: &'158 i32; // anonymous local
-    let _88: &'166 i32; // anonymous local
-    let _89: &'184 i32; // anonymous local
-    let _90: &'190 i32; // anonymous local
-    let _91: &'191 i64; // anonymous local
-    let _92: &'197 i32; // anonymous local
-    let _93: &'205 i32; // anonymous local
-    let _94: &'210 i32; // anonymous local
-    let _95: &'224 i32; // anonymous local
+    let _72: &'112 i32; // anonymous local
+    let _73: &'113 i32; // anonymous local
+    let _74: &'114 i32; // anonymous local
+    let _75: &'115 i32; // anonymous local
+    let _76: Option<Arguments<'116>>[{built_in impl Sized for Arguments<'116>}]; // anonymous local
+    let _77: &'120 i32; // anonymous local
+    let _78: &'121 i32; // anonymous local
+    let _79: &'122 i32; // anonymous local
+    let _80: &'123 i64; // anonymous local
+    let _81: &'124 i32; // anonymous local
+    let _82: &'125 i32; // anonymous local
+    let _83: &'126 i32; // anonymous local
+    let _84: &'127 i32; // anonymous local
+    let _85: &'128 i32; // anonymous local
+    let _86: &'129 i32; // anonymous local
+    let _87: &'160 i32; // anonymous local
+    let _88: &'168 i32; // anonymous local
+    let _89: &'187 i32; // anonymous local
+    let _90: &'193 i32; // anonymous local
+    let _91: &'194 i64; // anonymous local
+    let _92: &'200 i32; // anonymous local
+    let _93: &'208 i32; // anonymous local
+    let _94: &'213 i32; // anonymous local
+    let _95: &'228 i32; // anonymous local
     let _96: i32; // anonymous local
-    let _97: &'225 i32; // anonymous local
+    let _97: &'229 i32; // anonymous local
     let _98: i32; // anonymous local
-    let _99: &'226 i32; // anonymous local
+    let _99: &'230 i32; // anonymous local
     let _100: i32; // anonymous local
-    let _101: &'227 i32; // anonymous local
+    let _101: &'231 i32; // anonymous local
     let _102: i32; // anonymous local
-    let _103: &'228 i32; // anonymous local
+    let _103: &'232 i32; // anonymous local
     let _104: i32; // anonymous local
-    let _105: &'229 i64; // anonymous local
+    let _105: &'233 i64; // anonymous local
     let _106: i64; // anonymous local
-    let _107: &'230 i32; // anonymous local
+    let _107: &'234 i32; // anonymous local
     let _108: i32; // anonymous local
-    let _109: &'231 i32; // anonymous local
+    let _109: &'235 i32; // anonymous local
     let _110: i32; // anonymous local
-    let _111: &'232 i32; // anonymous local
+    let _111: &'236 i32; // anonymous local
     let _112: i32; // anonymous local
 
     storage_live(_86)
@@ -1404,10 +1404,10 @@ fn main()
     _85 = move _86
     _3 = &(*_85)
     _2 = &(*_3)
-    x = unsize_cast<&'6 i32, &'128 (dyn Checkable<i32> + '129), &impl_Checkable_i32_for_i32::{vtable}>(move _2)
+    x = unsize_cast<&'6 i32, &'130 (dyn Checkable<i32> + '131), &impl_Checkable_i32_for_i32::{vtable}>(move _2)
     storage_dead(_2)
     fake_read(x)
-    set_type(typeof(x) == &'130 (dyn Checkable<i32> + '131))
+    set_type(typeof(x) == &'132 (dyn Checkable<i32> + '133))
     storage_dead(_3)
     storage_live(_4)
     storage_live(_5)
@@ -1448,10 +1448,10 @@ fn main()
     _9 = const 99i32
     _8 = &mut _9
     _7 = &mut (*_8)
-    y = unsize_cast<&'16 mut i32, &'136 mut (dyn Modifiable<i32> + '137), &impl_Modifiable_for_i32::{vtable}<i32>[{built_in impl Sized for i32}, impl_Clone_for_i32]>(move _7)
+    y = unsize_cast<&'16 mut i32, &'138 mut (dyn Modifiable<i32> + '139), &impl_Modifiable_for_i32::{vtable}<i32>[{built_in impl Sized for i32}, impl_Clone_for_i32]>(move _7)
     storage_dead(_7)
     fake_read(y)
-    set_type(typeof(y) == &'138 mut (dyn Modifiable<i32> + '139))
+    set_type(typeof(y) == &'140 mut (dyn Modifiable<i32> + '141))
     storage_dead(_8)
     storage_live(_10)
     storage_live(_11)
@@ -1463,7 +1463,7 @@ fn main()
     storage_live(_17)
     _17 = const "Hello"
     _16 = &(*_17) with_metadata(copy _17.metadata)
-    _15 = to_string<'142, str>[{built_in impl MetaSized for str}, {impl#16}](move _16)
+    _15 = to_string<'144, str>[{built_in impl MetaSized for str}, {impl#16}](move _16)
     ↳⚡ storage_dead(_85)
         storage_dead(_84)
         storage_dead(_83)
@@ -1491,8 +1491,8 @@ fn main()
     storage_dead(_16)
     _14 = &_15
     _13 = &(*_14)
-    _12 = modify_trait_object<'144, String>[{built_in impl Sized for String}, impl_Clone_for_String](move _13)
-    ↳⚡ conditional_drop[drop_glue<'145>] _15
+    _12 = modify_trait_object<'146, String>[{built_in impl Sized for String}, impl_Clone_for_String](move _13)
+    ↳⚡ conditional_drop[drop_glue<'147>] _15
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -1570,8 +1570,8 @@ fn main()
         unwind_continue
     _11 = &_12
     storage_dead(_13)
-    _10 = is_empty<'147>(move _11)
-    ↳⚡ conditional_drop[drop_glue<'148>] _12
+    _10 = is_empty<'149>(move _11)
+    ↳⚡ conditional_drop[drop_glue<'150>] _12
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -1623,7 +1623,7 @@ fn main()
             storage_dead(_87)
             storage_dead(_86)
             unwind_terminate
-        conditional_drop[drop_glue<'145>] _15
+        conditional_drop[drop_glue<'147>] _15
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -1702,8 +1702,8 @@ fn main()
     if move _10 {
     } else {
         storage_dead(_11)
-        conditional_drop[drop_glue<'150>] _12
-        ↳⚡ conditional_drop[drop_glue<'145>] _15
+        conditional_drop[drop_glue<'152>] _12
+        ↳⚡ conditional_drop[drop_glue<'147>] _15
             ↳⚡ storage_dead(_85)
                 storage_dead(_84)
                 storage_dead(_83)
@@ -1779,7 +1779,7 @@ fn main()
             storage_dead(_32)
             storage_dead(kind_31)
             unwind_continue
-        conditional_drop[drop_glue<'152>] _15
+        conditional_drop[drop_glue<'154>] _15
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -1964,7 +1964,7 @@ fn main()
         _83 = move _88
         _42 = &(*_83)
         _41 = &(*_42)
-        _40 = to_dyn_obj<'168, i32>[{built_in impl Sized for i32}, impl_NoParam_for_i32](move _41)
+        _40 = to_dyn_obj<'170, i32>[{built_in impl Sized for i32}, impl_NoParam_for_i32](move _41)
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -1990,11 +1990,11 @@ fn main()
             storage_dead(kind_31)
             unwind_continue
         _39 = &(*_40) with_metadata(copy _40.metadata)
-        z = unsize_cast<&'65 (dyn NoParam + '66), &'176 (dyn NoParam + '177),  at []>(move _39)
+        z = unsize_cast<&'67 (dyn NoParam + '68), &'179 (dyn NoParam + '180),  at []>(move _39)
         storage_dead(_41)
         storage_dead(_39)
         fake_read(z)
-        set_type(typeof(z) == &'178 (dyn NoParam + '179))
+        set_type(typeof(z) == &'181 (dyn NoParam + '182))
         storage_dead(_42)
         storage_dead(_40)
         storage_live(_43)
@@ -2051,10 +2051,10 @@ fn main()
         _82 = move _89
         _47 = &(*_82)
         _46 = &(*_47)
-        a = unsize_cast<&'78 i32, &'185 (dyn Both32And64 + '186), &impl_Both32And64_for_i32::{vtable}>(move _46)
+        a = unsize_cast<&'80 i32, &'188 (dyn Both32And64 + '189), &impl_Both32And64_for_i32::{vtable}>(move _46)
         storage_dead(_46)
         fake_read(a)
-        set_type(typeof(a) == &'187 (dyn Both32And64 + '188))
+        set_type(typeof(a) == &'190 (dyn Both32And64 + '191))
         storage_dead(_47)
         storage_live(_48)
         storage_live(_49)
@@ -2118,10 +2118,10 @@ fn main()
         _79 = move _92
         _56 = &(*_79)
         _55 = &(*_56)
-        b = unsize_cast<&'92 i32, &'198 (dyn LifetimeTrait<Ty = i32> + '199), &impl_LifetimeTrait_for_i32::{vtable}>(move _55)
+        b = unsize_cast<&'94 i32, &'201 (dyn LifetimeTrait<Ty = i32> + '202), &impl_LifetimeTrait_for_i32::{vtable}>(move _55)
         storage_dead(_55)
         fake_read(b)
-        set_type(typeof(b) == &'200 (dyn LifetimeTrait<Ty = i32> + '201))
+        set_type(typeof(b) == &'203 (dyn LifetimeTrait<Ty = i32> + '204))
         storage_dead(_56)
         storage_live(_57)
         storage_live(_58)
@@ -2129,14 +2129,14 @@ fn main()
         storage_live(_60)
         storage_live(_61)
         _61 = &(*b) with_metadata(copy b.metadata)
-        _60 = unsize_cast<&'103 (dyn LifetimeTrait<Ty = i32> + '104), &'203 (dyn LifetimeTrait<Ty = i32> + '204),  at []>(move _61)
+        _60 = unsize_cast<&'105 (dyn LifetimeTrait<Ty = i32> + '106), &'206 (dyn LifetimeTrait<Ty = i32> + '207),  at []>(move _61)
         storage_dead(_61)
         storage_live(_62)
         storage_live(_63)
         _78 = move _93
         _63 = &(*_78)
         _62 = &(*_63)
-        _59 = use_lifetime_trait<'208, '209>(move _60, move _62)
+        _59 = use_lifetime_trait<'211, '212>(move _60, move _62)
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -2325,8 +2325,8 @@ fn main()
         return
     }
     storage_dead(_11)
-    conditional_drop[drop_glue<'149>] _12
-    ↳⚡ conditional_drop[drop_glue<'145>] _15
+    conditional_drop[drop_glue<'151>] _12
+    ↳⚡ conditional_drop[drop_glue<'147>] _15
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -2402,7 +2402,7 @@ fn main()
         storage_dead(_32)
         storage_dead(kind_31)
         unwind_continue
-    conditional_drop[drop_glue<'151>] _15
+    conditional_drop[drop_glue<'153>] _15
     ↳⚡ storage_dead(_85)
         storage_dead(_84)
         storage_dead(_83)

--- a/charon/tests/ui/gosim-demo.out
+++ b/charon/tests/ui/gosim-demo.out
@@ -86,30 +86,30 @@ where
     let _2: Iter<'3, T>[TraitClause0]; // anonymous local
     let _3: &'4 [T]; // anonymous local
     let iter: Iter<'5, T>[TraitClause0]; // local
-    let _5: Option<&'13 T>[{built_in impl Sized for &'13 T}]; // anonymous local
-    let _6: &'19 mut Iter<'20, T>[TraitClause0]; // anonymous local
-    let _7: &'21 mut Iter<'22, T>[TraitClause0]; // anonymous local
-    let x: &'23 T; // local
+    let _5: Option<&'14 T>[{built_in impl Sized for &'14 T}]; // anonymous local
+    let _6: &'20 mut Iter<'21, T>[TraitClause0]; // anonymous local
+    let _7: &'22 mut Iter<'23, T>[TraitClause0]; // anonymous local
+    let x: &'24 T; // local
     let _9: (); // anonymous local
-    let _10: Arguments<'25>; // anonymous local
-    let args_11: (&'30 &'31 T,); // local
-    let _12: &'32 &'33 T; // anonymous local
-    let args_13: [Argument<'41>; 1usize]; // local
-    let _14: Argument<'45>; // anonymous local
-    let _15: &'46 &'47 T; // anonymous local
-    let _16: &'49 [u8; 7usize]; // anonymous local
-    let _17: &'50 [u8; 7usize]; // anonymous local
-    let _18: &'56 [Argument<'57>; 1usize]; // anonymous local
-    let _19: &'61 [Argument<'62>; 1usize]; // anonymous local
+    let _10: Arguments<'26>; // anonymous local
+    let args_11: (&'31 &'32 T,); // local
+    let _12: &'33 &'34 T; // anonymous local
+    let args_13: [Argument<'43>; 1usize]; // local
+    let _14: Argument<'47>; // anonymous local
+    let _15: &'48 &'49 T; // anonymous local
+    let _16: &'51 [u8; 7usize]; // anonymous local
+    let _17: &'52 [u8; 7usize]; // anonymous local
+    let _18: &'58 [Argument<'59>; 1usize]; // anonymous local
+    let _19: &'63 [Argument<'64>; 1usize]; // anonymous local
     let _20: [u8; 7usize]; // anonymous local
-    let _21: &'95 [u8; 7usize]; // anonymous local
+    let _21: &'98 [u8; 7usize]; // anonymous local
 
     storage_live(_0)
     _0 = ()
     storage_live(_2)
     storage_live(_3)
     _3 = copy slice
-    _2 = into_iter<'66, T>[TraitClause0](move _3)
+    _2 = into_iter<'68, T>[TraitClause0](move _3)
     ↳⚡ storage_dead(slice)
         unwind_continue
     storage_dead(_3)
@@ -121,7 +121,7 @@ where
         storage_live(_7)
         _7 = &mut iter
         _6 = &two-phase-mut (*_7)
-        _5 = next<'68, '70, T>[TraitClause0](move _6)
+        _5 = next<'70, '72, T>[TraitClause0](move _6)
         ↳⚡ storage_dead(slice)
             unwind_continue
         storage_dead(_6)
@@ -146,7 +146,7 @@ where
         storage_live(_14)
         storage_live(_15)
         _15 = &(*args_11._0)
-        _14 = new_debug<'81, '93, &'83 T>[{built_in impl Sized for &'85 T}, {impl#8}<'91, T>[TraitClause1]](move _15)
+        _14 = new_debug<'83, '96, &'85 T>[{built_in impl Sized for &'87 T}, {impl#8}<'94, T>[TraitClause1]](move _15)
         ↳⚡ storage_dead(slice)
             unwind_continue
         storage_dead(_15)
@@ -165,14 +165,14 @@ where
         storage_live(_19)
         _19 = &args_13
         _18 = &(*_19)
-        _10 = new<'100, 7usize, 1usize>(move _16, move _18)
+        _10 = new<'103, 7usize, 1usize>(move _16, move _18)
         ↳⚡ storage_dead(slice)
             unwind_continue
         storage_dead(_19)
         storage_dead(_18)
         storage_dead(_17)
         storage_dead(_16)
-        _9 = _eprint<'102>(move _10)
+        _9 = _eprint<'105>(move _10)
         ↳⚡ storage_dead(slice)
             unwind_continue
         storage_dead(_10)

--- a/charon/tests/ui/impl-trait.out
+++ b/charon/tests/ui/impl-trait.out
@@ -314,11 +314,11 @@ where
     TraitClause0: (U: Sized),
     TypeOutlives0: U: '_0,
 {
-    let _0: WrapClone<&'9 U>[{built_in impl Sized for &'9 U}, {impl Clone for &'_0 T}<'9, U>]; // return
+    let _0: WrapClone<&'10 U>[{built_in impl Sized for &'10 U}, {impl Clone for &'_0 T}<'10, U>]; // return
     let _1: {closure}<U>[TraitClause0]; // arg #1
     let tupled_args: (&'_0 U,); // arg #2
-    let x: &'15 U; // local
-    let _4: &'16 U; // anonymous local
+    let x: &'16 U; // local
+    let _4: &'17 U; // anonymous local
 
     storage_live(_0)
     storage_live(x)
@@ -376,14 +376,14 @@ pub fn use_wrap()
 {
     let _0: (); // return
     let f: {closure}<u32>[{built_in impl Sized for u32}]; // local
-    let _2: WrapClone<&'10 u32>[{built_in impl Sized for &'10 u32}, {impl Clone for &'_0 T}<'10, u32>]; // anonymous local
+    let _2: WrapClone<&'11 u32>[{built_in impl Sized for &'11 u32}, {impl Clone for &'_0 T}<'11, u32>]; // anonymous local
     let _3: {closure}<u32>[{built_in impl Sized for u32}]; // anonymous local
-    let _4: (&'17 u32,); // anonymous local
-    let _5: &'18 u32; // anonymous local
-    let _6: &'19 u32; // anonymous local
-    let _7: &'20 u32; // anonymous local
-    let _8: &'21 u32; // anonymous local
-    let _9: &'36 u32; // anonymous local
+    let _4: (&'18 u32,); // anonymous local
+    let _5: &'19 u32; // anonymous local
+    let _6: &'20 u32; // anonymous local
+    let _7: &'21 u32; // anonymous local
+    let _8: &'22 u32; // anonymous local
+    let _9: &'37 u32; // anonymous local
     let _10: u32; // anonymous local
 
     storage_live(_0)
@@ -410,14 +410,14 @@ pub fn use_wrap()
     _6 = &(*_7)
     _5 = &(*_6)
     _4 = (move _5,)
-    _2 = call_once<'26, u32>[{built_in impl Sized for u32}](move _3, move _4)
-    ↳⚡ conditional_drop[drop_glue<'27, u32>[{built_in impl Sized for u32}]] _3
+    _2 = call_once<'27, u32>[{built_in impl Sized for u32}](move _3, move _4)
+    ↳⚡ conditional_drop[drop_glue<'28, u32>[{built_in impl Sized for u32}]] _3
         ↳⚡ storage_dead(_7)
             storage_dead(_10)
             storage_dead(_9)
             storage_dead(_8)
             unwind_terminate
-        conditional_drop[drop_glue<'35, u32>[{built_in impl Sized for u32}]] f
+        conditional_drop[drop_glue<'36, u32>[{built_in impl Sized for u32}]] f
         ↳⚡ storage_dead(_7)
             storage_dead(_10)
             storage_dead(_9)
@@ -428,11 +428,11 @@ pub fn use_wrap()
     storage_dead(_5)
     storage_dead(_4)
     storage_dead(_3)
-    set_type(typeof(_2) <= WrapClone<&'28 u32>[{built_in impl Sized for &'28 u32}, {impl Clone for &'_0 T}<'28, u32>])
+    set_type(typeof(_2) <= WrapClone<&'29 u32>[{built_in impl Sized for &'29 u32}, {impl Clone for &'_0 T}<'29, u32>])
     storage_dead(_6)
     storage_dead(_2)
     _0 = ()
-    conditional_drop[drop_glue<'34, u32>[{built_in impl Sized for u32}]] f
+    conditional_drop[drop_glue<'35, u32>[{built_in impl Sized for u32}]] f
     ↳⚡ storage_dead(_7)
         unwind_continue
     storage_dead(f)

--- a/charon/tests/ui/issue-1409-anonymous-method-lifetime.out
+++ b/charon/tests/ui/issue-1409-anonymous-method-lifetime.out
@@ -191,7 +191,7 @@ pub fn test<'a>(x: &'a u64)
     storage_live(_2)
     storage_live(_3)
     _3 = &(*x)
-    _2 = use_fn<'3, from<'5>>[{built_in impl Sized for from<'7>}, {impl FnMut<(&'_0 u64,)> for from<'_0>}<'3>](move _3, const from<'19>)
+    _2 = use_fn<'3, from<'5>>[{built_in impl Sized for from<'7>}, {impl FnMut<(&'_0 u64,)> for from<'_0>}<'3>](move _3, const from<'20>)
     ↳⚡ storage_dead(x)
         unwind_continue
     storage_dead(_3)

--- a/charon/tests/ui/issue-394-rpit-with-lifetime.out
+++ b/charon/tests/ui/issue-394-rpit-with-lifetime.out
@@ -174,13 +174,13 @@ impl<'a> "impl_FnMut_unit_for_closure" FnMut<()> for {closure}<'a> {
 // Full name: test_crate::sparse_transitions
 fn sparse_transitions<'a>() -> FromFn<{closure}<'a>>[{built_in impl Sized for {closure}<'a>}]
 {
-    let _0: FromFn<{closure}<'6>>[{built_in impl Sized for {closure}<'6>}]; // return
-    let _1: {closure}<'10>; // anonymous local
+    let _0: FromFn<{closure}<'8>>[{built_in impl Sized for {closure}<'8>}]; // return
+    let _1: {closure}<'12>; // anonymous local
 
     storage_live(_0)
     storage_live(_1)
     _1 = {closure} {  }
-    _0 = from_fn<u8, {closure}<'13>>[{built_in impl Sized for u8}, {built_in impl Sized for {closure}<'13>}, impl_FnMut_unit_for_closure<'13>](move _1)
+    _0 = from_fn<u8, {closure}<'15>>[{built_in impl Sized for u8}, {built_in impl Sized for {closure}<'15>}, impl_FnMut_unit_for_closure<'15>](move _1)
     ↳⚡ unwind_continue
     storage_dead(_1)
     return

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -656,25 +656,25 @@ fn select<'_0, '_1>(lhs: &'_0 [u8], rhs: &'_1 [u8])
     let lhs: &'1 [u8]; // arg #1
     let rhs: &'2 [u8]; // arg #2
     let _3: bool; // anonymous local
-    let _4: (&'11 usize, &'12 usize); // anonymous local
-    let _5: &'16 usize; // anonymous local
+    let _4: (&'12 usize, &'13 usize); // anonymous local
+    let _5: &'17 usize; // anonymous local
     let _6: usize; // anonymous local
-    let _7: &'17 [u8]; // anonymous local
-    let _8: &'18 usize; // anonymous local
+    let _7: &'18 [u8]; // anonymous local
+    let _8: &'19 usize; // anonymous local
     let _9: usize; // anonymous local
-    let _10: &'19 [u8]; // anonymous local
-    let left_val: &'20 usize; // local
-    let right_val: &'21 usize; // local
+    let _10: &'20 [u8]; // anonymous local
+    let left_val: &'21 usize; // local
+    let right_val: &'22 usize; // local
     let _13: bool; // anonymous local
     let _14: usize; // anonymous local
     let _15: usize; // anonymous local
     let kind: AssertKind; // local
     let _17: AssertKind; // anonymous local
-    let _18: &'22 usize; // anonymous local
-    let _19: &'23 usize; // anonymous local
-    let _20: &'24 usize; // anonymous local
-    let _21: &'25 usize; // anonymous local
-    let _22: Option<Arguments<'33>>[{built_in impl Sized for Arguments<'33>}]; // anonymous local
+    let _18: &'23 usize; // anonymous local
+    let _19: &'24 usize; // anonymous local
+    let _20: &'25 usize; // anonymous local
+    let _21: &'26 usize; // anonymous local
+    let _22: Option<Arguments<'35>>[{built_in impl Sized for Arguments<'35>}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -686,7 +686,7 @@ fn select<'_0, '_1>(lhs: &'_0 [u8], rhs: &'_1 [u8])
         storage_live(_6)
         storage_live(_7)
         _7 = &(*lhs) with_metadata(copy lhs.metadata)
-        _6 = core::slice::{[T]}::len<'38, u8>[{built_in impl Sized for u8}](move _7)
+        _6 = core::slice::{[T]}::len<'40, u8>[{built_in impl Sized for u8}](move _7)
         ↳⚡ storage_dead(_22)
             storage_dead(_21)
             storage_dead(_20)
@@ -703,7 +703,7 @@ fn select<'_0, '_1>(lhs: &'_0 [u8], rhs: &'_1 [u8])
         storage_live(_9)
         storage_live(_10)
         _10 = &(*rhs) with_metadata(copy rhs.metadata)
-        _9 = core::slice::{[T]}::len<'40, u8>[{built_in impl Sized for u8}](move _10)
+        _9 = core::slice::{[T]}::len<'42, u8>[{built_in impl Sized for u8}](move _10)
         ↳⚡ storage_dead(_22)
             storage_dead(_21)
             storage_dead(_20)

--- a/charon/tests/ui/iterator.out
+++ b/charon/tests/ui/iterator.out
@@ -5481,47 +5481,47 @@ fn main()
     let _15: &'7 [i32]; // anonymous local
     let _16: &'9 [i32; 7usize]; // anonymous local
     let iter_17: Iter<'10, i32>[{built_in impl Sized for i32}]; // local
-    let _18: Option<&'18 i32>[{built_in impl Sized for &'18 i32}]; // anonymous local
-    let _19: &'24 mut Iter<'25, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _20: &'26 mut Iter<'27, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let v_21: &'28 i32; // local
+    let _18: Option<&'19 i32>[{built_in impl Sized for &'19 i32}]; // anonymous local
+    let _19: &'25 mut Iter<'26, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _20: &'27 mut Iter<'28, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let v_21: &'29 i32; // local
     let _22: (); // anonymous local
-    let _23: &'30 mut i32; // anonymous local
-    let _24: &'31 i32; // anonymous local
-    let _25: Chunks<'33, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _26: Chunks<'34, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _27: &'35 [i32]; // anonymous local
-    let _28: &'36 [i32; 7usize]; // anonymous local
-    let iter_29: Chunks<'37, i32>[{built_in impl Sized for i32}]; // local
-    let _30: Option<&'44 [i32]>[{built_in impl Sized for &'44 [i32]}]; // anonymous local
-    let _31: &'50 mut Chunks<'51, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _32: &'52 mut Chunks<'53, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _23: &'31 mut i32; // anonymous local
+    let _24: &'32 i32; // anonymous local
+    let _25: Chunks<'34, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _26: Chunks<'35, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _27: &'36 [i32]; // anonymous local
+    let _28: &'37 [i32; 7usize]; // anonymous local
+    let iter_29: Chunks<'38, i32>[{built_in impl Sized for i32}]; // local
+    let _30: Option<&'46 [i32]>[{built_in impl Sized for &'46 [i32]}]; // anonymous local
+    let _31: &'52 mut Chunks<'53, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _32: &'54 mut Chunks<'55, i32>[{built_in impl Sized for i32}]; // anonymous local
     let _33: i32; // anonymous local
-    let _34: ChunksExact<'55, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _35: ChunksExact<'56, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _36: &'57 [i32]; // anonymous local
-    let _37: &'58 [i32; 7usize]; // anonymous local
-    let iter_38: ChunksExact<'59, i32>[{built_in impl Sized for i32}]; // local
-    let _39: Option<&'60 [i32]>[{built_in impl Sized for &'60 [i32]}]; // anonymous local
-    let _40: &'66 mut ChunksExact<'67, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _41: &'68 mut ChunksExact<'69, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _34: ChunksExact<'57, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _35: ChunksExact<'58, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _36: &'59 [i32]; // anonymous local
+    let _37: &'60 [i32; 7usize]; // anonymous local
+    let iter_38: ChunksExact<'61, i32>[{built_in impl Sized for i32}]; // local
+    let _39: Option<&'62 [i32]>[{built_in impl Sized for &'62 [i32]}]; // anonymous local
+    let _40: &'68 mut ChunksExact<'69, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _41: &'70 mut ChunksExact<'71, i32>[{built_in impl Sized for i32}]; // anonymous local
     let _42: i32; // anonymous local
     let expected: i32; // local
-    let _44: (&'77 i32, &'78 i32); // anonymous local
-    let _45: &'82 i32; // anonymous local
-    let _46: &'83 i32; // anonymous local
-    let left_val: &'84 i32; // local
-    let right_val: &'85 i32; // local
+    let _44: (&'80 i32, &'81 i32); // anonymous local
+    let _45: &'85 i32; // anonymous local
+    let _46: &'86 i32; // anonymous local
+    let left_val: &'87 i32; // local
+    let right_val: &'88 i32; // local
     let _49: bool; // anonymous local
     let _50: i32; // anonymous local
     let _51: i32; // anonymous local
     let kind: AssertKind; // local
     let _53: AssertKind; // anonymous local
-    let _54: &'86 i32; // anonymous local
-    let _55: &'87 i32; // anonymous local
-    let _56: &'88 i32; // anonymous local
-    let _57: &'89 i32; // anonymous local
-    let _58: Option<Arguments<'97>>[{built_in impl Sized for Arguments<'97>}]; // anonymous local
+    let _54: &'89 i32; // anonymous local
+    let _55: &'90 i32; // anonymous local
+    let _56: &'91 i32; // anonymous local
+    let _57: &'92 i32; // anonymous local
+    let _58: Option<Arguments<'101>>[{built_in impl Sized for Arguments<'101>}]; // anonymous local
 
     storage_live(_0)
     storage_live(_12)
@@ -5552,7 +5552,7 @@ fn main()
         unwind_continue
     storage_dead(_5)
     _3 = impl_IntoIterator_for_T::into_iter<IntoIter<i32, 7usize>[{built_in impl Sized for i32}]>[{built_in impl Sized for IntoIter<i32, 7usize>[{built_in impl Sized for i32}]}, impl_Iterator_for_IntoIter<i32, 7usize>[{built_in impl Sized for i32}]](move _4)
-    ↳⚡ conditional_drop[drop_glue<'101, i32, 7usize>[{built_in impl Sized for i32}]] _4
+    ↳⚡ conditional_drop[drop_glue<'105, i32, 7usize>[{built_in impl Sized for i32}]] _4
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5584,8 +5584,8 @@ fn main()
         storage_live(_9)
         _9 = &mut iter_6
         _8 = &two-phase-mut (*_9)
-        _7 = impl_Iterator_for_IntoIter::next<'103, i32, 7usize>[{built_in impl Sized for i32}](move _8)
-        ↳⚡ conditional_drop[drop_glue<'104, i32, 7usize>[{built_in impl Sized for i32}]] iter_6
+        _7 = impl_Iterator_for_IntoIter::next<'107, i32, 7usize>[{built_in impl Sized for i32}](move _8)
+        ↳⚡ conditional_drop[drop_glue<'108, i32, 7usize>[{built_in impl Sized for i32}]] iter_6
             ↳⚡ storage_dead(_58)
                 storage_dead(_57)
                 storage_dead(_56)
@@ -5597,7 +5597,7 @@ fn main()
                 storage_dead(_33)
                 storage_dead(_12)
                 unwind_terminate
-            conditional_drop[drop_glue<'105, i32, 7usize>[{built_in impl Sized for i32}]] _3
+            conditional_drop[drop_glue<'109, i32, 7usize>[{built_in impl Sized for i32}]] _3
             ↳⚡ storage_dead(_58)
                 storage_dead(_57)
                 storage_dead(_56)
@@ -5642,8 +5642,8 @@ fn main()
     }
     storage_dead(_9)
     storage_dead(_7)
-    conditional_drop[drop_glue<'106, i32, 7usize>[{built_in impl Sized for i32}]] iter_6
-    ↳⚡ conditional_drop[drop_glue<'105, i32, 7usize>[{built_in impl Sized for i32}]] _3
+    conditional_drop[drop_glue<'110, i32, 7usize>[{built_in impl Sized for i32}]] iter_6
+    ↳⚡ conditional_drop[drop_glue<'109, i32, 7usize>[{built_in impl Sized for i32}]] _3
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5667,7 +5667,7 @@ fn main()
         storage_dead(_12)
         unwind_continue
     storage_dead(iter_6)
-    conditional_drop[drop_glue<'107, i32, 7usize>[{built_in impl Sized for i32}]] _3
+    conditional_drop[drop_glue<'111, i32, 7usize>[{built_in impl Sized for i32}]] _3
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5688,7 +5688,7 @@ fn main()
     _15 = as_slice<'_, i32, 7usize>[{built_in impl Sized for i32}](move _16)
     ↳⚡ undefined_behavior
     storage_dead(_16)
-    _14 = iter<'110, i32>[{built_in impl Sized for i32}](move _15)
+    _14 = iter<'114, i32>[{built_in impl Sized for i32}](move _15)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5701,7 +5701,7 @@ fn main()
         storage_dead(_12)
         unwind_continue
     storage_dead(_15)
-    _13 = impl_IntoIterator_for_T::into_iter<Iter<'112, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Iter<'112, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_Iter<'112, i32>[{built_in impl Sized for i32}]](move _14)
+    _13 = impl_IntoIterator_for_T::into_iter<Iter<'116, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Iter<'116, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_Iter<'116, i32>[{built_in impl Sized for i32}]](move _14)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5722,7 +5722,7 @@ fn main()
         storage_live(_20)
         _20 = &mut iter_17
         _19 = &two-phase-mut (*_20)
-        _18 = impl_Iterator_for_Iter::next<'122, '124, i32>[{built_in impl Sized for i32}](move _19)
+        _18 = impl_Iterator_for_Iter::next<'127, '129, i32>[{built_in impl Sized for i32}](move _19)
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5749,7 +5749,7 @@ fn main()
         _23 = &two-phase-mut i
         storage_live(_24)
         _24 = copy v_21
-        _22 = add_assign<'130, '132>(move _23, move _24)
+        _22 = add_assign<'135, '137>(move _23, move _24)
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5781,7 +5781,7 @@ fn main()
     _27 = as_slice<'_, i32, 7usize>[{built_in impl Sized for i32}](move _28)
     ↳⚡ undefined_behavior
     storage_dead(_28)
-    _26 = chunks<'135, i32>[{built_in impl Sized for i32}](move _27, const 2usize)
+    _26 = chunks<'140, i32>[{built_in impl Sized for i32}](move _27, const 2usize)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5794,7 +5794,7 @@ fn main()
         storage_dead(_12)
         unwind_continue
     storage_dead(_27)
-    _25 = impl_IntoIterator_for_T::into_iter<Chunks<'137, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Chunks<'137, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_Chunks<'137, i32>[{built_in impl Sized for i32}]](move _26)
+    _25 = impl_IntoIterator_for_T::into_iter<Chunks<'142, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Chunks<'142, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_Chunks<'142, i32>[{built_in impl Sized for i32}]](move _26)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5815,7 +5815,7 @@ fn main()
         storage_live(_32)
         _32 = &mut iter_29
         _31 = &two-phase-mut (*_32)
-        _30 = impl_Iterator_for_Chunks::next<'147, '149, i32>[{built_in impl Sized for i32}](move _31)
+        _30 = impl_Iterator_for_Chunks::next<'153, '155, i32>[{built_in impl Sized for i32}](move _31)
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5853,7 +5853,7 @@ fn main()
     _36 = as_slice<'_, i32, 7usize>[{built_in impl Sized for i32}](move _37)
     ↳⚡ undefined_behavior
     storage_dead(_37)
-    _35 = chunks_exact<'152, i32>[{built_in impl Sized for i32}](move _36, const 2usize)
+    _35 = chunks_exact<'158, i32>[{built_in impl Sized for i32}](move _36, const 2usize)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5866,7 +5866,7 @@ fn main()
         storage_dead(_12)
         unwind_continue
     storage_dead(_36)
-    _34 = impl_IntoIterator_for_T::into_iter<ChunksExact<'154, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for ChunksExact<'154, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_ChunksExact<'154, i32>[{built_in impl Sized for i32}]](move _35)
+    _34 = impl_IntoIterator_for_T::into_iter<ChunksExact<'160, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for ChunksExact<'160, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_ChunksExact<'160, i32>[{built_in impl Sized for i32}]](move _35)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5887,7 +5887,7 @@ fn main()
         storage_live(_41)
         _41 = &mut iter_38
         _40 = &two-phase-mut (*_41)
-        _39 = impl_Iterator_for_ChunksExact::next<'164, '166, i32>[{built_in impl Sized for i32}](move _40)
+        _39 = impl_Iterator_for_ChunksExact::next<'171, '173, i32>[{built_in impl Sized for i32}](move _40)
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)

--- a/charon/tests/ui/ml-name-matcher-tests.out
+++ b/charon/tests/ui/ml-name-matcher-tests.out
@@ -636,7 +636,7 @@ fn mono_usage()
 {
     let _0: (); // return
     let _container1: MonoContainer<i32>[{built_in impl Sized for i32}]; // local
-    let _container2: MonoContainer<&'7 str>[{built_in impl Sized for &'7 str}]; // local
+    let _container2: MonoContainer<&'8 str>[{built_in impl Sized for &'8 str}]; // local
 
     storage_live(_0)
     _0 = ()
@@ -645,7 +645,7 @@ fn mono_usage()
     ↳⚡ unwind_continue
     fake_read(_container1)
     storage_live(_container2)
-    _container2 = create<&'12 str>[{built_in impl Sized for &'12 str}](const "test")
+    _container2 = create<&'13 str>[{built_in impl Sized for &'13 str}](const "test")
     ↳⚡ unwind_continue
     fake_read(_container2)
     _0 = ()

--- a/charon/tests/ui/ml-partial-mono-name-matcher-tests.out
+++ b/charon/tests/ui/ml-partial-mono-name-matcher-tests.out
@@ -126,17 +126,17 @@ where
     let x: A; // arg #1
     let _2: &'1 mut A; // anonymous local
     let _3: &'2 mut A; // anonymous local
-    let _4: Option<&'9 mut A>; // anonymous local
-    let _5: Option<&'13 mut A>; // anonymous local
-    let _6: &'17 mut A; // anonymous local
+    let _4: Option<&'10 mut A>; // anonymous local
+    let _5: Option<&'14 mut A>; // anonymous local
+    let _6: &'18 mut A; // anonymous local
 
     storage_live(_0)
     _0 = ()
     storage_live(_2)
     storage_live(_3)
     _3 = &mut x
-    _2 = test_crate::identity::<&_ mut _><'19, A>[{built_in impl core::marker::Sized::<&_ mut _><'19> for A}](move _3)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'25>] x
+    _2 = test_crate::identity::<&_ mut _><'20, A>[{built_in impl core::marker::Sized::<&_ mut _><'20> for A}](move _3)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'27>] x
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_3)
@@ -147,14 +147,14 @@ where
     _6 = &mut x
     _5 = Option::Some { _0: move _6 }
     storage_dead(_6)
-    _4 = test_crate::identity::<Option<&_ mut _>><'39, A>[{built_in impl core::marker::Sized::<Option<&_ mut _>><'39> for A}](move _5)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'25>] x
+    _4 = test_crate::identity::<Option<&_ mut _>><'43, A>[{built_in impl core::marker::Sized::<Option<&_ mut _>><'43> for A}](move _5)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'27>] x
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_5)
     storage_dead(_4)
     _0 = ()
-    conditional_drop[{built_in impl Destruct for A}::drop_glue<'69>] x
+    conditional_drop[{built_in impl Destruct for A}::drop_glue<'83>] x
     ↳⚡ unwind_continue
     return
 }

--- a/charon/tests/ui/monomorphization/issue-1159-assoc-const.out
+++ b/charon/tests/ui/monomorphization/issue-1159-assoc-const.out
@@ -148,13 +148,13 @@ const ARR: [u64; 1usize] = ARR()
 // Full name: test_crate::{impl MyConfig for Concrete}::SLICE_HOLDER
 pub fn {impl MyConfig for Concrete}::SLICE_HOLDER() -> Option<&'static [u64]>[{built_in impl Sized for &'static [u64]}]
 {
-    let _0: Option<&'6 [u64]>[{built_in impl Sized for &'6 [u64]}]; // return
-    let _1: &'10 [u64]; // anonymous local
-    let _2: &'12 [u64; 1usize]; // anonymous local
-    let _3: &'13 [u64; 1usize]; // anonymous local
-    let _4: &'14 [u64; 1usize]; // anonymous local
-    let _5: &'15 [u64; 1usize]; // anonymous local
-    let _6: &'23 [u64; 1usize]; // anonymous local
+    let _0: Option<&'8 [u64]>[{built_in impl Sized for &'8 [u64]}]; // return
+    let _1: &'12 [u64]; // anonymous local
+    let _2: &'14 [u64; 1usize]; // anonymous local
+    let _3: &'15 [u64; 1usize]; // anonymous local
+    let _4: &'16 [u64; 1usize]; // anonymous local
+    let _5: &'17 [u64; 1usize]; // anonymous local
+    let _6: &'26 [u64; 1usize]; // anonymous local
     let _7: [u64; 1usize]; // anonymous local
 
     storage_live(_5)
@@ -171,7 +171,7 @@ pub fn {impl MyConfig for Concrete}::SLICE_HOLDER() -> Option<&'static [u64]>[{b
     _4 = move _5
     _3 = &(*_4)
     _2 = &(*_3)
-    _1 = unsize_cast<&'12 [u64; 1usize], &'16 [u64], 1usize>(move _2)
+    _1 = unsize_cast<&'14 [u64; 1usize], &'18 [u64], 1usize>(move _2)
     storage_dead(_2)
     _0 = Option::Some { _0: move _1 }
     storage_dead(_1)

--- a/charon/tests/ui/monomorphize-mut-no-types.out
+++ b/charon/tests/ui/monomorphize-mut-no-types.out
@@ -167,17 +167,17 @@ where
     let _4: &'4 mut u32; // anonymous local
     let _5: &'5 mut u32; // anonymous local
     let _6: u32; // anonymous local
-    let _7: Option<&'12 mut u32>; // anonymous local
-    let _8: Option<&'16 mut u32>; // anonymous local
-    let _9: &'20 mut u32; // anonymous local
+    let _7: Option<&'13 mut u32>; // anonymous local
+    let _8: Option<&'17 mut u32>; // anonymous local
+    let _9: &'21 mut u32; // anonymous local
     let _10: u32; // anonymous local
-    let _11: Option<Option<&'58 mut A>>; // anonymous local
-    let _12: Option<Option<&'74 mut A>>; // anonymous local
-    let _13: Option<&'90 mut A>; // anonymous local
-    let _14: &'94 mut A; // anonymous local
-    let _15: &'95 u32; // anonymous local
-    let _16: &'96 u32; // anonymous local
-    let _17: &'367 u32; // anonymous local
+    let _11: Option<Option<&'70 mut A>>; // anonymous local
+    let _12: Option<Option<&'86 mut A>>; // anonymous local
+    let _13: Option<&'102 mut A>; // anonymous local
+    let _14: &'106 mut A; // anonymous local
+    let _15: &'107 u32; // anonymous local
+    let _16: &'108 u32; // anonymous local
+    let _17: &'485 u32; // anonymous local
     let _18: u32; // anonymous local
 
     storage_live(_16)
@@ -193,8 +193,8 @@ where
     storage_live(_3)
     _15 = move _16
     _3 = &(*_15)
-    _2 = identity<&'98 u32>[{built_in impl Sized for &'98 u32}](move _3)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'104>] x
+    _2 = identity<&'110 u32>[{built_in impl Sized for &'110 u32}](move _3)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'117>] x
         ↳⚡ storage_dead(_15)
             storage_dead(x)
             storage_dead(_18)
@@ -211,8 +211,8 @@ where
     storage_live(_6)
     _6 = const 0u32
     _5 = &mut _6
-    _4 = test_crate::identity::<&_ mut _><'106, u32>[{built_in impl core::marker::Sized::<&_ mut _><'106> for u32}](move _5)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'104>] x
+    _4 = test_crate::identity::<&_ mut _><'119, u32>[{built_in impl core::marker::Sized::<&_ mut _><'119> for u32}](move _5)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'117>] x
         ↳⚡ storage_dead(_15)
             storage_dead(x)
             storage_dead(_18)
@@ -233,8 +233,8 @@ where
     _9 = &mut _10
     _8 = Option::Some { _0: move _9 }
     storage_dead(_9)
-    _7 = test_crate::identity::<Option<&_ mut _>><'125, u32>[{built_in impl core::marker::Sized::<Option<&_ mut _>><'125> for u32}](move _8)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'104>] x
+    _7 = test_crate::identity::<Option<&_ mut _>><'141, u32>[{built_in impl core::marker::Sized::<Option<&_ mut _>><'141> for u32}](move _8)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'117>] x
         ↳⚡ storage_dead(_15)
             storage_dead(x)
             storage_dead(_18)
@@ -256,8 +256,8 @@ where
     storage_dead(_14)
     _12 = Option::Some { _0: move _13 }
     storage_dead(_13)
-    _11 = test_crate::identity::<Option<Option<&_ mut _>>><'228, A>[{built_in impl core::marker::Sized::<Option<Option<&_ mut _>>><'228> for A}](move _12)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'104>] x
+    _11 = test_crate::identity::<Option<Option<&_ mut _>>><'276, A>[{built_in impl core::marker::Sized::<Option<Option<&_ mut _>>><'276> for A}](move _12)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'117>] x
         ↳⚡ storage_dead(_15)
             storage_dead(x)
             storage_dead(_18)
@@ -270,7 +270,7 @@ where
     storage_dead(_12)
     storage_dead(_11)
     _0 = ()
-    conditional_drop[{built_in impl Destruct for A}::drop_glue<'366>] x
+    conditional_drop[{built_in impl Destruct for A}::drop_glue<'484>] x
     ↳⚡ storage_dead(_15)
         storage_dead(x)
         unwind_continue

--- a/charon/tests/ui/monomorphize-mut.out
+++ b/charon/tests/ui/monomorphize-mut.out
@@ -339,17 +339,17 @@ where
 {
     let _0: (); // return
     let x: A; // arg #1
-    let _2: core::option::Option::<&_ mut _><'7, u32>[{built_in impl core::marker::Sized::<&_ mut _><'7> for u32}]; // anonymous local
-    let _3: &'11 mut u32; // anonymous local
+    let _2: core::option::Option::<&_ mut _><'8, u32>[{built_in impl core::marker::Sized::<&_ mut _><'8> for u32}]; // anonymous local
+    let _3: &'12 mut u32; // anonymous local
     let _4: u32; // anonymous local
-    let _5: core::option::Option::<&_ mut _><'19, A>[{built_in impl core::marker::Sized::<&_ mut _><'19> for A}]; // anonymous local
-    let _6: &'23 mut A; // anonymous local
-    let _7: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'54, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'54>[{built_in impl core::marker::Sized::<&_ mut _><'54> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'54> for A}]; // anonymous local
-    let _8: core::option::Option::<&_ mut _><'70, A>[{built_in impl core::marker::Sized::<&_ mut _><'70> for A}]; // anonymous local
-    let _9: &'74 mut A; // anonymous local
-    let _10: core::option::Option::<&_ mut &_ mut _><'91, '92, u32>[{built_in impl core::marker::Sized::<&_ mut &_ mut _><'91, '92> for u32}]; // anonymous local
-    let _11: &'99 mut &'100 mut u32; // anonymous local
-    let _12: &'101 mut u32; // anonymous local
+    let _5: core::option::Option::<&_ mut _><'21, A>[{built_in impl core::marker::Sized::<&_ mut _><'21> for A}]; // anonymous local
+    let _6: &'25 mut A; // anonymous local
+    let _7: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'66, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'66>[{built_in impl core::marker::Sized::<&_ mut _><'66> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'66> for A}]; // anonymous local
+    let _8: core::option::Option::<&_ mut _><'82, A>[{built_in impl core::marker::Sized::<&_ mut _><'82> for A}]; // anonymous local
+    let _9: &'86 mut A; // anonymous local
+    let _10: core::option::Option::<&_ mut &_ mut _><'106, '107, u32>[{built_in impl core::marker::Sized::<&_ mut &_ mut _><'106, '107> for u32}]; // anonymous local
+    let _11: &'114 mut &'115 mut u32; // anonymous local
+    let _12: &'116 mut u32; // anonymous local
     let _13: u32; // anonymous local
 
     storage_live(_0)
@@ -391,7 +391,7 @@ where
     storage_dead(_13)
     storage_dead(_12)
     storage_dead(_4)
-    conditional_drop[{built_in impl Destruct for A}::drop_glue<'164>] x
+    conditional_drop[{built_in impl Destruct for A}::drop_glue<'195>] x
     ↳⚡ storage_dead(x)
         unwind_continue
     storage_dead(x)
@@ -560,24 +560,24 @@ where
     let _4: &'4 mut u32; // anonymous local
     let _5: &'5 mut u32; // anonymous local
     let _6: u32; // anonymous local
-    let _7: core::option::Option::<&_ mut _><'12, u32>[{built_in impl core::marker::Sized::<&_ mut _><'12> for u32}]; // anonymous local
-    let _8: core::option::Option::<&_ mut _><'16, u32>[{built_in impl core::marker::Sized::<&_ mut _><'16> for u32}]; // anonymous local
-    let _9: &'20 mut u32; // anonymous local
+    let _7: core::option::Option::<&_ mut _><'13, u32>[{built_in impl core::marker::Sized::<&_ mut _><'13> for u32}]; // anonymous local
+    let _8: core::option::Option::<&_ mut _><'17, u32>[{built_in impl core::marker::Sized::<&_ mut _><'17> for u32}]; // anonymous local
+    let _9: &'21 mut u32; // anonymous local
     let _10: u32; // anonymous local
-    let _11: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'58, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'58>[{built_in impl core::marker::Sized::<&_ mut _><'58> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'58> for A}]; // anonymous local
-    let _12: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'74, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'74>[{built_in impl core::marker::Sized::<&_ mut _><'74> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'74> for A}]; // anonymous local
-    let _13: core::option::Option::<&_ mut _><'90, A>[{built_in impl core::marker::Sized::<&_ mut _><'90> for A}]; // anonymous local
-    let _14: &'94 mut A; // anonymous local
-    let _15: Option<&'101 u32>[{built_in impl Sized for &'101 u32}]; // anonymous local
-    let _16: Option<&'105 u32>[{built_in impl Sized for &'105 u32}]; // anonymous local
-    let _17: &'109 u32; // anonymous local
-    let _18: &'110 u32; // anonymous local
-    let _19: &'111 u32; // anonymous local
-    let _20: &'112 u32; // anonymous local
-    let _21: &'382 u32; // anonymous local
-    let _22: &'489 u32; // anonymous local
+    let _11: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'70, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'70>[{built_in impl core::marker::Sized::<&_ mut _><'70> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'70> for A}]; // anonymous local
+    let _12: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'86, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'86>[{built_in impl core::marker::Sized::<&_ mut _><'86> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'86> for A}]; // anonymous local
+    let _13: core::option::Option::<&_ mut _><'102, A>[{built_in impl core::marker::Sized::<&_ mut _><'102> for A}]; // anonymous local
+    let _14: &'106 mut A; // anonymous local
+    let _15: Option<&'114 u32>[{built_in impl Sized for &'114 u32}]; // anonymous local
+    let _16: Option<&'118 u32>[{built_in impl Sized for &'118 u32}]; // anonymous local
+    let _17: &'122 u32; // anonymous local
+    let _18: &'123 u32; // anonymous local
+    let _19: &'124 u32; // anonymous local
+    let _20: &'125 u32; // anonymous local
+    let _21: &'501 u32; // anonymous local
+    let _22: &'627 u32; // anonymous local
     let _23: u32; // anonymous local
-    let _24: &'490 u32; // anonymous local
+    let _24: &'628 u32; // anonymous local
     let _25: u32; // anonymous local
 
     storage_live(_20)
@@ -594,13 +594,13 @@ where
     storage_live(_3)
     _19 = move _20
     _3 = &(*_19)
-    _2 = identity<&'114 u32>[{built_in impl Sized for &'114 u32}](move _3)
+    _2 = identity<&'127 u32>[{built_in impl Sized for &'127 u32}](move _3)
     ↳⚡ // Make sure we do generics right.
         // Use a function pointer.
         // These cause errors because of missing normalization :'(
         // let _ = Some(&mut 0u32).map(identity);
         // let _ = Some(&mut 0u32).map(mutable_identity);
-        conditional_drop[{built_in impl Destruct for A}::drop_glue<'120>] x
+        conditional_drop[{built_in impl Destruct for A}::drop_glue<'134>] x
         ↳⚡ storage_dead(_19)
             storage_dead(_18)
             storage_dead(x)
@@ -622,8 +622,8 @@ where
     storage_live(_6)
     _6 = const 0u32
     _5 = &mut _6
-    _4 = test_crate::identity::<&_ mut _><'122, u32>[{built_in impl core::marker::Sized::<&_ mut _><'122> for u32}](move _5)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'120>] x
+    _4 = test_crate::identity::<&_ mut _><'136, u32>[{built_in impl core::marker::Sized::<&_ mut _><'136> for u32}](move _5)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'134>] x
         ↳⚡ storage_dead(_19)
             storage_dead(_18)
             storage_dead(x)
@@ -649,8 +649,8 @@ where
     _9 = &mut _10
     _8 = core::option::Option::<&_ mut _>::Some { _0: move _9 }
     storage_dead(_9)
-    _7 = test_crate::identity::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'141, u32>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'141>[{built_in impl core::marker::Sized::<&_ mut _><'141> for u32}] for u32}, {built_in impl core::marker::Sized::<&_ mut _><'141> for u32}](move _8)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'120>] x
+    _7 = test_crate::identity::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'158, u32>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'158>[{built_in impl core::marker::Sized::<&_ mut _><'158> for u32}] for u32}, {built_in impl core::marker::Sized::<&_ mut _><'158> for u32}](move _8)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'134>] x
         ↳⚡ storage_dead(_19)
             storage_dead(_18)
             storage_dead(x)
@@ -677,8 +677,8 @@ where
     storage_dead(_14)
     _12 = core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]>::Some { _0: move _13 }
     storage_dead(_13)
-    _11 = test_crate::identity::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause1, TraitClause2]><'244, A>[{built_in impl core::marker::Sized::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause0, TraitClause1]><'244>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'244>[{built_in impl core::marker::Sized::<&_ mut _><'244> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'244> for A}] for A}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'244>[{built_in impl core::marker::Sized::<&_ mut _><'244> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'244> for A}](move _12)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'120>] x
+    _11 = test_crate::identity::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause1, TraitClause2]><'293, A>[{built_in impl core::marker::Sized::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause0, TraitClause1]><'293>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'293>[{built_in impl core::marker::Sized::<&_ mut _><'293> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'293> for A}] for A}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'293>[{built_in impl core::marker::Sized::<&_ mut _><'293> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'293> for A}](move _12)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'134>] x
         ↳⚡ storage_dead(_19)
             storage_dead(_18)
             storage_dead(x)
@@ -708,8 +708,8 @@ where
     _17 = &(*_18)
     _16 = Option::Some { _0: move _17 }
     storage_dead(_17)
-    _15 = map<&'390 u32, &'391 u32, identity<&'399 u32>[{built_in impl Sized for &'399 u32}]>[{built_in impl Sized for &'390 u32}, {built_in impl Sized for &'391 u32}, {built_in impl Sized for identity<&'420 u32>[{built_in impl Sized for &'420 u32}]}, {impl FnOnce<(T,)> for identity<T>[TraitClause0]}<&'390 u32>[{built_in impl Sized for &'390 u32}], {built_in impl Destruct for identity<&'466 u32>[{built_in impl Sized for &'466 u32}]}](move _16, const identity<&'482 u32>[{built_in impl Sized for &'482 u32}])
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'120>] x
+    _15 = map<&'510 u32, &'511 u32, identity<&'520 u32>[{built_in impl Sized for &'520 u32}]>[{built_in impl Sized for &'510 u32}, {built_in impl Sized for &'511 u32}, {built_in impl Sized for identity<&'544 u32>[{built_in impl Sized for &'544 u32}]}, {impl FnOnce<(T,)> for identity<T>[TraitClause0]}<&'510 u32>[{built_in impl Sized for &'510 u32}], {built_in impl Destruct for identity<&'602 u32>[{built_in impl Sized for &'602 u32}]}](move _16, const identity<&'619 u32>[{built_in impl Sized for &'619 u32}])
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'134>] x
         ↳⚡ storage_dead(_19)
             storage_dead(_18)
             storage_dead(x)
@@ -727,7 +727,7 @@ where
     storage_dead(_16)
     storage_dead(_15)
     _0 = ()
-    conditional_drop[{built_in impl Destruct for A}::drop_glue<'488>] x
+    conditional_drop[{built_in impl Destruct for A}::drop_glue<'626>] x
     ↳⚡ storage_dead(_19)
         storage_dead(_18)
         storage_dead(x)
@@ -793,7 +793,7 @@ where
 fn use_foo<'_0>(_1: test_crate::Foo3::<&_ mut _><'_0, u32>[{built_in impl core::marker::Sized::<&_ mut _><'_0> for u32}])
 {
     let _0: (); // return
-    let _1: test_crate::Foo3::<&_ mut _><'6, u32>[{built_in impl core::marker::Sized::<&_ mut _><'6> for u32}]; // arg #1
+    let _1: test_crate::Foo3::<&_ mut _><'8, u32>[{built_in impl core::marker::Sized::<&_ mut _><'8> for u32}]; // arg #1
 
     storage_live(_0)
     _0 = ()
@@ -839,7 +839,7 @@ where
     RegionOutlives0: 'b: 'a,
 {
     let _0: (); // return
-    let _1: test_crate::Triple::<_, &_ mut &_ mut _, core::option::Option::<&_ mut _><_, _>[TraitClause3]><'44, '45, '46, u32, T, bool>[{built_in impl Sized for u32}, {built_in impl core::marker::Sized::<&_ mut &_ mut _><'44, '45> for T}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'46>[{built_in impl core::marker::Sized::<&_ mut _><'46> for bool}] for bool}, {built_in impl core::marker::Sized::<&_ mut _><'46> for bool}]; // arg #1
+    let _1: test_crate::Triple::<_, &_ mut &_ mut _, core::option::Option::<&_ mut _><_, _>[TraitClause3]><'68, '69, '70, u32, T, bool>[{built_in impl Sized for u32}, {built_in impl core::marker::Sized::<&_ mut &_ mut _><'68, '69> for T}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'70>[{built_in impl core::marker::Sized::<&_ mut _><'70> for bool}] for bool}, {built_in impl core::marker::Sized::<&_ mut _><'70> for bool}]; // arg #1
 
     storage_live(_0)
     _0 = ()
@@ -888,7 +888,7 @@ where
     RegionOutlives0: '_1: '_0,
 {
     let _0: (); // return
-    let _1: &'11 test_crate::List::<&_ mut _><'12, u32>[{built_in impl core::marker::Sized::<&_ mut _><'12> for u32}]; // arg #1
+    let _1: &'13 test_crate::List::<&_ mut _><'14, u32>[{built_in impl core::marker::Sized::<&_ mut _><'14> for u32}]; // arg #1
 
     storage_live(_0)
     _0 = ()
@@ -913,7 +913,7 @@ where
     TypeOutlives0: bool: 'a,
 {
     let _0: (); // return
-    let _1: core::option::Option::<Iter<_, _>[TraitClause1]><'6, bool>[{built_in impl core::marker::Sized::<Iter<_, _>[TraitClause0]><'6>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}]; // arg #1
+    let _1: core::option::Option::<Iter<_, _>[TraitClause1]><'8, bool>[{built_in impl core::marker::Sized::<Iter<_, _>[TraitClause0]><'8>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}]; // arg #1
 
     storage_live(_0)
     _0 = ()
@@ -930,7 +930,7 @@ where
     TypeOutlives1: T: 'b,
 {
     let _0: (); // return
-    let _1: test_crate::Iter::<_, &_ mut _><'7, '8, T>[{built_in impl core::marker::Sized::<&_ mut _><'8> for T}]; // arg #1
+    let _1: test_crate::Iter::<_, &_ mut _><'9, '10, T>[{built_in impl core::marker::Sized::<&_ mut _><'10> for T}]; // arg #1
 
     storage_live(_0)
     _0 = ()
@@ -946,7 +946,7 @@ where
     TypeOutlives0: bool: 'a,
 {
     let _0: (); // return
-    let _1: core::option::Option::<IterWrapper<_, _>[TraitClause1]><'6, bool>[{built_in impl core::marker::Sized::<IterWrapper<_, _>[TraitClause0]><'6>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}]; // arg #1
+    let _1: core::option::Option::<IterWrapper<_, _>[TraitClause1]><'8, bool>[{built_in impl core::marker::Sized::<IterWrapper<_, _>[TraitClause0]><'8>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}]; // arg #1
 
     storage_live(_0)
     _0 = ()
@@ -981,8 +981,8 @@ where
 fn use_const_generic<'_0, '_1>(_1: test_crate::ArrayWrapper::<&_ mut _, 1usize><'_0, u32>[{built_in impl core::marker::Sized::<&_ mut _><'_0> for u32}], _2: test_crate::ArrayWrapper::<&_ mut _, 2usize><'_1, u32>[{built_in impl core::marker::Sized::<&_ mut _><'_1> for u32}])
 {
     let _0: (); // return
-    let _1: test_crate::ArrayWrapper::<&_ mut _, 1usize><'6, u32>[{built_in impl core::marker::Sized::<&_ mut _><'6> for u32}]; // arg #1
-    let _2: test_crate::ArrayWrapper::<&_ mut _, 2usize><'16, u32>[{built_in impl core::marker::Sized::<&_ mut _><'16> for u32}]; // arg #2
+    let _1: test_crate::ArrayWrapper::<&_ mut _, 1usize><'8, u32>[{built_in impl core::marker::Sized::<&_ mut _><'8> for u32}]; // arg #1
+    let _2: test_crate::ArrayWrapper::<&_ mut _, 2usize><'19, u32>[{built_in impl core::marker::Sized::<&_ mut _><'19> for u32}]; // arg #2
 
     storage_live(_0)
     _0 = ()

--- a/charon/tests/ui/multi-target/issue-1213-merge-methods-when-missing.out
+++ b/charon/tests/ui/multi-target/issue-1213-merge-methods-when-missing.out
@@ -229,9 +229,9 @@ fn test_crate::f<'_0>(blocks: &'_0 mut [u8])
     let _3: core::slice::iter::IterMut<'4, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
     let _4: &'5 mut [u8]; // anonymous local
     let iter: core::slice::iter::IterMut<'6, u8>[{built_in impl core::marker::Sized for u8}]; // local
-    let _6: core::option::Option<&'14 mut u8>[{built_in impl core::marker::Sized for &'14 mut u8}]; // anonymous local
-    let _7: &'20 mut core::slice::iter::IterMut<'21, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
-    let _8: &'22 mut core::slice::iter::IterMut<'23, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
+    let _6: core::option::Option<&'15 mut u8>[{built_in impl core::marker::Sized for &'15 mut u8}]; // anonymous local
+    let _7: &'21 mut core::slice::iter::IterMut<'22, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
+    let _8: &'23 mut core::slice::iter::IterMut<'24, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -239,11 +239,11 @@ fn test_crate::f<'_0>(blocks: &'_0 mut [u8])
     storage_live(_3)
     storage_live(_4)
     _4 = &two-phase-mut (*blocks) with_metadata(copy blocks.metadata)
-    _3 = core::slice::{[T]}::iter_mut<'25, u8>[{built_in impl core::marker::Sized for u8}](move _4)
+    _3 = core::slice::{[T]}::iter_mut<'26, u8>[{built_in impl core::marker::Sized for u8}](move _4)
     ↳⚡ storage_dead(blocks)
         unwind_continue
     storage_dead(_4)
-    _2 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::slice::iter::IterMut<'27, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::IterMut<'27, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}<'27, u8>[{built_in impl core::marker::Sized for u8}]](move _3)
+    _2 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::slice::iter::IterMut<'28, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::IterMut<'28, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}<'28, u8>[{built_in impl core::marker::Sized for u8}]](move _3)
     ↳⚡ storage_dead(blocks)
         unwind_continue
     storage_dead(_3)
@@ -255,7 +255,7 @@ fn test_crate::f<'_0>(blocks: &'_0 mut [u8])
         storage_live(_8)
         _8 = &mut iter
         _7 = &two-phase-mut (*_8)
-        _6 = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}::next<'37, '39, u8>[{built_in impl core::marker::Sized for u8}](move _7)
+        _6 = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}::next<'39, '41, u8>[{built_in impl core::marker::Sized for u8}](move _7)
         ↳⚡ storage_dead(blocks)
             unwind_continue
         storage_dead(_7)
@@ -284,16 +284,16 @@ fn test_crate::g<'_0, '_1>(s0: &'_0 [u8], s1: &'_1 [u8])
     let _0: (); // return
     let s0: &'1 [u8]; // arg #1
     let s1: &'2 [u8]; // arg #2
-    let _3: core::iter::adapters::zip::Zip<core::slice::iter::Iter<'16, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'17, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'16, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'17, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
-    let _4: core::iter::adapters::zip::Zip<core::slice::iter::Iter<'24, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'25, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'24, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'25, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
-    let _5: core::slice::iter::Iter<'32, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
-    let _6: &'33 [u8]; // anonymous local
-    let _7: core::slice::iter::Iter<'34, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
-    let _8: &'35 [u8]; // anonymous local
-    let iter: core::iter::adapters::zip::Zip<core::slice::iter::Iter<'36, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'37, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'36, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'37, u8>[{built_in impl core::marker::Sized for u8}]}]; // local
-    let _10: core::option::Option<(&'88 u8, &'89 u8)>[{built_in impl core::marker::Sized for (&'88 u8, &'89 u8)}]; // anonymous local
-    let _11: &'117 mut core::iter::adapters::zip::Zip<core::slice::iter::Iter<'118, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'119, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'118, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'119, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
-    let _12: &'126 mut core::iter::adapters::zip::Zip<core::slice::iter::Iter<'127, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'128, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'127, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'128, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
+    let _3: core::iter::adapters::zip::Zip<core::slice::iter::Iter<'18, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'19, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'18, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'19, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
+    let _4: core::iter::adapters::zip::Zip<core::slice::iter::Iter<'26, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'27, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'26, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'27, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
+    let _5: core::slice::iter::Iter<'34, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
+    let _6: &'35 [u8]; // anonymous local
+    let _7: core::slice::iter::Iter<'36, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
+    let _8: &'37 [u8]; // anonymous local
+    let iter: core::iter::adapters::zip::Zip<core::slice::iter::Iter<'38, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'39, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'38, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'39, u8>[{built_in impl core::marker::Sized for u8}]}]; // local
+    let _10: core::option::Option<(&'102 u8, &'103 u8)>[{built_in impl core::marker::Sized for (&'102 u8, &'103 u8)}]; // anonymous local
+    let _11: &'131 mut core::iter::adapters::zip::Zip<core::slice::iter::Iter<'132, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'133, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'132, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'133, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
+    let _12: &'140 mut core::iter::adapters::zip::Zip<core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'142, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'142, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -302,7 +302,7 @@ fn test_crate::g<'_0, '_1>(s0: &'_0 [u8], s1: &'_1 [u8])
     storage_live(_5)
     storage_live(_6)
     _6 = &(*s0) with_metadata(copy s0.metadata)
-    _5 = core::slice::{[T]}::iter<'136, u8>[{built_in impl core::marker::Sized for u8}](move _6)
+    _5 = core::slice::{[T]}::iter<'150, u8>[{built_in impl core::marker::Sized for u8}](move _6)
     ↳⚡ storage_dead(s1)
         storage_dead(s0)
         unwind_continue
@@ -310,18 +310,18 @@ fn test_crate::g<'_0, '_1>(s0: &'_0 [u8], s1: &'_1 [u8])
     storage_live(_7)
     storage_live(_8)
     _8 = &(*s1) with_metadata(copy s1.metadata)
-    _7 = core::slice::{[T]}::iter<'138, u8>[{built_in impl core::marker::Sized for u8}](move _8)
+    _7 = core::slice::{[T]}::iter<'152, u8>[{built_in impl core::marker::Sized for u8}](move _8)
     ↳⚡ storage_dead(s1)
         storage_dead(s0)
         unwind_continue
     storage_dead(_8)
-    _4 = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}::zip<'140, u8, core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for u8}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'140, u8>[{built_in impl core::marker::Sized for u8}]}, core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}<core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'141, u8>[{built_in impl core::marker::Sized for u8}]]](move _5, move _7)
+    _4 = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}::zip<'154, u8, core::slice::iter::Iter<'155, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for u8}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'155, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'154, u8>[{built_in impl core::marker::Sized for u8}]}, core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}<core::slice::iter::Iter<'155, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'155, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'155, u8>[{built_in impl core::marker::Sized for u8}]]](move _5, move _7)
     ↳⚡ storage_dead(s1)
         storage_dead(s0)
         unwind_continue
     storage_dead(_7)
     storage_dead(_5)
-    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::iter::adapters::zip::Zip<core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]}]>[{built_in impl core::marker::Sized for core::iter::adapters::zip::Zip<core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]}]}, core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}<core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'186, u8>[{built_in impl core::marker::Sized for u8}]]](move _4)
+    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::iter::adapters::zip::Zip<core::slice::iter::Iter<'202, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'205, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'202, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'205, u8>[{built_in impl core::marker::Sized for u8}]}]>[{built_in impl core::marker::Sized for core::iter::adapters::zip::Zip<core::slice::iter::Iter<'202, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'205, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'202, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'205, u8>[{built_in impl core::marker::Sized for u8}]}]}, core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}<core::slice::iter::Iter<'202, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'205, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'202, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'205, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'202, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'205, u8>[{built_in impl core::marker::Sized for u8}]]](move _4)
     ↳⚡ storage_dead(s1)
         storage_dead(s0)
         unwind_continue
@@ -334,7 +334,7 @@ fn test_crate::g<'_0, '_1>(s0: &'_0 [u8], s1: &'_1 [u8])
         storage_live(_12)
         _12 = &mut iter
         _11 = &two-phase-mut (*_12)
-        _10 = core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}::next<'304, core::slice::iter::Iter<'285, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'286, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'285, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'286, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'285, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'286, u8>[{built_in impl core::marker::Sized for u8}]](move _11)
+        _10 = core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}::next<'348, core::slice::iter::Iter<'327, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'328, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'327, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'328, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'327, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'328, u8>[{built_in impl core::marker::Sized for u8}]](move _11)
         ↳⚡ storage_dead(s1)
             storage_dead(s0)
             unwind_continue

--- a/charon/tests/ui/partial-monomorphization/issue-1204-partial-mono-tuples.out
+++ b/charon/tests/ui/partial-monomorphization/issue-1204-partial-mono-tuples.out
@@ -89,14 +89,14 @@ where
     TypeOutlives0: T: 'a,
     TypeOutlives1: U: 'a,
 {
-    let _0: (&'8 mut T, &'9 mut U); // return
-    let x: (&'13 mut T, &'14 mut U); // arg #1
-    let _2: (&'18 mut T, &'19 mut U); // anonymous local
+    let _0: (&'10 mut T, &'11 mut U); // return
+    let x: (&'15 mut T, &'16 mut U); // arg #1
+    let _2: (&'20 mut T, &'21 mut U); // anonymous local
 
     storage_live(_0)
     storage_live(_2)
     _2 = move x
-    _0 = test_crate::id::<(&_ mut _, &_ mut _)><'32, '33, T, U>[{built_in impl core::marker::Sized::<(&_ mut _, &_ mut _)><'32, '33, U> for T}](move _2)
+    _0 = test_crate::id::<(&_ mut _, &_ mut _)><'35, '36, T, U>[{built_in impl core::marker::Sized::<(&_ mut _, &_ mut _)><'35, '36, U> for T}](move _2)
     ↳⚡ storage_dead(x)
         unwind_continue
     storage_dead(_2)

--- a/charon/tests/ui/partial-monomorphization/mono-mut-tuple.out
+++ b/charon/tests/ui/partial-monomorphization/mono-mut-tuple.out
@@ -191,24 +191,24 @@ fn call<'a, T>(x: (&'a mut u32, T)) -> (&'a mut u32, T)
 where
     TraitClause0: (T: Sized),
 {
-    let _0: (&'6 mut u32, T); // return
-    let x: (&'10 mut u32, T); // arg #1
-    let _2: (&'14 mut u32, T); // anonymous local
+    let _0: (&'8 mut u32, T); // return
+    let x: (&'12 mut u32, T); // arg #1
+    let _2: (&'16 mut u32, T); // anonymous local
 
     storage_live(_0)
     storage_live(_2)
     _2 = move x
-    _0 = test_crate::id::<(&_ mut _, _)><'25, u32, T>[{built_in impl core::marker::Sized::<(&_ mut _, _)><'25, T>[{built_in impl core::marker::Sized::<&_ mut _><'25> for u32}] for u32}, {built_in impl core::marker::Sized::<&_ mut _><'25> for u32}](move _2)
-    ↳⚡ conditional_drop[(_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'72, '66, u32, T>[{built_in impl core::marker::Sized::<&_ mut _><'66> for u32}]] _2
+    _0 = test_crate::id::<(&_ mut _, _)><'28, u32, T>[{built_in impl core::marker::Sized::<(&_ mut _, _)><'28, T>[{built_in impl core::marker::Sized::<&_ mut _><'28> for u32}] for u32}, {built_in impl core::marker::Sized::<&_ mut _><'28> for u32}](move _2)
+    ↳⚡ conditional_drop[(_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'87, '80, u32, T>[{built_in impl core::marker::Sized::<&_ mut _><'80> for u32}]] _2
         ↳⚡ storage_dead(x)
             unwind_terminate
-        conditional_drop[(_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'108, '102, u32, T>[{built_in impl core::marker::Sized::<&_ mut _><'102> for u32}]] x
+        conditional_drop[(_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'127, '120, u32, T>[{built_in impl core::marker::Sized::<&_ mut _><'120> for u32}]] x
         ↳⚡ storage_dead(x)
             unwind_terminate
         storage_dead(x)
         unwind_continue
     storage_dead(_2)
-    conditional_drop[(_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'90, '84, u32, T>[{built_in impl core::marker::Sized::<&_ mut _><'84> for u32}]] x
+    conditional_drop[(_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'107, '100, u32, T>[{built_in impl core::marker::Sized::<&_ mut _><'100> for u32}]] x
     ↳⚡ storage_dead(x)
         unwind_continue
     storage_dead(x)

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -248,25 +248,25 @@ pub fn get_or_insert<'_0>(map: &'_0 mut HashMap<u32, u32, RandomState, Global>[{
 {
     let _0: &'1 u32; // return
     let map: &'3 mut HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]; // arg #1
-    let _2: Option<&'10 u32>[{built_in impl Sized for &'10 u32}]; // anonymous local
-    let _3: &'15 HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]; // anonymous local
-    let _4: &'16 u32; // anonymous local
-    let _5: &'17 u32; // anonymous local
-    let v: &'18 u32; // local
+    let _2: Option<&'11 u32>[{built_in impl Sized for &'11 u32}]; // anonymous local
+    let _3: &'16 HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]; // anonymous local
+    let _4: &'17 u32; // anonymous local
+    let _5: &'18 u32; // anonymous local
+    let v: &'19 u32; // local
     let _7: Option<u32>[{built_in impl Sized for u32}]; // anonymous local
-    let _8: &'19 mut HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]; // anonymous local
-    let _9: &'20 u32; // anonymous local
-    let _10: &'21 u32; // anonymous local
-    let _11: &'22 HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]; // anonymous local
-    let _12: &'23 u32; // anonymous local
-    let _13: &'24 u32; // anonymous local
-    let _14: &'25 u32; // anonymous local
-    let _15: &'26 u32; // anonymous local
-    let _16: &'27 u32; // anonymous local
-    let _17: &'34 u32; // anonymous local
-    let _18: &'43 u32; // anonymous local
+    let _8: &'20 mut HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]; // anonymous local
+    let _9: &'21 u32; // anonymous local
+    let _10: &'22 u32; // anonymous local
+    let _11: &'23 HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]; // anonymous local
+    let _12: &'24 u32; // anonymous local
+    let _13: &'25 u32; // anonymous local
+    let _14: &'26 u32; // anonymous local
+    let _15: &'27 u32; // anonymous local
+    let _16: &'28 u32; // anonymous local
+    let _17: &'35 u32; // anonymous local
+    let _18: &'44 u32; // anonymous local
     let _19: u32; // anonymous local
-    let _20: &'44 u32; // anonymous local
+    let _20: &'45 u32; // anonymous local
     let _21: u32; // anonymous local
 
     storage_live(_16)
@@ -286,7 +286,7 @@ pub fn get_or_insert<'_0>(map: &'_0 mut HashMap<u32, u32, RandomState, Global>[{
     _15 = move _16
     _5 = &(*_15)
     _4 = &(*_5)
-    _2 = std::collections::hash::map::{HashMap<K, V, S, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::get<'30, '31, u32, u32, RandomState, Global, u32>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}, impl_Eq_for_u32, impl_Hash_for_u32, impl_BuildHasher_for_RandomState, {built_in impl MetaSized for u32}, impl_Borrow_for_T<u32>[{built_in impl MetaSized for u32}], impl_Hash_for_u32, impl_Eq_for_u32](move _3, move _4)
+    _2 = std::collections::hash::map::{HashMap<K, V, S, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::get<'31, '32, u32, u32, RandomState, Global, u32>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}, impl_Eq_for_u32, impl_Hash_for_u32, impl_BuildHasher_for_RandomState, {built_in impl MetaSized for u32}, impl_Borrow_for_T<u32>[{built_in impl MetaSized for u32}], impl_Hash_for_u32, impl_Eq_for_u32](move _3, move _4)
     ↳⚡ storage_dead(_15)
         storage_dead(_14)
         storage_dead(map)
@@ -318,7 +318,7 @@ pub fn get_or_insert<'_0>(map: &'_0 mut HashMap<u32, u32, RandomState, Global>[{
     storage_live(_7)
     storage_live(_8)
     _8 = &two-phase-mut (*map)
-    _7 = insert<'33, u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}, impl_Eq_for_u32, impl_Hash_for_u32, impl_BuildHasher_for_RandomState](move _8, const 22u32, const 33u32)
+    _7 = insert<'34, u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}, impl_Eq_for_u32, impl_Hash_for_u32, impl_BuildHasher_for_RandomState](move _8, const 22u32, const 33u32)
     ↳⚡ storage_dead(_15)
         storage_dead(_14)
         storage_dead(map)
@@ -340,7 +340,7 @@ pub fn get_or_insert<'_0>(map: &'_0 mut HashMap<u32, u32, RandomState, Global>[{
     _14 = move _17
     _13 = &(*_14)
     _12 = &(*_13)
-    _10 = impl_Index_for_HashMap::index<'35, '37, u32, u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl MetaSized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}, impl_Eq_for_u32, impl_Hash_for_u32, impl_Borrow_for_T<u32>[{built_in impl MetaSized for u32}], impl_Eq_for_u32, impl_Hash_for_u32, impl_BuildHasher_for_RandomState](move _11, move _12)
+    _10 = impl_Index_for_HashMap::index<'36, '38, u32, u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl MetaSized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}, impl_Eq_for_u32, impl_Hash_for_u32, impl_Borrow_for_T<u32>[{built_in impl MetaSized for u32}], impl_Eq_for_u32, impl_Hash_for_u32, impl_BuildHasher_for_RandomState](move _11, move _12)
     ↳⚡ storage_dead(_15)
         storage_dead(_14)
         storage_dead(map)

--- a/charon/tests/ui/predicates-on-late-bound-vars.out
+++ b/charon/tests/ui/predicates-on-late-bound-vars.out
@@ -90,9 +90,9 @@ where
 // Full name: test_crate::wrap
 fn wrap<'a>(x: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'a u32}]
 {
-    let _0: Option<&'6 u32>[{built_in impl Sized for &'6 u32}]; // return
-    let x: &'10 u32; // arg #1
-    let _2: &'11 u32; // anonymous local
+    let _0: Option<&'8 u32>[{built_in impl Sized for &'8 u32}]; // return
+    let x: &'12 u32; // arg #1
+    let _2: &'13 u32; // anonymous local
 
     storage_live(_0)
     storage_live(_2)
@@ -108,9 +108,9 @@ fn wrap2<'a>(x: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'a u32}]
 where
     TraitClause0: (&'a (): Clone),
 {
-    let _0: Option<&'6 u32>[{built_in impl Sized for &'6 u32}]; // return
-    let x: &'10 u32; // arg #1
-    let _2: &'11 u32; // anonymous local
+    let _0: Option<&'8 u32>[{built_in impl Sized for &'8 u32}]; // return
+    let x: &'12 u32; // arg #1
+    let _2: &'13 u32; // anonymous local
 
     storage_live(_0)
     storage_live(_2)
@@ -126,8 +126,8 @@ fn foo()
 {
     let _0: (); // return
     let ref_b: RefCell<bool>[{built_in impl MetaSized for bool}]; // local
-    let _2: Result<Ref<'7, bool>[{built_in impl MetaSized for bool}], BorrowError>[{built_in impl Sized for Ref<'7, bool>[{built_in impl MetaSized for bool}]}, {built_in impl Sized for BorrowError}]; // anonymous local
-    let _3: &'12 RefCell<bool>[{built_in impl MetaSized for bool}]; // anonymous local
+    let _2: Result<Ref<'8, bool>[{built_in impl MetaSized for bool}], BorrowError>[{built_in impl Sized for Ref<'8, bool>[{built_in impl MetaSized for bool}]}, {built_in impl Sized for BorrowError}]; // anonymous local
+    let _3: &'13 RefCell<bool>[{built_in impl MetaSized for bool}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -139,10 +139,10 @@ fn foo()
     storage_live(_3)
     // `try_borrow` has a type that includes predicates on late bound regions.
     _3 = &ref_b
-    _2 = try_borrow<'14, bool>[{built_in impl MetaSized for bool}](move _3)
+    _2 = try_borrow<'15, bool>[{built_in impl MetaSized for bool}](move _3)
     ↳⚡ unwind_continue
     storage_dead(_3)
-    conditional_drop[drop_glue<'32, Ref<'26, bool>[{built_in impl MetaSized for bool}], BorrowError>[{built_in impl Sized for Ref<'26, bool>[{built_in impl MetaSized for bool}]}, {built_in impl Sized for BorrowError}]] _2
+    conditional_drop[drop_glue<'35, Ref<'28, bool>[{built_in impl MetaSized for bool}], BorrowError>[{built_in impl Sized for Ref<'28, bool>[{built_in impl MetaSized for bool}]}, {built_in impl Sized for BorrowError}]] _2
     ↳⚡ unwind_continue
     storage_dead(_2)
     _0 = ()

--- a/charon/tests/ui/quantified-clause.out
+++ b/charon/tests/ui/quantified-clause.out
@@ -180,8 +180,8 @@ where
 // Full name: test_crate::f
 pub fn f<'a>(_1: &'a ()) -> Option<(&'a u8,)>[{built_in impl Sized for (&'a u8,)}]
 {
-    let _0: Option<(&'8 u8,)>[{built_in impl Sized for (&'8 u8,)}]; // return
-    let _1: &'13 (); // arg #1
+    let _0: Option<(&'12 u8,)>[{built_in impl Sized for (&'12 u8,)}]; // return
+    let _1: &'17 (); // arg #1
 
     storage_live(_0)
     _0 = Option::None {  }

--- a/charon/tests/ui/regressions/issue-1073-out-of-bounds-body-region.out
+++ b/charon/tests/ui/regressions/issue-1073-out-of-bounds-body-region.out
@@ -33,16 +33,16 @@ where
     RegionOutlives1: '_2: '_1,
 {
     let _0: (); // return
-    let bufs: &'17 mut &'18 mut [IoSlice<'19>]; // arg #1
+    let bufs: &'19 mut &'20 mut [IoSlice<'21>]; // arg #1
     let _2: (); // anonymous local
-    let _3: &'23 mut &'24 mut [IoSlice<'25>]; // anonymous local
+    let _3: &'25 mut &'26 mut [IoSlice<'27>]; // anonymous local
 
     storage_live(_0)
     _0 = ()
     storage_live(_2)
     storage_live(_3)
     _3 = &two-phase-mut (*bufs)
-    _2 = advance_slices<'34, '37, '38>(move _3, const 0usize)
+    _2 = advance_slices<'36, '39, '40>(move _3, const 0usize)
     ↳⚡ storage_dead(bufs)
         unwind_continue
     storage_dead(_3)

--- a/charon/tests/ui/rust-name-matcher-tests.out
+++ b/charon/tests/ui/rust-name-matcher-tests.out
@@ -246,9 +246,9 @@ fn use_generic()
 {
     let _0: (); // return
     let _int_generic: Generic<i32>[{built_in impl Sized for i32}]; // local
-    let _str_generic: Generic<&'7 str>[{built_in impl Sized for &'7 str}]; // local
-    let _3: &'12 i32; // anonymous local
-    let _4: &'14 Generic<i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _str_generic: Generic<&'8 str>[{built_in impl Sized for &'8 str}]; // local
+    let _3: &'13 i32; // anonymous local
+    let _4: &'15 Generic<i32>[{built_in impl Sized for i32}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -257,13 +257,13 @@ fn use_generic()
     ↳⚡ unwind_continue
     fake_read(_int_generic)
     storage_live(_str_generic)
-    _str_generic = new<&'16 str>[{built_in impl Sized for &'16 str}](const "hello")
+    _str_generic = new<&'17 str>[{built_in impl Sized for &'17 str}](const "hello")
     ↳⚡ unwind_continue
     fake_read(_str_generic)
     storage_live(_3)
     storage_live(_4)
     _4 = &_int_generic
-    _3 = test_crate::{Generic<T>[TraitClause0]}::get<'24, i32>[{built_in impl Sized for i32}](move _4)
+    _3 = test_crate::{Generic<T>[TraitClause0]}::get<'26, i32>[{built_in impl Sized for i32}](move _4)
     ↳⚡ unwind_continue
     storage_dead(_4)
     storage_dead(_3)

--- a/charon/tests/ui/simple/catch-unwind.out
+++ b/charon/tests/ui/simple/catch-unwind.out
@@ -139,7 +139,7 @@ impl "impl_FnOnce_unit_for_closure" FnOnce<()> for {closure} {
 fn main()
 {
     let _0: (); // return
-    let _1: Result<(), Box<(dyn Any + Send + '27)>[{built_in impl MetaSized for (dyn Any + Send + '29)}, {built_in impl Sized for Global}]>[{built_in impl Sized for ()}, {built_in impl Sized for Box<(dyn Any + Send + '36)>[{built_in impl MetaSized for (dyn Any + Send + '38)}, {built_in impl Sized for Global}]}]; // anonymous local
+    let _1: Result<(), Box<(dyn Any + Send + '36)>[{built_in impl MetaSized for (dyn Any + Send + '38)}, {built_in impl Sized for Global}]>[{built_in impl Sized for ()}, {built_in impl Sized for Box<(dyn Any + Send + '45)>[{built_in impl MetaSized for (dyn Any + Send + '47)}, {built_in impl Sized for Global}]}]; // anonymous local
     let _2: {closure}; // anonymous local
 
     storage_live(_0)
@@ -150,7 +150,7 @@ fn main()
     _1 = catch_unwind<{closure}, ()>[{built_in impl Sized for {closure}}, {built_in impl Sized for ()}, impl_FnOnce_unit_for_closure, {built_in impl UnwindSafe for {closure}}](move _2)
     ↳⚡ unwind_continue
     storage_dead(_2)
-    conditional_drop[drop_glue<'100, (), Box<(dyn Any + Send + '78)>[{built_in impl MetaSized for (dyn Any + Send + '80)}, {built_in impl Sized for Global}]>[{built_in impl Sized for ()}, {built_in impl Sized for Box<(dyn Any + Send + '78)>[{built_in impl MetaSized for (dyn Any + Send + '80)}, {built_in impl Sized for Global}]}]] _1
+    conditional_drop[drop_glue<'126, (), Box<(dyn Any + Send + '96)>[{built_in impl MetaSized for (dyn Any + Send + '98)}, {built_in impl Sized for Global}]>[{built_in impl Sized for ()}, {built_in impl Sized for Box<(dyn Any + Send + '96)>[{built_in impl MetaSized for (dyn Any + Send + '98)}, {built_in impl Sized for Global}]}]] _1
     ↳⚡ unwind_continue
     storage_dead(_1)
     _0 = ()

--- a/charon/tests/ui/simple/closure-fn.out
+++ b/charon/tests/ui/simple/closure-fn.out
@@ -393,7 +393,7 @@ fn main()
     storage_live(_11)
     _11 = &f
     _10 = &(*_11)
-    _9 = apply_to<'62, {closure}<'43, '44>>[{built_in impl Sized for {closure}<'43, '44>}, impl_Fn_tuple_for_closure<'43, '44>](move _10)
+    _9 = apply_to<'64, {closure}<'43, '44>>[{built_in impl Sized for {closure}<'43, '44>}, impl_Fn_tuple_for_closure<'43, '44>](move _10)
     ↳⚡ unwind_continue
     storage_dead(_10)
     storage_dead(_11)
@@ -403,7 +403,7 @@ fn main()
     storage_live(_14)
     _14 = &mut f
     _13 = &two-phase-mut (*_14)
-    _12 = apply_to_mut<'86, {closure}<'67, '68>>[{built_in impl Sized for {closure}<'67, '68>}, impl_FnMut_tuple_for_closure<'67, '68>](move _13)
+    _12 = apply_to_mut<'90, {closure}<'69, '70>>[{built_in impl Sized for {closure}<'69, '70>}, impl_FnMut_tuple_for_closure<'69, '70>](move _13)
     ↳⚡ unwind_continue
     storage_dead(_13)
     storage_dead(_14)
@@ -411,7 +411,7 @@ fn main()
     storage_live(_15)
     storage_live(_16)
     _16 = copy f
-    _15 = apply_to_once<{closure}<'89, '90>>[{built_in impl Sized for {closure}<'89, '90>}, impl_FnOnce_tuple_for_closure<'89, '90>](move _16)
+    _15 = apply_to_once<{closure}<'93, '94>>[{built_in impl Sized for {closure}<'93, '94>}, impl_FnOnce_tuple_for_closure<'93, '94>](move _16)
     ↳⚡ unwind_continue
     storage_dead(_16)
     storage_dead(_15)

--- a/charon/tests/ui/simple/lending-iterator-gat.out
+++ b/charon/tests/ui/simple/lending-iterator-gat.out
@@ -140,12 +140,12 @@ where
     TypeOutlives1: T: '_1,
     RegionOutlives0: 'a: '_1,
 {
-    let _0: Option<&'6 T>[{built_in impl Sized for &'6 T}]; // return
-    let self: &'15 mut Option<&'16 T>[{built_in impl Sized for &'16 T}]; // arg #1
-    let item_2: &'22 mut &'23 T; // local
-    let item_3: &'24 T; // local
-    let _4: Option<&'25 T>[{built_in impl Sized for &'25 T}]; // anonymous local
-    let _5: &'29 T; // anonymous local
+    let _0: Option<&'8 T>[{built_in impl Sized for &'8 T}]; // return
+    let self: &'17 mut Option<&'18 T>[{built_in impl Sized for &'18 T}]; // arg #1
+    let item_2: &'24 mut &'25 T; // local
+    let item_3: &'26 T; // local
+    let _4: Option<&'27 T>[{built_in impl Sized for &'27 T}]; // anonymous local
+    let _5: &'31 T; // anonymous local
 
     storage_live(_0)
     match (*self) {
@@ -497,35 +497,35 @@ pub fn main()
 {
     let _0: (); // return
     let x: i32; // local
-    let iter: Option<&'7 i32>[{built_in impl Sized for &'7 i32}]; // local
-    let _3: &'11 i32; // anonymous local
+    let iter: Option<&'8 i32>[{built_in impl Sized for &'8 i32}]; // local
+    let _3: &'12 i32; // anonymous local
     let sum: i32; // local
     let _5: (); // anonymous local
-    let _6: Option<&'12 i32>[{built_in impl Sized for &'12 i32}]; // anonymous local
-    let _7: {closure}<'17>; // anonymous local
-    let _8: &'19 mut i32; // anonymous local
-    let _9: (&'27 i32, &'28 i32); // anonymous local
-    let _10: &'32 i32; // anonymous local
-    let _11: &'33 i32; // anonymous local
-    let left_val: &'34 i32; // local
-    let right_val: &'35 i32; // local
+    let _6: Option<&'13 i32>[{built_in impl Sized for &'13 i32}]; // anonymous local
+    let _7: {closure}<'18>; // anonymous local
+    let _8: &'20 mut i32; // anonymous local
+    let _9: (&'29 i32, &'30 i32); // anonymous local
+    let _10: &'34 i32; // anonymous local
+    let _11: &'35 i32; // anonymous local
+    let left_val: &'36 i32; // local
+    let right_val: &'37 i32; // local
     let _14: bool; // anonymous local
     let _15: i32; // anonymous local
     let _16: i32; // anonymous local
     let kind: AssertKind; // local
     let _18: AssertKind; // anonymous local
-    let _19: &'36 i32; // anonymous local
-    let _20: &'37 i32; // anonymous local
-    let _21: &'38 i32; // anonymous local
-    let _22: &'39 i32; // anonymous local
-    let _23: Option<Arguments<'47>>[{built_in impl Sized for Arguments<'47>}]; // anonymous local
-    let _24: &'51 i32; // anonymous local
-    let _25: &'52 i32; // anonymous local
-    let _26: &'53 i32; // anonymous local
-    let _27: &'121 i32; // anonymous local
-    let _28: &'135 i32; // anonymous local
+    let _19: &'38 i32; // anonymous local
+    let _20: &'39 i32; // anonymous local
+    let _21: &'40 i32; // anonymous local
+    let _22: &'41 i32; // anonymous local
+    let _23: Option<Arguments<'50>>[{built_in impl Sized for Arguments<'50>}]; // anonymous local
+    let _24: &'54 i32; // anonymous local
+    let _25: &'55 i32; // anonymous local
+    let _26: &'56 i32; // anonymous local
+    let _27: &'138 i32; // anonymous local
+    let _28: &'153 i32; // anonymous local
     let _29: i32; // anonymous local
-    let _30: &'136 i32; // anonymous local
+    let _30: &'154 i32; // anonymous local
     let _31: i32; // anonymous local
 
     storage_live(_26)
@@ -559,7 +559,7 @@ pub fn main()
     _8 = &mut sum
     _7 = {closure} { _0: move _8 }
     storage_dead(_8)
-    _5 = for_each<Option<&'71 i32>[{built_in impl Sized for &'71 i32}], {closure}<'73>>[{built_in impl Sized for Option<&'71 i32>[{built_in impl Sized for &'71 i32}]}, {built_in impl Sized for {closure}<'73>}, impl_LendingIterator_for_Option<'71, i32>[{built_in impl Sized for i32}], impl_FnMut_tuple_for_closure<'73, '120>](move _6, move _7)
+    _5 = for_each<Option<&'76 i32>[{built_in impl Sized for &'76 i32}], {closure}<'78>>[{built_in impl Sized for Option<&'76 i32>[{built_in impl Sized for &'76 i32}]}, {built_in impl Sized for {closure}<'78>}, impl_LendingIterator_for_Option<'76, i32>[{built_in impl Sized for i32}], impl_FnMut_tuple_for_closure<'78, '137>](move _6, move _7)
     ↳⚡ storage_dead(_25)
         storage_dead(_24)
         storage_dead(_23)

--- a/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
+++ b/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
@@ -196,7 +196,7 @@ pub fn flibidi()
     storage_live(_0)
     _0 = ()
     storage_live(_1)
-    _1 = test_crate::call<'0, for<'a> flabada<'a>>[{built_in impl Sized for for<'a> flabada<'a>}, {impl Fn<(&'a (),), &'a ()> for for<'a> flabada<'a>}<'0>](const flabada<'11>)
+    _1 = test_crate::call<'0, for<'a> flabada<'a>>[{built_in impl Sized for for<'a> flabada<'a>}, {impl Fn<(&'a (),), &'a ()> for for<'a> flabada<'a>}<'0>](const flabada<'12>)
     ↳⚡ unwind_continue
     storage_dead(_1)
     _0 = ()

--- a/charon/tests/ui/simple/slice_index_range.out
+++ b/charon/tests/ui/simple/slice_index_range.out
@@ -17,22 +17,22 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     let start: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 57usize]; // anonymous local
-    let _13: &'34 [u8; 57usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 57usize]; // anonymous local
+    let _13: &'36 [u8; 57usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 57usize]; // anonymous local
-    let _19: &'66 [u8; 57usize]; // anonymous local
+    let _19: &'68 [u8; 57usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -51,7 +51,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -65,7 +65,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -90,7 +90,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = core::fmt::{Arguments<'a>}::new<'71, 57usize, 2usize>(move _12, move _14)
+    _3 = core::fmt::{Arguments<'a>}::new<'73, 57usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -122,22 +122,22 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     let end: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 55usize]; // anonymous local
-    let _13: &'34 [u8; 55usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 55usize]; // anonymous local
+    let _13: &'36 [u8; 55usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 55usize]; // anonymous local
-    let _19: &'66 [u8; 55usize]; // anonymous local
+    let _19: &'68 [u8; 55usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -156,7 +156,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -170,7 +170,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -195,7 +195,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = core::fmt::{Arguments<'a>}::new<'71, 55usize, 2usize>(move _12, move _14)
+    _3 = core::fmt::{Arguments<'a>}::new<'73, 55usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -227,22 +227,22 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     let start: usize; // arg #1
     let end: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 40usize]; // anonymous local
-    let _13: &'34 [u8; 40usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 40usize]; // anonymous local
+    let _13: &'36 [u8; 40usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 40usize]; // anonymous local
-    let _19: &'66 [u8; 40usize]; // anonymous local
+    let _19: &'68 [u8; 40usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -261,7 +261,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -275,7 +275,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -300,7 +300,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = core::fmt::{Arguments<'a>}::new<'71, 40usize, 2usize>(move _12, move _14)
+    _3 = core::fmt::{Arguments<'a>}::new<'73, 40usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -332,22 +332,22 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     let end: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 55usize]; // anonymous local
-    let _13: &'34 [u8; 55usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 55usize]; // anonymous local
+    let _13: &'36 [u8; 55usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 55usize]; // anonymous local
-    let _19: &'66 [u8; 55usize]; // anonymous local
+    let _19: &'68 [u8; 55usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -366,7 +366,7 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -380,7 +380,7 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -405,7 +405,7 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = core::fmt::{Arguments<'a>}::new<'71, 55usize, 2usize>(move _12, move _14)
+    _3 = core::fmt::{Arguments<'a>}::new<'73, 55usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -884,9 +884,9 @@ where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_0,
 {
-    let _0: Option<&'6 [T]>[{built_in impl Sized for &'6 [T]}]; // return
+    let _0: Option<&'8 [T]>[{built_in impl Sized for &'8 [T]}]; // return
     let self: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice: &'10 [T]; // arg #2
+    let slice: &'12 [T]; // arg #2
     let _3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _4: usize; // anonymous local
     let _5: usize; // anonymous local
@@ -894,9 +894,9 @@ where
     let _7: bool; // anonymous local
     let _8: usize; // anonymous local
     let _9: usize; // anonymous local
-    let _10: &'11 [T]; // anonymous local
-    let _11: &'12 [T]; // anonymous local
-    let _12: &'13 [T]; // anonymous local
+    let _10: &'13 [T]; // anonymous local
+    let _11: &'14 [T]; // anonymous local
+    let _12: &'15 [T]; // anonymous local
     let _13: *const [T]; // anonymous local
     let _14: *const [T]; // anonymous local
     let _15: usize; // anonymous local
@@ -924,7 +924,7 @@ where
             storage_live(_9)
             storage_live(_10)
             _10 = &(*slice) with_metadata(copy slice.metadata)
-            _9 = core::slice::{[T]}::len<'15, T>[TraitClause0](move _10)
+            _9 = core::slice::{[T]}::len<'17, T>[TraitClause0](move _10)
             ↳⚡ storage_dead(slice)
                 storage_dead(self)
                 unwind_continue
@@ -984,9 +984,9 @@ where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_0,
 {
-    let _0: Option<&'6 mut [T]>[{built_in impl Sized for &'6 mut [T]}]; // return
+    let _0: Option<&'8 mut [T]>[{built_in impl Sized for &'8 mut [T]}]; // return
     let self: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice: &'10 mut [T]; // arg #2
+    let slice: &'12 mut [T]; // arg #2
     let _3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _4: usize; // anonymous local
     let _5: usize; // anonymous local
@@ -994,9 +994,9 @@ where
     let _7: bool; // anonymous local
     let _8: usize; // anonymous local
     let _9: usize; // anonymous local
-    let _10: &'12 [T]; // anonymous local
-    let _11: &'13 mut [T]; // anonymous local
-    let _12: &'14 mut [T]; // anonymous local
+    let _10: &'14 [T]; // anonymous local
+    let _11: &'15 mut [T]; // anonymous local
+    let _12: &'16 mut [T]; // anonymous local
     let _13: *mut [T]; // anonymous local
     let _14: *mut [T]; // anonymous local
     let _15: usize; // anonymous local
@@ -1024,7 +1024,7 @@ where
             storage_live(_9)
             storage_live(_10)
             _10 = &(*slice) with_metadata(copy slice.metadata)
-            _9 = core::slice::{[T]}::len<'16, T>[TraitClause0](move _10)
+            _9 = core::slice::{[T]}::len<'18, T>[TraitClause0](move _10)
             ↳⚡ storage_dead(slice)
                 storage_dead(self)
                 unwind_continue
@@ -1830,18 +1830,18 @@ where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_0,
 {
-    let _0: Option<&'6 mut [T]>[{built_in impl Sized for &'6 mut [T]}]; // return
+    let _0: Option<&'8 mut [T]>[{built_in impl Sized for &'8 mut [T]}]; // return
     let self: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice: &'10 mut [T]; // arg #2
+    let slice: &'12 mut [T]; // arg #2
     let _3: bool; // anonymous local
     let _4: usize; // anonymous local
-    let _5: &'12 usize; // anonymous local
-    let _6: &'14 RangeInclusive<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _5: &'14 usize; // anonymous local
+    let _6: &'16 RangeInclusive<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _7: usize; // anonymous local
-    let _8: &'16 [T]; // anonymous local
+    let _8: &'18 [T]; // anonymous local
     let _9: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _10: RangeInclusive<usize>[{built_in impl Sized for usize}]; // anonymous local
-    let _11: &'17 mut [T]; // anonymous local
+    let _11: &'19 mut [T]; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
@@ -1849,7 +1849,7 @@ where
     storage_live(_5)
     storage_live(_6)
     _6 = &self
-    _5 = end<'19, usize>[{built_in impl Sized for usize}](move _6)
+    _5 = end<'21, usize>[{built_in impl Sized for usize}](move _6)
     ↳⚡ storage_dead(slice)
         storage_dead(self)
         unwind_continue
@@ -1858,7 +1858,7 @@ where
     storage_live(_7)
     storage_live(_8)
     _8 = &(*slice) with_metadata(copy slice.metadata)
-    _7 = core::slice::{[T]}::len<'21, T>[TraitClause0](move _8)
+    _7 = core::slice::{[T]}::len<'23, T>[TraitClause0](move _8)
     ↳⚡ storage_dead(slice)
         storage_dead(self)
         unwind_continue
@@ -1879,7 +1879,7 @@ where
         storage_dead(_10)
         storage_live(_11)
         _11 = &two-phase-mut (*slice) with_metadata(copy slice.metadata)
-        _0 = impl_SliceIndex_slice_for_Range_usize::get_mut<'29, T>[TraitClause0](move _9, move _11)
+        _0 = impl_SliceIndex_slice_for_Range_usize::get_mut<'32, T>[TraitClause0](move _9, move _11)
         ↳⚡ storage_dead(slice)
             storage_dead(self)
             unwind_continue
@@ -1906,18 +1906,18 @@ where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_0,
 {
-    let _0: Option<&'6 [T]>[{built_in impl Sized for &'6 [T]}]; // return
+    let _0: Option<&'8 [T]>[{built_in impl Sized for &'8 [T]}]; // return
     let self: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice: &'10 [T]; // arg #2
+    let slice: &'12 [T]; // arg #2
     let _3: bool; // anonymous local
     let _4: usize; // anonymous local
-    let _5: &'12 usize; // anonymous local
-    let _6: &'14 RangeInclusive<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _5: &'14 usize; // anonymous local
+    let _6: &'16 RangeInclusive<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _7: usize; // anonymous local
-    let _8: &'15 [T]; // anonymous local
+    let _8: &'17 [T]; // anonymous local
     let _9: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _10: RangeInclusive<usize>[{built_in impl Sized for usize}]; // anonymous local
-    let _11: &'16 [T]; // anonymous local
+    let _11: &'18 [T]; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
@@ -1925,7 +1925,7 @@ where
     storage_live(_5)
     storage_live(_6)
     _6 = &self
-    _5 = end<'18, usize>[{built_in impl Sized for usize}](move _6)
+    _5 = end<'20, usize>[{built_in impl Sized for usize}](move _6)
     ↳⚡ storage_dead(slice)
         storage_dead(self)
         unwind_continue
@@ -1934,7 +1934,7 @@ where
     storage_live(_7)
     storage_live(_8)
     _8 = &(*slice) with_metadata(copy slice.metadata)
-    _7 = core::slice::{[T]}::len<'20, T>[TraitClause0](move _8)
+    _7 = core::slice::{[T]}::len<'22, T>[TraitClause0](move _8)
     ↳⚡ storage_dead(slice)
         storage_dead(self)
         unwind_continue
@@ -1955,7 +1955,7 @@ where
         storage_dead(_10)
         storage_live(_11)
         _11 = &(*slice) with_metadata(copy slice.metadata)
-        _0 = impl_SliceIndex_slice_for_Range_usize::get<'28, T>[TraitClause0](move _9, move _11)
+        _0 = impl_SliceIndex_slice_for_Range_usize::get<'31, T>[TraitClause0](move _9, move _11)
         ↳⚡ storage_dead(slice)
             storage_dead(self)
             unwind_continue

--- a/charon/tests/ui/simple/thread-local.out
+++ b/charon/tests/ui/simple/thread-local.out
@@ -345,8 +345,8 @@ fn {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{bui
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_mut<'_0, '22>(move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::FOO::{const}::{closure}}::drop_glue<'23>] _1
+    _0 = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_mut<'_0, '23>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::FOO::{const}::{closure}}::drop_glue<'24>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -355,7 +355,7 @@ fn {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{bui
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::FOO::{const}::{closure}}::drop_glue<'24>] _1
+    drop[{impl Destruct for test_crate::FOO::{const}::{closure}}::drop_glue<'25>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -519,8 +519,8 @@ fn {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{bui
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_mut<'_0, '22>(move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::FOO::{const}::{closure#1}}::drop_glue<'23>] _1
+    _0 = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_mut<'_0, '23>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::FOO::{const}::{closure#1}}::drop_glue<'24>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -529,7 +529,7 @@ fn {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{bui
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::FOO::{const}::{closure#1}}::drop_glue<'24>] _1
+    drop[{impl Destruct for test_crate::FOO::{const}::{closure#1}}::drop_glue<'25>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)

--- a/charon/tests/ui/simple/well-formedness-bound.out
+++ b/charon/tests/ui/simple/well-formedness-bound.out
@@ -29,9 +29,9 @@ struct () {}
 
 pub fn test_crate::get<'a>(x: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'a u32}]
 {
-    let _0: Option<&'6 u32>[{built_in impl Sized for &'6 u32}]; // return
-    let x: &'10 u32; // arg #1
-    let _2: &'11 u32; // anonymous local
+    let _0: Option<&'8 u32>[{built_in impl Sized for &'8 u32}]; // return
+    let x: &'12 u32; // arg #1
+    let _2: &'13 u32; // anonymous local
 
     storage_live(_0)
     storage_live(_2)

--- a/charon/tests/ui/slice-index-range.out
+++ b/charon/tests/ui/slice-index-range.out
@@ -55,22 +55,22 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     let start: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 57usize]; // anonymous local
-    let _13: &'34 [u8; 57usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 57usize]; // anonymous local
+    let _13: &'36 [u8; 57usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 57usize]; // anonymous local
-    let _19: &'66 [u8; 57usize]; // anonymous local
+    let _19: &'68 [u8; 57usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -89,7 +89,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -103,7 +103,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -128,7 +128,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = new<'71, 57usize, 2usize>(move _12, move _14)
+    _3 = new<'73, 57usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -160,22 +160,22 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     let end: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 55usize]; // anonymous local
-    let _13: &'34 [u8; 55usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 55usize]; // anonymous local
+    let _13: &'36 [u8; 55usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 55usize]; // anonymous local
-    let _19: &'66 [u8; 55usize]; // anonymous local
+    let _19: &'68 [u8; 55usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -194,7 +194,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -208,7 +208,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -233,7 +233,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = new<'71, 55usize, 2usize>(move _12, move _14)
+    _3 = new<'73, 55usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -265,22 +265,22 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     let start: usize; // arg #1
     let end: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 40usize]; // anonymous local
-    let _13: &'34 [u8; 40usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 40usize]; // anonymous local
+    let _13: &'36 [u8; 40usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 40usize]; // anonymous local
-    let _19: &'66 [u8; 40usize]; // anonymous local
+    let _19: &'68 [u8; 40usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -299,7 +299,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -313,7 +313,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -338,7 +338,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = new<'71, 40usize, 2usize>(move _12, move _14)
+    _3 = new<'73, 40usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -370,22 +370,22 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     let end: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 55usize]; // anonymous local
-    let _13: &'34 [u8; 55usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 55usize]; // anonymous local
+    let _13: &'36 [u8; 55usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 55usize]; // anonymous local
-    let _19: &'66 [u8; 55usize]; // anonymous local
+    let _19: &'68 [u8; 55usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -404,7 +404,7 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -418,7 +418,7 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -443,7 +443,7 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = new<'71, 55usize, 2usize>(move _12, move _14)
+    _3 = new<'73, 55usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -1585,9 +1585,9 @@ where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_0,
 {
-    let _0: Option<&'6 mut [T]>[{built_in impl Sized for &'6 mut [T]}]; // return
+    let _0: Option<&'8 mut [T]>[{built_in impl Sized for &'8 mut [T]}]; // return
     let self: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice: &'10 mut [T]; // arg #2
+    let slice: &'12 mut [T]; // arg #2
     let _3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _4: usize; // anonymous local
     let _5: usize; // anonymous local
@@ -1595,9 +1595,9 @@ where
     let _7: bool; // anonymous local
     let _8: usize; // anonymous local
     let _9: usize; // anonymous local
-    let _10: &'12 [T]; // anonymous local
-    let _11: &'13 mut [T]; // anonymous local
-    let _12: &'14 mut [T]; // anonymous local
+    let _10: &'14 [T]; // anonymous local
+    let _11: &'15 mut [T]; // anonymous local
+    let _12: &'16 mut [T]; // anonymous local
     let _13: *mut [T]; // anonymous local
     let _14: *mut [T]; // anonymous local
     let _15: usize; // anonymous local
@@ -1625,7 +1625,7 @@ where
             storage_live(_9)
             storage_live(_10)
             _10 = &(*slice) with_metadata(copy slice.metadata)
-            _9 = core::slice::{[T]}::len<'16, T>[TraitClause0](move _10)
+            _9 = core::slice::{[T]}::len<'18, T>[TraitClause0](move _10)
             ↳⚡ storage_dead(slice)
                 storage_dead(self)
                 unwind_continue
@@ -1685,9 +1685,9 @@ where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_0,
 {
-    let _0: Option<&'6 [T]>[{built_in impl Sized for &'6 [T]}]; // return
+    let _0: Option<&'8 [T]>[{built_in impl Sized for &'8 [T]}]; // return
     let self: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice: &'10 [T]; // arg #2
+    let slice: &'12 [T]; // arg #2
     let _3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _4: usize; // anonymous local
     let _5: usize; // anonymous local
@@ -1695,9 +1695,9 @@ where
     let _7: bool; // anonymous local
     let _8: usize; // anonymous local
     let _9: usize; // anonymous local
-    let _10: &'11 [T]; // anonymous local
-    let _11: &'12 [T]; // anonymous local
-    let _12: &'13 [T]; // anonymous local
+    let _10: &'13 [T]; // anonymous local
+    let _11: &'14 [T]; // anonymous local
+    let _12: &'15 [T]; // anonymous local
     let _13: *const [T]; // anonymous local
     let _14: *const [T]; // anonymous local
     let _15: usize; // anonymous local
@@ -1725,7 +1725,7 @@ where
             storage_live(_9)
             storage_live(_10)
             _10 = &(*slice) with_metadata(copy slice.metadata)
-            _9 = core::slice::{[T]}::len<'15, T>[TraitClause0](move _10)
+            _9 = core::slice::{[T]}::len<'17, T>[TraitClause0](move _10)
             ↳⚡ storage_dead(slice)
                 storage_dead(self)
                 unwind_continue

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -1548,8 +1548,8 @@ impl "impl_RecursiveImpl_for_unit" RecursiveImpl for () {
 // Full name: test_crate::flabada
 pub fn flabada<'a>(_x: &'a ()) -> Wrapper<(bool, &'a ())>[{built_in impl Sized for (bool, &'a ())}]
 {
-    let _0: Wrapper<(bool, &'8 ())>[{built_in impl Sized for (bool, &'8 ())}]; // return
-    let _x: &'12 (); // arg #1
+    let _0: Wrapper<(bool, &'12 ())>[{built_in impl Sized for (bool, &'12 ())}]; // return
+    let _x: &'16 (); // arg #1
 
     storage_live(_0)
     storage_dead(_x)
@@ -1666,7 +1666,7 @@ pub fn flibidi()
     storage_live(_0)
     _0 = ()
     storage_live(_1)
-    _1 = test_crate::call<'0, for<'a> flabada<'a>>[{built_in impl Sized for for<'a> flabada<'a>}, {impl Fn<(&'a (),)> for for<'a> flabada<'a>}<'0>](const flabada<'11>)
+    _1 = test_crate::call<'0, for<'a> flabada<'a>>[{built_in impl Sized for for<'a> flabada<'a>}, {impl Fn<(&'a (),)> for for<'a> flabada<'a>}<'0>](const flabada<'12>)
     ↳⚡ unwind_continue
     storage_dead(_1)
     _0 = ()

--- a/charon/tests/ui/type_inference_is_order_dependent.out
+++ b/charon/tests/ui/type_inference_is_order_dependent.out
@@ -93,15 +93,15 @@ where
     let args_3: (&'4 U,); // local
     let _4: &'5 U; // anonymous local
     let _5: U; // anonymous local
-    let args_6: [Argument<'13>; 1usize]; // local
-    let _7: Argument<'17>; // anonymous local
-    let _8: &'18 U; // anonymous local
-    let _9: &'20 [u8; 4usize]; // anonymous local
-    let _10: &'21 [u8; 4usize]; // anonymous local
-    let _11: &'27 [Argument<'28>; 1usize]; // anonymous local
-    let _12: &'32 [Argument<'33>; 1usize]; // anonymous local
+    let args_6: [Argument<'14>; 1usize]; // local
+    let _7: Argument<'18>; // anonymous local
+    let _8: &'19 U; // anonymous local
+    let _9: &'21 [u8; 4usize]; // anonymous local
+    let _10: &'22 [u8; 4usize]; // anonymous local
+    let _11: &'28 [Argument<'29>; 1usize]; // anonymous local
+    let _12: &'33 [Argument<'34>; 1usize]; // anonymous local
     let _13: [u8; 4usize]; // anonymous local
-    let _14: &'44 [u8; 4usize]; // anonymous local
+    let _14: &'45 [u8; 4usize]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -120,8 +120,8 @@ where
     storage_live(_7)
     storage_live(_8)
     _8 = &(*args_3._0)
-    _7 = new_debug<'39, '41, U>[TraitClause1, TraitClause5](move _8)
-    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'42>] _5
+    _7 = new_debug<'40, '42, U>[TraitClause1, TraitClause5](move _8)
+    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'43>] _5
         ↳⚡ storage_dead(_14)
             storage_dead(_13)
             unwind_terminate
@@ -142,8 +142,8 @@ where
     storage_live(_12)
     _12 = &args_6
     _11 = &(*_12)
-    _2 = new<'49, 4usize, 1usize>(move _9, move _11)
-    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'42>] _5
+    _2 = new<'50, 4usize, 1usize>(move _9, move _11)
+    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'43>] _5
         ↳⚡ storage_dead(_14)
             storage_dead(_13)
             unwind_terminate
@@ -152,15 +152,15 @@ where
     storage_dead(_11)
     storage_dead(_10)
     storage_dead(_9)
-    _1 = _print<'51>(move _2)
-    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'42>] _5
+    _1 = _print<'52>(move _2)
+    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'43>] _5
         ↳⚡ storage_dead(_14)
             storage_dead(_13)
             unwind_terminate
         unwind_continue
     storage_dead(_2)
     storage_dead(args_6)
-    conditional_drop[{built_in impl Destruct for U}::drop_glue<'52>] _5
+    conditional_drop[{built_in impl Destruct for U}::drop_glue<'53>] _5
     ↳⚡ unwind_continue
     storage_dead(_5)
     storage_dead(args_3)

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -315,22 +315,22 @@ fn foo()
     let _18: &'8 (dyn Display + '9); // anonymous local
     let _19: &'11 String; // anonymous local
     let _20: &'12 String; // anonymous local
-    let _21: Box<(dyn Display + '17)>[{built_in impl MetaSized for (dyn Display + '19)}, {built_in impl Sized for Global}]; // anonymous local
+    let _21: Box<(dyn Display + '18)>[{built_in impl MetaSized for (dyn Display + '20)}, {built_in impl Sized for Global}]; // anonymous local
     let _22: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
     let _23: String; // anonymous local
-    let _24: &'20 String; // anonymous local
-    let _25: Rc<(dyn Display + '25)>[{built_in impl MetaSized for (dyn Display + '27)}, {built_in impl Sized for Global}]; // anonymous local
+    let _24: &'21 String; // anonymous local
+    let _25: Rc<(dyn Display + '27)>[{built_in impl MetaSized for (dyn Display + '29)}, {built_in impl Sized for Global}]; // anonymous local
     let _26: Rc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
     let _27: String; // anonymous local
-    let _28: &'28 String; // anonymous local
-    let _29: Arc<(dyn Display + '33)>[{built_in impl MetaSized for (dyn Display + '35)}, {built_in impl Sized for Global}]; // anonymous local
+    let _28: &'30 String; // anonymous local
+    let _29: Arc<(dyn Display + '36)>[{built_in impl MetaSized for (dyn Display + '38)}, {built_in impl Sized for Global}]; // anonymous local
     let _30: Arc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
     let _31: String; // anonymous local
-    let _32: &'36 String; // anonymous local
-    let _33: MyPtr<(dyn Display + '41)>[{built_in impl MetaSized for (dyn Display + '43)}]; // anonymous local
+    let _32: &'39 String; // anonymous local
+    let _33: MyPtr<(dyn Display + '45)>[{built_in impl MetaSized for (dyn Display + '47)}]; // anonymous local
     let _34: MyPtr<String>[{built_in impl MetaSized for String}]; // anonymous local
     let _35: String; // anonymous local
-    let _36: &'44 String; // anonymous local
+    let _36: &'48 String; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -347,7 +347,7 @@ fn foo()
     _2 = as_slice<'_, i32, 2usize>[{built_in impl Sized for i32}](move _3)
     ↳⚡ undefined_behavior
     storage_dead(_3)
-    set_type(typeof(_2) <= &'46 [i32])
+    set_type(typeof(_2) <= &'50 [i32])
     storage_dead(_4)
     storage_dead(_2)
     storage_live(_5)
@@ -357,14 +357,14 @@ fn foo()
     _6 = alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<[i32; 2usize]>[{built_in impl Sized for [i32; 2usize]}](move _7)
     ↳⚡ unwind_continue
     _5 = unsize_cast<Box<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}], Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 2usize>(move _6)
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'47, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _6
-    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'49, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'51, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _6
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'53, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_7)
     storage_dead(_6)
     set_type(typeof(_5) <= Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'48, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'52, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
     ↳⚡ unwind_continue
     storage_dead(_5)
     storage_live(_8)
@@ -374,14 +374,14 @@ fn foo()
     _9 = alloc::rc::{Rc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<[i32; 2usize]>[{built_in impl Sized for [i32; 2usize]}](move _10)
     ↳⚡ unwind_continue
     _8 = unsize_cast<Rc<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}], Rc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 2usize>(move _9)
-    conditional_drop[impl_Destruct_for_Rc::drop_glue<'50, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _9
-    ↳⚡ conditional_drop[impl_Destruct_for_Rc::drop_glue<'52, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _8
+    conditional_drop[impl_Destruct_for_Rc::drop_glue<'54, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _9
+    ↳⚡ conditional_drop[impl_Destruct_for_Rc::drop_glue<'56, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _8
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_10)
     storage_dead(_9)
     set_type(typeof(_8) <= Rc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Rc::drop_glue<'51, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _8
+    conditional_drop[impl_Destruct_for_Rc::drop_glue<'55, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _8
     ↳⚡ unwind_continue
     storage_dead(_8)
     storage_live(_11)
@@ -391,14 +391,14 @@ fn foo()
     _12 = alloc::sync::{Arc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<[i32; 2usize]>[{built_in impl Sized for [i32; 2usize]}](move _13)
     ↳⚡ unwind_continue
     _11 = unsize_cast<Arc<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}], Arc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 2usize>(move _12)
-    conditional_drop[impl_Destruct_for_Arc::drop_glue<'53, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _12
-    ↳⚡ conditional_drop[impl_Destruct_for_Arc::drop_glue<'55, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _11
+    conditional_drop[impl_Destruct_for_Arc::drop_glue<'57, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _12
+    ↳⚡ conditional_drop[impl_Destruct_for_Arc::drop_glue<'59, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _11
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_13)
     storage_dead(_12)
     set_type(typeof(_11) <= Arc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Arc::drop_glue<'54, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _11
+    conditional_drop[impl_Destruct_for_Arc::drop_glue<'58, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _11
     ↳⚡ unwind_continue
     storage_dead(_11)
     storage_live(_14)
@@ -408,14 +408,14 @@ fn foo()
     _15 = test_crate::{MyPtr<T>[TraitClause0::ImpliedClause0]}::new<[i32; 2usize]>[{built_in impl Sized for [i32; 2usize]}](move _16)
     ↳⚡ unwind_continue
     _14 = unsize_cast<MyPtr<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}], MyPtr<[i32]>[{built_in impl MetaSized for [i32]}], 2usize>(move _15)
-    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'56, [i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}]] _15
-    ↳⚡ conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'58, [i32]>[{built_in impl MetaSized for [i32]}]] _14
+    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'60, [i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}]] _15
+    ↳⚡ conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'62, [i32]>[{built_in impl MetaSized for [i32]}]] _14
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_16)
     storage_dead(_15)
     set_type(typeof(_14) <= MyPtr<[i32]>[{built_in impl MetaSized for [i32]}])
-    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'57, [i32]>[{built_in impl MetaSized for [i32]}]] _14
+    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'61, [i32]>[{built_in impl MetaSized for [i32]}]] _14
     ↳⚡ unwind_continue
     storage_dead(_14)
     storage_live(string)
@@ -427,9 +427,9 @@ fn foo()
     storage_live(_20)
     _20 = &string
     _19 = &(*_20)
-    _18 = unsize_cast<&'11 String, &'59 (dyn Display + '60), &impl_Display_for_String::{vtable}>(move _19)
+    _18 = unsize_cast<&'11 String, &'63 (dyn Display + '64), &impl_Display_for_String::{vtable}>(move _19)
     storage_dead(_19)
-    set_type(typeof(_18) <= &'61 (dyn Display + '62))
+    set_type(typeof(_18) <= &'65 (dyn Display + '66))
     storage_dead(_20)
     storage_dead(_18)
     storage_live(_21)
@@ -437,31 +437,31 @@ fn foo()
     storage_live(_23)
     storage_live(_24)
     _24 = &string
-    _23 = impl_Clone_for_String::clone<'64>(move _24)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    _23 = impl_Clone_for_String::clone<'68>(move _24)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_24)
     _22 = alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<String>[{built_in impl Sized for String}](move _23)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'66>] _23
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'70>] _23
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
-    _21 = unsize_cast<Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Box<(dyn Display + '67)>[{built_in impl MetaSized for (dyn Display + '69)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _22)
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'70, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _22
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'87>] _23
+    _21 = unsize_cast<Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Box<(dyn Display + '71)>[{built_in impl MetaSized for (dyn Display + '73)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _22)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'74, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _22
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'93>] _23
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_Box::drop_glue<'102, (dyn Display + '98), Global>[{built_in impl MetaSized for (dyn Display + '98)}, {built_in impl Sized for Global}]] _21
+        conditional_drop[impl_Destruct_for_Box::drop_glue<'110, (dyn Display + '105), Global>[{built_in impl MetaSized for (dyn Display + '105)}, {built_in impl Sized for Global}]] _21
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_23)
     storage_dead(_22)
-    set_type(typeof(_21) <= Box<(dyn Display + '71)>[{built_in impl MetaSized for (dyn Display + '73)}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'86, (dyn Display + '82), Global>[{built_in impl MetaSized for (dyn Display + '82)}, {built_in impl Sized for Global}]] _21
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    set_type(typeof(_21) <= Box<(dyn Display + '75)>[{built_in impl MetaSized for (dyn Display + '77)}, {built_in impl Sized for Global}])
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'92, (dyn Display + '87), Global>[{built_in impl MetaSized for (dyn Display + '87)}, {built_in impl Sized for Global}]] _21
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_21)
@@ -470,31 +470,31 @@ fn foo()
     storage_live(_27)
     storage_live(_28)
     _28 = &string
-    _27 = impl_Clone_for_String::clone<'89>(move _28)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    _27 = impl_Clone_for_String::clone<'95>(move _28)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_28)
     _26 = alloc::rc::{Rc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<String>[{built_in impl Sized for String}](move _27)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'103>] _27
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'111>] _27
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
-    _25 = unsize_cast<Rc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Rc<(dyn Display + '104)>[{built_in impl MetaSized for (dyn Display + '106)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _26)
-    conditional_drop[impl_Destruct_for_Rc::drop_glue<'107, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _26
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'124>] _27
+    _25 = unsize_cast<Rc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Rc<(dyn Display + '112)>[{built_in impl MetaSized for (dyn Display + '114)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _26)
+    conditional_drop[impl_Destruct_for_Rc::drop_glue<'115, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _26
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'134>] _27
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_Rc::drop_glue<'139, (dyn Display + '135), Global>[{built_in impl MetaSized for (dyn Display + '135)}, {built_in impl Sized for Global}]] _25
+        conditional_drop[impl_Destruct_for_Rc::drop_glue<'151, (dyn Display + '146), Global>[{built_in impl MetaSized for (dyn Display + '146)}, {built_in impl Sized for Global}]] _25
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_27)
     storage_dead(_26)
-    set_type(typeof(_25) <= Rc<(dyn Display + '108)>[{built_in impl MetaSized for (dyn Display + '110)}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Rc::drop_glue<'123, (dyn Display + '119), Global>[{built_in impl MetaSized for (dyn Display + '119)}, {built_in impl Sized for Global}]] _25
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    set_type(typeof(_25) <= Rc<(dyn Display + '116)>[{built_in impl MetaSized for (dyn Display + '118)}, {built_in impl Sized for Global}])
+    conditional_drop[impl_Destruct_for_Rc::drop_glue<'133, (dyn Display + '128), Global>[{built_in impl MetaSized for (dyn Display + '128)}, {built_in impl Sized for Global}]] _25
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_25)
@@ -503,31 +503,31 @@ fn foo()
     storage_live(_31)
     storage_live(_32)
     _32 = &string
-    _31 = impl_Clone_for_String::clone<'126>(move _32)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    _31 = impl_Clone_for_String::clone<'136>(move _32)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_32)
     _30 = alloc::sync::{Arc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<String>[{built_in impl Sized for String}](move _31)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'140>] _31
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'152>] _31
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
-    _29 = unsize_cast<Arc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Arc<(dyn Display + '141)>[{built_in impl MetaSized for (dyn Display + '143)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _30)
-    conditional_drop[impl_Destruct_for_Arc::drop_glue<'144, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _30
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'161>] _31
+    _29 = unsize_cast<Arc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Arc<(dyn Display + '153)>[{built_in impl MetaSized for (dyn Display + '155)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _30)
+    conditional_drop[impl_Destruct_for_Arc::drop_glue<'156, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _30
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'175>] _31
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_Arc::drop_glue<'176, (dyn Display + '172), Global>[{built_in impl MetaSized for (dyn Display + '172)}, {built_in impl Sized for Global}]] _29
+        conditional_drop[impl_Destruct_for_Arc::drop_glue<'192, (dyn Display + '187), Global>[{built_in impl MetaSized for (dyn Display + '187)}, {built_in impl Sized for Global}]] _29
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_31)
     storage_dead(_30)
-    set_type(typeof(_29) <= Arc<(dyn Display + '145)>[{built_in impl MetaSized for (dyn Display + '147)}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Arc::drop_glue<'160, (dyn Display + '156), Global>[{built_in impl MetaSized for (dyn Display + '156)}, {built_in impl Sized for Global}]] _29
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    set_type(typeof(_29) <= Arc<(dyn Display + '157)>[{built_in impl MetaSized for (dyn Display + '159)}, {built_in impl Sized for Global}])
+    conditional_drop[impl_Destruct_for_Arc::drop_glue<'174, (dyn Display + '169), Global>[{built_in impl MetaSized for (dyn Display + '169)}, {built_in impl Sized for Global}]] _29
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_29)
@@ -536,36 +536,36 @@ fn foo()
     storage_live(_35)
     storage_live(_36)
     _36 = &string
-    _35 = impl_Clone_for_String::clone<'163>(move _36)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    _35 = impl_Clone_for_String::clone<'177>(move _36)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_36)
     _34 = test_crate::{MyPtr<T>[TraitClause0::ImpliedClause0]}::new<String>[{built_in impl Sized for String}](move _35)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'177>] _35
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'193>] _35
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
-    _33 = unsize_cast<MyPtr<String>[{built_in impl MetaSized for String}], MyPtr<(dyn Display + '178)>[{built_in impl MetaSized for (dyn Display + '180)}], &impl_Display_for_String::{vtable}>(move _34)
-    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'181, String>[{built_in impl MetaSized for String}]] _34
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'198>] _35
+    _33 = unsize_cast<MyPtr<String>[{built_in impl MetaSized for String}], MyPtr<(dyn Display + '194)>[{built_in impl MetaSized for (dyn Display + '196)}], &impl_Display_for_String::{vtable}>(move _34)
+    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'197, String>[{built_in impl MetaSized for String}]] _34
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'216>] _35
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'212, (dyn Display + '208)>[{built_in impl MetaSized for (dyn Display + '208)}]] _33
+        conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'232, (dyn Display + '227)>[{built_in impl MetaSized for (dyn Display + '227)}]] _33
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_35)
     storage_dead(_34)
-    set_type(typeof(_33) <= MyPtr<(dyn Display + '182)>[{built_in impl MetaSized for (dyn Display + '184)}])
-    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'197, (dyn Display + '193)>[{built_in impl MetaSized for (dyn Display + '193)}]] _33
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    set_type(typeof(_33) <= MyPtr<(dyn Display + '198)>[{built_in impl MetaSized for (dyn Display + '200)}])
+    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'215, (dyn Display + '210)>[{built_in impl MetaSized for (dyn Display + '210)}]] _33
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_33)
     _0 = ()
-    conditional_drop[impl_Destruct_for_String::drop_glue<'199>] string
+    conditional_drop[impl_Destruct_for_String::drop_glue<'217>] string
     ↳⚡ unwind_continue
     storage_dead(string)
     storage_dead(array)

--- a/charon/tests/ui/unsupported/issue-79-bound-regions.out
+++ b/charon/tests/ui/unsupported/issue-79-bound-regions.out
@@ -78,13 +78,13 @@ fn main()
     let slice: &'1 [i32]; // local
     let _2: &'3 [i32; 1usize]; // anonymous local
     let _3: &'4 [i32; 1usize]; // anonymous local
-    let _4: Option<&'12 i32>[{built_in impl Sized for &'12 i32}]; // anonymous local
-    let _5: &'19 mut Iter<'20, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _6: Iter<'21, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _7: &'22 [i32]; // anonymous local
-    let _8: &'23 [i32; 1usize]; // anonymous local
-    let _9: &'24 [i32; 1usize]; // anonymous local
-    let _10: &'32 [i32; 1usize]; // anonymous local
+    let _4: Option<&'13 i32>[{built_in impl Sized for &'13 i32}]; // anonymous local
+    let _5: &'20 mut Iter<'21, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _6: Iter<'22, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _7: &'23 [i32]; // anonymous local
+    let _8: &'24 [i32; 1usize]; // anonymous local
+    let _9: &'25 [i32; 1usize]; // anonymous local
+    let _10: &'33 [i32; 1usize]; // anonymous local
     let _11: [i32; 1usize]; // anonymous local
 
     storage_live(_9)
@@ -106,19 +106,19 @@ fn main()
     ↳⚡ undefined_behavior
     storage_dead(_2)
     fake_read(slice)
-    set_type(typeof(slice) == &'26 [i32])
+    set_type(typeof(slice) == &'27 [i32])
     storage_dead(_3)
     storage_live(_4)
     storage_live(_5)
     storage_live(_6)
     storage_live(_7)
     _7 = &(*slice) with_metadata(copy slice.metadata)
-    _6 = iter<'28, i32>[{built_in impl Sized for i32}](move _7)
+    _6 = iter<'29, i32>[{built_in impl Sized for i32}](move _7)
     ↳⚡ storage_dead(_8)
         unwind_continue
     _5 = &two-phase-mut _6
     storage_dead(_7)
-    _4 = next<'29, '31, i32>[{built_in impl Sized for i32}](move _5)
+    _4 = next<'30, '32, i32>[{built_in impl Sized for i32}](move _5)
     ↳⚡ storage_dead(_8)
         unwind_continue
     storage_dead(_5)


### PR DESCRIPTION
Closes #1388

Generate VTables and their shims for the `Fn*` traits, for closures, function items and function pointers! Also fixed the behaviour of `dyn FnOnce` and other dyn-compatible functions that take `Self`, by making the shim receive `Self` by pointer (this is also what rustc does)

I don't love the code, but I'm also not sure how to do this better; `translate_trait_objects` is already pretty intense:') 


LLMS were used for this PR, though I went through and cleaned up and read the code.