### PR TITLE
Fix missing statics!

### DIFF
--- a/charon/src/bin/charon-driver/hax/constant_utils/uneval.rs
+++ b/charon/src/bin/charon-driver/hax/constant_utils/uneval.rs
@@ -262,7 +262,7 @@ fn op_to_const<'tcx, S: UnderOwnerState<'tcx>>(
         // Detect statics
         _ if let Some(place) = op.as_mplace_or_imm().left()
             && let ptr = place.ptr()
-            && let (alloc_id, _, _) = ecx.ptr_get_alloc_id(ptr, 0)?
+            && let Some((alloc_id, _, _)) = ecx.ptr_get_alloc_id(ptr, 0).discard_err()
             && let interpret::GlobalAlloc::Static(did) = tcx.global_alloc(alloc_id) =>
         {
             let item = translate_item_ref(s, did, ty::GenericArgsRef::default());
@@ -350,7 +350,11 @@ fn op_to_const<'tcx, S: UnderOwnerState<'tcx>>(
             ConstantExprKind::FnPtr(fun)
         }
         ty::RawPtr(..) | ty::Ref(..) => {
-            if let Some(op) = ecx.deref_pointer(&op).discard_err() {
+            // Make sure we only read through if it's not dangling!
+            let place_dangling = ecx.deref_pointer(&op).discard_err();
+            let place = place_dangling
+                .filter(|place| ecx.ptr_get_alloc_id(place.ptr(), 0).discard_err().is_some());
+            if let Some(op) = place {
                 // Valid pointer case
                 let val = op_to_const(s, span, ecx, op.into())?;
                 match ty.kind() {

--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -1152,7 +1152,13 @@ impl<'tcx> FullDef<'tcx> {
         let args = self.this().rustc_args(s);
         let kind = ty::AliasConstKind::new_from_def_id(tcx, def_id);
         let uneval = ty::AliasConst::new(tcx, kind, args);
-        let c = eval_ty_constant(s, uneval)?;
+        let Some(c) = eval_ty_constant(s, uneval) else {
+            // Const-evaluation gives up on a const that isn't monomorphic. For "trivial" consts,
+            // we can still read the value directly.
+            let (val, ty) = tcx.trivial_const(def_id)?;
+            let expr = const_value_to_constant_expr(s, ty, val, tcx.def_span(def_id));
+            return expr.discard_err();
+        };
         match c.kind() {
             ty::ConstKind::Error(..) => None,
             _ => Some(c.sinto(s)),
@@ -1178,6 +1184,15 @@ impl<'tcx> FullDef<'tcx> {
             self.def_id().type_of(s),
         );
         let alloc = s.base().tcx.eval_static_initializer(def_id).ok()?;
+        // A static whose type has interior mutability gets a mutable allocation, which
+        // const-eval refuses to read. We don't care though, so we reintern it as immutable.
+        let alloc = if alloc.inner().mutability.is_mut() {
+            let mut alloc = alloc.inner().clone();
+            alloc.mutability = rustc_middle::mir::Mutability::Not;
+            s.base().tcx.mk_const_alloc(alloc)
+        } else {
+            alloc
+        };
         // `eval_static_initializer` returns an interned allocation without an `AllocId`; give it
         // one so we can inspect it through the existing `ConstValue` path.
         let val = mir::ConstValue::Indirect {

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -206,10 +206,9 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         if let Some(body) = self.get_mir(def.this(), span)? {
             Ok(self.translate_body(span, body, &def.source_text))
         } else if let Some(value) = self.evaluate_const_def(def) {
-            // For globals without MIR, generate a body by evaluating the global.
-            // TODO: we lost the MIR of some consts on a rustc update. A trait assoc const
-            // default value no longer has a cross-crate MIR so it's unclear how to retreive
-            // the value. See the `trait-default-const-cross-crate` test.
+            // For globals without MIR, generate a body by evaluating the global. This is how we
+            // get the value of statics (which have no cross-crate MIR at all) and of "trivial"
+            // consts (whose value rustc stores directly instead of encoding MIR for it).
             let c = self.translate_constant_expr(span, &value)?;
             let mut bb = BodyBuilder::new(span, 0);
             let ret = bb.new_var(None, c.ty().clone());

--- a/charon/tests/ui/consts/evaluate-consts-recursive-static.out
+++ b/charon/tests/ui/consts/evaluate-consts-recursive-static.out
@@ -11,20 +11,11 @@ pub opaque type Cell<T>
 where
     TraitClause0: (T: MetaSized),
 
-// Full name: core::marker::Sized
-#[fundamental]
-#[lang_item(Sized)]
-pub trait Sized<Self>
-{
-    proof ImpliedClause0: (Self: MetaSized)
-    non-dyn-compatible
-}
-
-// Full name: core::cell::{Cell<T>[TraitClause0::ImpliedClause0]}::new
-pub fn new<T>(_1: T) -> Cell<T>[TraitClause0::ImpliedClause0]
+// Full name: core::cell::UnsafeCell
+#[lang_item(UnsafeCell)]
+pub opaque type UnsafeCell<T>
 where
-    TraitClause0: (T: Sized),
-= <opaque>
+    TraitClause0: (T: MetaSized),
 
 // Full name: core::marker::Sync
 #[lang_item(Sync)]
@@ -43,70 +34,10 @@ impl "impl_Sync_for_Node" Sync for Node {
 }
 
 // Full name: test_crate::CYCLE_A
-pub fn CYCLE_A() -> Node
-{
-    let _0: Node; // return
-    let _1: Cell<&'5 Node>[{built_in impl MetaSized for &'5 Node}]; // anonymous local
-    let _2: &'8 Node; // anonymous local
-    let _3: &'9 Node; // anonymous local
-    let _4: &'10 Node; // anonymous local
-    let _5: &'11 Node; // anonymous local
-
-    storage_live(_0)
-    storage_live(_1)
-    storage_live(_2)
-    storage_live(_3)
-    storage_live(_4)
-    storage_live(_5)
-    _5 = &CYCLE_B
-    _4 = move _5
-    _3 = &(*_4)
-    _2 = &(*_3)
-    _1 = new<&'13 Node>[{built_in impl Sized for &'13 Node}](move _2)
-    ↳⚡ unwind_continue
-    storage_dead(_2)
-    _0 = Node { value: const 1u32, next: move _1 }
-    storage_dead(_4)
-    storage_dead(_3)
-    storage_dead(_1)
-    return
-}
-
-// Full name: test_crate::CYCLE_A
-pub static CYCLE_A: Node = CYCLE_A()
+pub static CYCLE_A: Node = Node { value: 1u32, next: Cell { 0: UnsafeCell { 0: &CYCLE_B } } }
 
 // Full name: test_crate::CYCLE_B
-pub fn CYCLE_B() -> Node
-{
-    let _0: Node; // return
-    let _1: Cell<&'5 Node>[{built_in impl MetaSized for &'5 Node}]; // anonymous local
-    let _2: &'8 Node; // anonymous local
-    let _3: &'9 Node; // anonymous local
-    let _4: &'10 Node; // anonymous local
-    let _5: &'11 Node; // anonymous local
-
-    storage_live(_0)
-    storage_live(_1)
-    storage_live(_2)
-    storage_live(_3)
-    storage_live(_4)
-    storage_live(_5)
-    _5 = &CYCLE_A
-    _4 = move _5
-    _3 = &(*_4)
-    _2 = &(*_3)
-    _1 = new<&'13 Node>[{built_in impl Sized for &'13 Node}](move _2)
-    ↳⚡ unwind_continue
-    storage_dead(_2)
-    _0 = Node { value: const 2u32, next: move _1 }
-    storage_dead(_4)
-    storage_dead(_3)
-    storage_dead(_1)
-    return
-}
-
-// Full name: test_crate::CYCLE_B
-pub static CYCLE_B: Node = CYCLE_B()
+pub static CYCLE_B: Node = Node { value: 2u32, next: Cell { 0: UnsafeCell { 0: &CYCLE_A } } }
 
 
 

--- a/charon/tests/ui/consts/evaluate-consts-recursive-static.rs
+++ b/charon/tests/ui/consts/evaluate-consts-recursive-static.rs
@@ -1,6 +1,7 @@
 //@ charon-args=--consts=values
 
-// A constant/static that genuinely cannot be evaluated to a value because of recursiveness.
+// Mutually-recursive statics. Evaluation terminates because a pointer to another static is
+// recorded as a reference to that static, not by following it.
 
 use core::cell::Cell;
 

--- a/charon/tests/ui/consts/evaluate-consts.out
+++ b/charon/tests/ui/consts/evaluate-consts.out
@@ -57,22 +57,10 @@ trait HasLen<Self>
 }
 
 // Full name: test_crate::{impl HasLen for [T; 4usize]}::LEN
-fn LEN<T>() -> usize
-where
-    TraitClause0: (T: Sized),
-{
-    let _0: usize; // return
-
-    storage_live(_0)
-    _0 = const 4usize
-    return
-}
-
-// Full name: test_crate::{impl HasLen for [T; 4usize]}::LEN
 const LEN<T>: usize
 where
     TraitClause0: (T: Sized),
- = LEN<T>[TraitClause0]()
+ = 4usize
 
 // Full name: test_crate::{impl HasLen for [T; 4usize]}
 impl<T> "impl_HasLen_for_array" HasLen for [T; 4usize]

--- a/charon/tests/ui/regressions/issue-1393-foreign-static-aux.rs
+++ b/charon/tests/ui/regressions/issue-1393-foreign-static-aux.rs
@@ -1,0 +1,16 @@
+//@ ignore
+// A `static mut`, like a static whose type has interior mutability (`Cell`, `RefCell`, atomics...),
+// gets a *mutable* allocation.
+pub static mut MUTABLE: u8 = 42;
+
+// A static holding a pointer with no provenance, which therefore can't be dereferenced.
+pub struct Wrapper(pub *const u8);
+unsafe impl Sync for Wrapper {}
+pub static DANGLING: Wrapper = Wrapper(4 as *const u8);
+
+// A "trivial" const in a generic impl: rustc stores its value directly and encodes no MIR for it,
+// and const-evaluating it fails because the item isn't monomorphic.
+pub struct Generic<T, const N: usize>(pub T);
+impl<T, const N: usize> Generic<T, N> {
+    pub const TRIVIAL: u8 = 128;
+}

--- a/charon/tests/ui/regressions/issue-1393-foreign-static.out
+++ b/charon/tests/ui/regressions/issue-1393-foreign-static.out
@@ -1,0 +1,117 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+// Full name: issue_1393_foreign_static_aux::MUTABLE
+pub fn MUTABLE() -> u8
+{
+    let _0: u8; // return
+
+    storage_live(_0)
+    _0 = const 42u8
+    return
+}
+
+// Full name: issue_1393_foreign_static_aux::MUTABLE
+pub static MUTABLE: u8 = MUTABLE()
+
+// Full name: issue_1393_foreign_static_aux::Wrapper
+pub struct Wrapper {
+  _0: *const u8,
+}
+
+// Full name: issue_1393_foreign_static_aux::DANGLING
+pub fn DANGLING() -> Wrapper
+{
+    let _0: Wrapper; // return
+    let _1: *const u8; // anonymous local
+    let _2: Wrapper; // anonymous local
+
+    storage_live(_0)
+    storage_live(_1)
+    _1 = cast<usize, *const u8>(const 4usize)
+    storage_live(_2)
+    _2 = Wrapper { _0: move _1 }
+    _0 = move _2
+    return
+}
+
+// Full name: issue_1393_foreign_static_aux::DANGLING
+pub static DANGLING: Wrapper = DANGLING()
+
+// Full name: issue_1393_foreign_static_aux::{Generic<T, N>[TraitClause0]}::TRIVIAL
+pub fn TRIVIAL<T, const N : usize>() -> u8
+where
+    TraitClause0: (T: Sized),
+{
+    let _0: u8; // return
+
+    storage_live(_0)
+    _0 = const 128u8
+    return
+}
+
+// Full name: issue_1393_foreign_static_aux::{Generic<T, N>[TraitClause0]}::TRIVIAL
+pub const TRIVIAL<T, const N : usize>: u8
+where
+    TraitClause0: (T: Sized),
+ = TRIVIAL<T, N>[TraitClause0]()
+
+struct (_, _, _)<A, B, C>
+where
+    TraitClause0: (A: Sized),
+    TraitClause1: (B: Sized),
+{
+  _0: A,
+  _1: B,
+  _2: C,
+}
+
+// Full name: test_crate::foo
+fn foo() -> (u8, *const u8, u8)
+{
+    let _0: (u8, *const u8, u8); // return
+    let _1: u8; // anonymous local
+    let _2: *mut u8; // anonymous local
+    let _3: *const u8; // anonymous local
+    let _4: &'1 Wrapper; // anonymous local
+    let _5: *mut u8; // anonymous local
+    let _6: &'2 Wrapper; // anonymous local
+
+    storage_live(_0)
+    storage_live(_1)
+    storage_live(_2)
+    storage_live(_5)
+    _5 = &raw mut MUTABLE
+    _2 = move _5
+    _1 = copy (*_2)
+    storage_live(_3)
+    storage_live(_4)
+    storage_live(_6)
+    _6 = &DANGLING
+    _4 = move _6
+    _3 = copy (*_4)._0
+    _0 = (move _1, move _3, copy TRIVIAL<bool, 3usize>[{built_in impl Sized for bool}])
+    storage_dead(_3)
+    storage_dead(_1)
+    storage_dead(_4)
+    storage_dead(_2)
+    storage_dead(_6)
+    storage_dead(_5)
+    return
+}
+
+
+

--- a/charon/tests/ui/regressions/issue-1393-foreign-static.rs
+++ b/charon/tests/ui/regressions/issue-1393-foreign-static.rs
@@ -1,0 +1,16 @@
+//@ aux-crate=issue-1393-foreign-static-aux.rs
+//@ charon-args=--extract-opaque-bodies
+// Statics have no cross-crate MIR, so the body of a foreign static's initializer is built by
+// evaluating the static instead. That evaluation used to fail (leaving a `Missing` body) for
+// statics with a mutable allocation, and for statics holding a pointer with no provenance.
+// A generic "trivial" const has no MIR either, and const-evaluation gives up on it because it
+// isn't monomorphic; we read the value rustc stored for it instead.
+use issue_1393_foreign_static_aux::*;
+
+fn foo() -> (u8, *const u8, u8) {
+    (
+        unsafe { MUTABLE },
+        DANGLING.0,
+        Generic::<bool, 3>::TRIVIAL,
+    )
+}

--- a/charon/tests/ui/simple/trait-default-const-cross-crate.out
+++ b/charon/tests/ui/simple/trait-default-const-cross-crate.out
@@ -28,7 +28,13 @@ trait Trait<Self>
 fn FOO<Self>() -> usize
 where
     TraitClause0: (Self: Trait),
-= <missing>
+{
+    let _0: usize; // return
+
+    storage_live(_0)
+    _0 = const 42usize
+    return
+}
 
 // Full name: trait_default_const::Trait::FOO
 const FOO<Self>: usize


### PR DESCRIPTION
Fixes #1393

The issue was in fact three problems in a trenchcoat! Hurray

- We were trying to read through dangling pointers in uneval, which gave up translation. We now check properly
- Const eval gives up in the present of interior mutability, so we cheat a bit to still const-evaluate.
- Const eval also gives up for poly constants, but if they're trivial we can get them regardless!!