### PR TITLE
Fix bugs

### DIFF
--- a/charon/rustc_trait_elaboration/src/elaboration.rs
+++ b/charon/rustc_trait_elaboration/src/elaboration.rs
@@ -102,7 +102,6 @@ impl<'tcx, Id: ItemId> Candidate<'tcx, Id> {
 #[derive(Clone)]
 pub struct PredicateSearcher<'tcx, Id: ItemId = DefId> {
     pub(crate) elab_ctx: ElaborationCtx<'tcx, Id>,
-    owner: Id,
     pub(crate) typing_env: rustc_middle::ty::TypingEnv<'tcx>,
     /// Local clauses available in the current context.
     candidates: HashMap<PolyTraitRef<'tcx>, Candidate<'tcx, Id>>,
@@ -126,7 +125,6 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
         let initial_self_pred = initial_self_pred(state, &owner_id);
         let mut out = Self {
             elab_ctx,
-            owner: owner_id.clone(),
             typing_env: TypingEnv::new(owner_id.param_env(state), TypingMode::PostAnalysis),
             candidates: Default::default(),
             implicit_self_clause: initial_self_pred.is_some(),
@@ -176,9 +174,9 @@ impl<'tcx, Id: ItemId> PredicateSearcher<'tcx, Id> {
         let tcx = self.elab_ctx.tcx;
 
         // Pretend there is an extra type parameter in the environment, and use it as `Self` in
-        // the dyn predicates.
-        let param_count = self.owner.generics_of(state).count();
-        let existential_ty = ParamTy::new(param_count as u32 + 1, Symbol::intern("_dyn"));
+        // the dyn predicates. Its index must not clash with the owner's parameters, and must
+        // also not depend on the owner, as it would break item identity (see charon#1391)
+        let existential_ty = ParamTy::new(u32::MAX, Symbol::intern("_dyn"));
         let self_ty = existential_ty.to_ty(tcx);
         let predicates = epreds.iter().map(|pred| pred.with_self_ty(tcx, self_ty));
         let predicates = ItemPredicates::new_unmapped(DUMMY_SP, predicates);

--- a/charon/src/ast/meta/names.rs
+++ b/charon/src/ast/meta/names.rs
@@ -205,6 +205,14 @@ impl Name {
         }
     }
 
+    /// Returns this name with the `PathElem::Instantiated` part removed, if it has one.
+    pub fn as_slice_uninstantiated(&self) -> &[PathElem] {
+        match self.name.as_slice() {
+            [name @ .., PathElem::Instantiated(_)] => name,
+            name => name,
+        }
+    }
+
     /// Compare the name to a constant array.
     /// This ignores disambiguators.
     ///

--- a/charon/src/ast/type_level/types.rs
+++ b/charon/src/ast/type_level/types.rs
@@ -462,13 +462,6 @@ impl Ty {
         }
     }
 
-    pub fn as_box(&self) -> Option<&Ty> {
-        match self.kind() {
-            TyKind::Adt(ty_ref) if ty_ref.is_box() => Some(&ty_ref.generics.types[0]),
-            _ => None,
-        }
-    }
-
     pub fn as_adt_id(&self) -> Option<TypeDeclId> {
         self.kind().as_adt().map(|a| a.id)
     }

--- a/charon/src/transform/normalize/transform_dyn_trait_calls.rs
+++ b/charon/src/transform/normalize/transform_dyn_trait_calls.rs
@@ -131,11 +131,8 @@ fn transform_dyn_trait_call(
         }
     };
 
-    let dyn_ty = dyn_trait_place
-        .ty()
-        .as_ref_or_ptr()
-        .or_else(|| dyn_trait_place.ty().as_box())
-        .expect("dyn trait receiver should be behind a pointer");
+    let dyn_pred = dyn_proof.trait_decl_ref.clone().erase();
+    let dyn_ty = &dyn_pred.generics.types[0];
     let PtrMetadata::VTable(receiver_vtable_ref) = dyn_ty.get_ptr_metadata(&ctx.ctx.translated)
     else {
         raise_error!(

--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -203,11 +203,16 @@ impl TypeCheckVisitor<'_> {
             (TyKind::RawPtr(.., src_kind), TyKind::RawPtr(.., tar_kind)) => {
                 assert_eq!(src_kind, tar_kind);
             }
-            (
-                TyKind::Adt(TypeDeclRef { id: src_id, .. }),
-                TyKind::Adt(TypeDeclRef { id: tar_id, .. }),
-            ) => {
-                assert_eq!(src_id, tar_id);
+            (TyKind::Adt(src), TyKind::Adt(tar)) => {
+                if !self.ctx.options.monomorphize_with_hax {
+                    assert_eq!(src.id, tar.id);
+                } else {
+                    // In mono `Box<dyn Trait> -> Box<T>`, have different declarations,
+                    // so we compare names instead.
+                    let instantiated_from =
+                        |id| self.ctx.translated.item_name(id).as_slice_uninstantiated();
+                    assert_eq!(instantiated_from(src.id), instantiated_from(tar.id));
+                }
             }
             // Can happen with `Box`, where the RHS is `Box`. FIXME(#1163): check for Box here.
             (TyKind::DynTrait(..), TyKind::Adt(..)) => {}

--- a/charon/tests/ui/regressions/issue-1391-duplicate-dyn-types.out
+++ b/charon/tests/ui/regressions/issue-1391-duplicate-dyn-types.out
@@ -1,0 +1,283 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+fn core::marker::MetaSized::{vtable}::<D>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<D>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<D>()
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+struct test_crate::Sub::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+// Full name: test_crate::Sub
+trait Sub<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    vtable: test_crate::Sub::{vtable}
+}
+
+// Full name: test_crate::D
+struct D {}
+
+// Full name: test_crate::D::{impl Destruct for D}::drop_glue
+unsafe fn drop_glue<'_0>(_1: &'_0 mut D)
+{
+    let _0: (); // return
+    let _1: &'1 mut D; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::D::{impl Destruct for D}
+impl "impl_Destruct_for_D" Destruct for D {
+    fn drop_glue<'_0_1> = drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl Sub for D}::{vtable_drop_shim}
+unsafe fn {vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Sub))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Sub + '0); // arg #1
+    let target_self: &'_0 mut D; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Sub + '1), &'_0 mut D>(move dyn_self)
+    drop[drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl Sub for D}::{vtable}
+fn impl_Sub_for_D::{vtable}() -> test_crate::Sub::{vtable}
+{
+    let ret: test_crate::Sub::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn Sub + '0)); // local
+    let erased_drop: *const (); // local
+    let _5: unsafe fn(*mut (dyn Sub + '3)); // anonymous local
+    let _6: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<D>
+    storage_live(align)
+    align = align_of<D>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_5)
+    _5 = cast<{vtable_drop_shim}<'2>, unsafe fn(*mut (dyn Sub + '3))>(const {vtable_drop_shim}<'2>)
+    drop = move _5
+    erased_drop = cast<unsafe fn(*mut (dyn Sub + '4)), *const ()>(move drop)
+    storage_live(_6)
+    _6 = &core::marker::MetaSized::{vtable}::<D>
+    ret = test_crate::Sub::{vtable} { size: move size, align: move align, drop: move erased_drop, super_trait_0: move _6 }
+    return
+}
+
+// Full name: test_crate::{impl Sub for D}::{vtable}
+static impl_Sub_for_D::{vtable}: test_crate::Sub::{vtable} = impl_Sub_for_D::{vtable}()
+
+// Full name: test_crate::{impl Sub for D}
+impl "impl_Sub_for_D" Sub for D {
+    proof ImpliedClause0: (D: MetaSized) = {built_in impl MetaSized for D}
+    vtable: impl_Sub_for_D::{vtable}
+}
+
+// Full name: test_crate::Wrapper::<(dyn Sub)>
+struct Wrapper::<(dyn Sub)> {
+  _0: *const (dyn Sub),
+}
+
+// Full name: test_crate::Wrapper::<(dyn Sub)>
+struct Wrapper::<(dyn Sub)> {
+  _0: *const (dyn Sub),
+}
+
+// Full name: test_crate::Wrapper::<(dyn Sub)>
+struct Wrapper::<(dyn Sub)> {
+  _0: *const (dyn Sub),
+}
+
+// Full name: test_crate::Wrapper::<(dyn Sub)>
+struct Wrapper::<(dyn Sub)> {
+  _0: *const (dyn Sub),
+}
+
+// Full name: test_crate::generic_context1::<u8>
+fn generic_context1::<u8>(_1: Wrapper::<(dyn Sub)>)
+{
+    let _0: (); // return
+    let _1: Wrapper::<(dyn Sub)>; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::generic_context2::<u8, u8>
+fn generic_context2::<u8, u8>(_1: Wrapper::<(dyn Sub)>)
+{
+    let _0: (); // return
+    let _1: Wrapper::<(dyn Sub)>; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::generic_context3::<u8, u8, u8>
+fn generic_context3::<u8, u8, u8>(_1: Wrapper::<(dyn Sub)>)
+{
+    let _0: (); // return
+    let _1: Wrapper::<(dyn Sub)>; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let d: D; // local
+    let _2: (); // anonymous local
+    let _3: Wrapper::<(dyn Sub)>; // anonymous local
+    let _4: *const (dyn Sub + '2); // anonymous local
+    let _5: *const (dyn Sub + '3); // anonymous local
+    let _6: *const (dyn Sub + '4); // anonymous local
+    let _7: *const D; // anonymous local
+    let _8: &'6 D; // anonymous local
+    let _9: (); // anonymous local
+    let _10: Wrapper::<(dyn Sub)>; // anonymous local
+    let _11: *const (dyn Sub + '7); // anonymous local
+    let _12: *const (dyn Sub + '8); // anonymous local
+    let _13: *const (dyn Sub + '9); // anonymous local
+    let _14: *const D; // anonymous local
+    let _15: &'10 D; // anonymous local
+    let _16: (); // anonymous local
+    let _17: Wrapper::<(dyn Sub)>; // anonymous local
+    let _18: *const (dyn Sub + '11); // anonymous local
+    let _19: *const (dyn Sub + '12); // anonymous local
+    let _20: *const (dyn Sub + '13); // anonymous local
+    let _21: *const D; // anonymous local
+    let _22: &'14 D; // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(d)
+    d = D {  }
+    fake_read(d)
+    storage_live(_2)
+    storage_live(_3)
+    storage_live(_4)
+    storage_live(_5)
+    storage_live(_6)
+    storage_live(_7)
+    storage_live(_8)
+    _8 = &d
+    _7 = &raw const (*_8)
+    _6 = unsize_cast<*const D, *const (dyn Sub + '15), &impl_Sub_for_D::{vtable}>(move _7)
+    storage_dead(_7)
+    set_type(typeof(_6) == *const (dyn Sub + '16))
+    _5 = copy _6
+    _4 = unsize_cast<*const (dyn Sub + '3), *const (dyn Sub + '17),  at []>(move _5)
+    storage_dead(_5)
+    _3 = Wrapper::<(dyn Sub)> { _0: move _4 }
+    storage_dead(_4)
+    _2 = generic_context1::<u8>(move _3)
+    ↳⚡ unwind_continue
+    storage_dead(_3)
+    storage_dead(_8)
+    storage_dead(_6)
+    storage_dead(_2)
+    storage_live(_9)
+    storage_live(_10)
+    storage_live(_11)
+    storage_live(_12)
+    storage_live(_13)
+    storage_live(_14)
+    storage_live(_15)
+    _15 = &d
+    _14 = &raw const (*_15)
+    _13 = unsize_cast<*const D, *const (dyn Sub + '18), &impl_Sub_for_D::{vtable}>(move _14)
+    storage_dead(_14)
+    set_type(typeof(_13) == *const (dyn Sub + '19))
+    _12 = copy _13
+    _11 = unsize_cast<*const (dyn Sub + '8), *const (dyn Sub + '20),  at []>(move _12)
+    storage_dead(_12)
+    _10 = Wrapper::<(dyn Sub)> { _0: move _11 }
+    storage_dead(_11)
+    _9 = generic_context2::<u8, u8>(move _10)
+    ↳⚡ unwind_continue
+    storage_dead(_10)
+    storage_dead(_15)
+    storage_dead(_13)
+    storage_dead(_9)
+    storage_live(_16)
+    storage_live(_17)
+    storage_live(_18)
+    storage_live(_19)
+    storage_live(_20)
+    storage_live(_21)
+    storage_live(_22)
+    _22 = &d
+    _21 = &raw const (*_22)
+    _20 = unsize_cast<*const D, *const (dyn Sub + '21), &impl_Sub_for_D::{vtable}>(move _21)
+    storage_dead(_21)
+    set_type(typeof(_20) == *const (dyn Sub + '22))
+    _19 = copy _20
+    _18 = unsize_cast<*const (dyn Sub + '12), *const (dyn Sub + '23),  at []>(move _19)
+    storage_dead(_19)
+    _17 = Wrapper::<(dyn Sub)> { _0: move _18 }
+    storage_dead(_18)
+    _16 = generic_context3::<u8, u8, u8>(move _17)
+    ↳⚡ unwind_continue
+    storage_dead(_17)
+    storage_dead(_22)
+    storage_dead(_20)
+    storage_dead(_16)
+    _0 = ()
+    storage_dead(d)
+    return
+}
+
+
+

--- a/charon/tests/ui/regressions/issue-1391-duplicate-dyn-types.out
+++ b/charon/tests/ui/regressions/issue-1391-duplicate-dyn-types.out
@@ -119,21 +119,6 @@ struct Wrapper::<(dyn Sub)> {
   _0: *const (dyn Sub),
 }
 
-// Full name: test_crate::Wrapper::<(dyn Sub)>
-struct Wrapper::<(dyn Sub)> {
-  _0: *const (dyn Sub),
-}
-
-// Full name: test_crate::Wrapper::<(dyn Sub)>
-struct Wrapper::<(dyn Sub)> {
-  _0: *const (dyn Sub),
-}
-
-// Full name: test_crate::Wrapper::<(dyn Sub)>
-struct Wrapper::<(dyn Sub)> {
-  _0: *const (dyn Sub),
-}
-
 // Full name: test_crate::generic_context1::<u8>
 fn generic_context1::<u8>(_1: Wrapper::<(dyn Sub)>)
 {

--- a/charon/tests/ui/regressions/issue-1391-duplicate-dyn-types.rs
+++ b/charon/tests/ui/regressions/issue-1391-duplicate-dyn-types.rs
@@ -1,0 +1,22 @@
+//@ charon-args=--monomorphize
+//! `Wrapper<dyn Sub>` is mentioned in two items whose generic parameter counts differ. The
+//! `dyn Sub` type must come out the same in both, otherwise `Wrapper<dyn Sub>` is declared twice.
+//! The unused type parameter of `generic_context` is what makes the counts differ; it is the
+//! point of the test.
+
+trait Sub {}
+struct D;
+impl Sub for D {}
+
+struct Wrapper<T: ?Sized>(*const T);
+
+fn generic_context1<T>(_: Wrapper<dyn Sub>) {}
+fn generic_context2<T, U>(_: Wrapper<dyn Sub>) {}
+fn generic_context3<T, U, V>(_: Wrapper<dyn Sub>) {}
+
+fn main() {
+    let d = D;
+    generic_context1::<u8>(Wrapper(&d as *const dyn Sub));
+    generic_context2::<u8, u8>(Wrapper(&d as *const dyn Sub));
+    generic_context3::<u8, u8, u8>(Wrapper(&d as *const dyn Sub));
+}

--- a/charon/tests/ui/regressions/issue-1394-box-self-dyn-mono.out
+++ b/charon/tests/ui/regressions/issue-1394-box-self-dyn-mono.out
@@ -1,0 +1,237 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+fn core::marker::MetaSized::{vtable}::<S>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<S>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<S>()
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+// Full name: alloc::boxed::Box::<S>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<S, Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<S, Global>}::drop_glue::<S, Global>
+unsafe fn {impl Destruct for Box::<S, Global>}::drop_glue::<S, Global><'_0>(_1: &'_0 mut Box::<S, Global>)
+= <opaque>
+
+// Full name: alloc::boxed::Box::<(dyn Trait)>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<(dyn Trait), Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<(dyn Trait), Global>}::drop_glue::<(dyn Trait), Global>
+unsafe fn {impl Destruct for Box::<(dyn Trait), Global>}::drop_glue::<(dyn Trait), Global><'_0>(_1: &'_0 mut Box::<(dyn Trait), Global>)
+= <opaque>
+
+// Full name: test_crate::S
+struct S {}
+
+// Full name: alloc::boxed::{Box::<S, Global>}::new::<S>
+#[track_caller]
+#[diagnostic_item("box_new")]
+pub fn new::<S>(_1: S) -> Box::<S, Global>
+= <opaque>
+
+struct test_crate::Trait::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  method_method: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+// Full name: test_crate::Trait
+trait Trait<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    vtable: test_crate::Trait::{vtable}
+}
+
+// Full name: test_crate::S::{impl Destruct for S}::drop_glue
+unsafe fn impl_Destruct_for_S::drop_glue<'_0>(_1: &'_0 mut S)
+{
+    let _0: (); // return
+    let _1: &'1 mut S; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::S::{impl Destruct for S}
+impl "impl_Destruct_for_S" Destruct for S {
+    fn drop_glue<'_0_1> = impl_Destruct_for_S::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl Trait for S}::method
+fn method(self: Box::<S, Global>)
+{
+    let _0: (); // return
+    let self: Box::<S, Global>; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    conditional_drop[{impl Destruct for Box::<S, Global>}::drop_glue::<S, Global><'0>] self
+    ↳⚡ storage_dead(self)
+        unwind_continue
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Trait for S}::method::{vtable_method}
+fn {vtable_method}(_1: Box::<(dyn Trait), Global>)
+{
+    let _0: (); // return
+    let _1: Box::<(dyn Trait), Global>; // arg #1
+    let _2: Box::<S, Global>; // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(_2)
+    _2 = concretize<Box::<(dyn Trait), Global>, Box::<S, Global>>(move _1)
+    _0 = method(move _2)
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Trait for S}::{vtable_drop_shim}
+unsafe fn {vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Trait))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Trait + '0); // arg #1
+    let target_self: &'_0 mut S; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Trait + '1), &'_0 mut S>(move dyn_self)
+    drop[impl_Destruct_for_S::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl Trait for S}::{vtable}
+fn impl_Trait_for_S::{vtable}() -> test_crate::Trait::{vtable}
+{
+    let ret: test_crate::Trait::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn Trait + '0)); // local
+    let erased_drop: *const (); // local
+    let method: fn(Box::<(dyn Trait), Global>); // local
+    let erased_method: *const (); // local
+    let _7: unsafe fn(*mut (dyn Trait + '3)); // anonymous local
+    let _8: fn(Box::<(dyn Trait), Global>); // anonymous local
+    let _9: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<S>
+    storage_live(align)
+    align = align_of<S>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_7)
+    _7 = cast<{vtable_drop_shim}<'2>, unsafe fn(*mut (dyn Trait + '3))>(const {vtable_drop_shim}<'2>)
+    drop = move _7
+    erased_drop = cast<unsafe fn(*mut (dyn Trait + '4)), *const ()>(move drop)
+    storage_live(method)
+    storage_live(erased_method)
+    storage_live(_8)
+    _8 = cast<{vtable_method}, fn(Box::<(dyn Trait), Global>)>(const {vtable_method})
+    method = move _8
+    erased_method = cast<fn(Box::<(dyn Trait), Global>), *const ()>(move method)
+    storage_live(_9)
+    _9 = &core::marker::MetaSized::{vtable}::<S>
+    ret = test_crate::Trait::{vtable} { size: move size, align: move align, drop: move erased_drop, method_method: move erased_method, super_trait_0: move _9 }
+    return
+}
+
+// Full name: test_crate::{impl Trait for S}::{vtable}
+static impl_Trait_for_S::{vtable}: test_crate::Trait::{vtable} = impl_Trait_for_S::{vtable}()
+
+// Full name: test_crate::{impl Trait for S}
+impl "impl_Trait_for_S" Trait for S {
+    proof ImpliedClause0: (S: MetaSized) = {built_in impl MetaSized for S}
+    vtable: impl_Trait_for_S::{vtable}
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let b: Box::<(dyn Trait), Global>; // local
+    let _2: Box::<S, Global>; // anonymous local
+    let _3: S; // anonymous local
+    let _4: (); // anonymous local
+    let _5: Box::<(dyn Trait), Global>; // anonymous local
+    let _6: unsafe fn(Box::<(dyn Trait), Global>); // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(b)
+    storage_live(_2)
+    storage_live(_3)
+    _3 = S {  }
+    _2 = new::<S>(move _3)
+    ↳⚡ unwind_continue
+    b = unsize_cast<Box::<S, Global>, Box::<(dyn Trait), Global>, &impl_Trait_for_S::{vtable}>(move _2)
+    conditional_drop[{impl Destruct for Box::<S, Global>}::drop_glue::<S, Global><'0>] _2
+    ↳⚡ unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    fake_read(b)
+    set_type(typeof(b) == Box::<(dyn Trait), Global>)
+    storage_live(_4)
+    storage_live(_5)
+    _5 = move b
+    storage_live(_6)
+    _6 = cast<*const (), unsafe fn(Box::<(dyn Trait), Global>)>(copy (*_5.metadata).method_method)
+    _4 = (copy _6)(move _5)
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn Trait), Global>}::drop_glue::<(dyn Trait), Global><'3>] _5
+        ↳⚡ storage_dead(_6)
+            unwind_terminate
+        conditional_drop[{impl Destruct for Box::<(dyn Trait), Global>}::drop_glue::<(dyn Trait), Global><'5>] b
+        ↳⚡ storage_dead(_6)
+            unwind_terminate
+        unwind_continue
+    storage_dead(_5)
+    storage_dead(_4)
+    _0 = ()
+    conditional_drop[{impl Destruct for Box::<(dyn Trait), Global>}::drop_glue::<(dyn Trait), Global><'4>] b
+    ↳⚡ unwind_continue
+    storage_dead(b)
+    storage_dead(_6)
+    return
+}
+
+
+

--- a/charon/tests/ui/regressions/issue-1394-box-self-dyn-mono.rs
+++ b/charon/tests/ui/regressions/issue-1394-box-self-dyn-mono.rs
@@ -1,0 +1,16 @@
+//@ charon-args=--monomorphize
+
+trait Trait {
+    fn method(self: Box<Self>);
+}
+
+struct S;
+
+impl Trait for S {
+    fn method(self: Box<Self>) {}
+}
+
+fn main() {
+    let b: Box<dyn Trait> = Box::new(S);
+    b.method();
+}


### PR DESCRIPTION
Fix #1391 -- the bug came from using the context's number of args when adding a new predicate to `dyn`, leading to the ID of that argument varying depending on the context that created it

Fix #1394 -- the bug came from two places: 
- `TypeDeclRef::as_box`, which panics in monomorphic code since there are no generics
- typechecking concretisation of ADTs would fail in monomorphic code, because both sides would have mismatched IDs