### PR TITLE
Make `Span` tiny

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.249"
+let supported_charon_version = "0.1.250"

--- a/charon-ml/src/generated/Generated_Meta.ml
+++ b/charon-ml/src/generated/Generated_Meta.ml
@@ -347,28 +347,30 @@ and raw_attribute = {
 
 and rustc_rustc_version = { major : int; minor : int; patch : int }
 
-(** A snippet of source code within a file. *)
+(** A snippet of source code within a file, along with the place the code was
+    generated from in case of macro expansion. This is a pair of the span itself
+    ([data]) and an optional "generated from" span ([generated_from_span]).
+
+    For code coming from a macro expansion, [data] is the span of the macro
+    before expansion, i.e. the location where the user wrote the call to the
+    macro, and [generated_from_span] is where the code actually comes from.
+
+    Ex:
+    {@rust[
+      // Below, we consider the spans for the statements inside [test]
+
+      //   the statement we consider, which gets inlined in [test]
+                               VV
+      macro_rules! macro { ... st ... } // [generated_from_span] refers to this location
+
+      fn test() {
+          macro!(); // <-- [data] refers to this location
+      }
+    ]} *)
 and span = {
   data : span_data;
-      (** The source code span.
-
-          If this meta information is for a statement/terminator coming from a
-          macro expansion/inlining/etc., this span is (in case of macros) for
-          the macro before expansion (i.e., the location the code where the user
-          wrote the call to the macro).
-
-          Ex:
-          {@rust[
-            // Below, we consider the spans for the statements inside [test]
-
-            //   the statement we consider, which gets inlined in [test]
-                                     VV
-            macro_rules! macro { ... st ... } // [generated_from_span] refers to this location
-
-            fn test() {
-                macro!(); // <-- [data] refers to this location
-            }
-          ]} *)
+      (** The source code span; for code coming from a macro expansion, the
+          location of the macro call. *)
   generated_from_span : span_data option;
       (** Where the code actually comes from, in case of macro
           expansion/inlining/etc. *)

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -51,10 +51,10 @@ type of_json_ctx = {
 let empty_of_json_ctx : of_json_ctx =
   {
     id_to_file_map = FileTbl.create 8;
-    ty_dedup_tbl = DedupTbl.create 1024;
+    ty_dedup_tbl = DedupTbl.create 2048;
     tref_dedup_tbl = DedupTbl.create 1024;
-    constant_expr_dedup_tbl = DedupTbl.create 1024;
-    exact_size_expr_dedup_tbl = DedupTbl.create 1024;
+    constant_expr_dedup_tbl = DedupTbl.create 64;
+    exact_size_expr_dedup_tbl = DedupTbl.create 16;
     span_dedup_tbl = DedupTbl.create 4096;
   }
 

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -30,7 +30,8 @@ module FileTbl = Hashtbl.Make (struct
   let hash = Hashtbl.hash
 end)
 
-(** Table of the values that were deduplicated in the serialized output, by id. *)
+(** Table of the values that were deduplicated in the serialized output, by id.
+*)
 module DedupTbl = Hashtbl.Make (struct
   type t = DedupId.id
 
@@ -44,6 +45,7 @@ type of_json_ctx = {
   tref_dedup_tbl : trait_ref DedupTbl.t;
   constant_expr_dedup_tbl : constant_expr DedupTbl.t;
   exact_size_expr_dedup_tbl : exact_size_expr DedupTbl.t;
+  span_dedup_tbl : span DedupTbl.t;
 }
 
 let empty_of_json_ctx : of_json_ctx =
@@ -53,11 +55,12 @@ let empty_of_json_ctx : of_json_ctx =
     tref_dedup_tbl = DedupTbl.create 1024;
     constant_expr_dedup_tbl = DedupTbl.create 1024;
     exact_size_expr_dedup_tbl = DedupTbl.create 1024;
+    span_dedup_tbl = DedupTbl.create 4096;
   }
 
 (** Values that come up often are deduplicated in the serialized output: the
-    first occurrence of a value is serialized in full along with an id, and later
-    occurrences only mention that id. *)
+    first occurrence of a value is serialized in full along with an id, and
+    later occurrences only mention that id. *)
 let dedup_val_of_json (tbl : 'a DedupTbl.t)
     (of_json : of_json_ctx -> json -> ('a, string) result) (ctx : of_json_ctx)
     (js : json) : ('a, string) result =
@@ -1257,12 +1260,20 @@ and scalar_value_of_json (ctx : of_json_ctx) (js : json) :
 and span_of_json (ctx : of_json_ctx) (js : json) : (span, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | `Assoc [ ("data", data); ("generated_from_span", generated_from_span) ] ->
-        let* data = span_data_of_json ctx data in
-        let* generated_from_span =
-          option_of_json span_data_of_json ctx generated_from_span
-        in
-        Ok ({ data; generated_from_span } : span)
+    | json ->
+        dedup_val_of_json ctx.span_dedup_tbl
+          (fun ctx json ->
+            match json with
+            | `Assoc
+                [ ("data", data); ("generated_from_span", generated_from_span) ]
+              ->
+                let* data = span_data_of_json ctx data in
+                let* generated_from_span =
+                  option_of_json span_data_of_json ctx generated_from_span
+                in
+                Ok ({ data; generated_from_span } : span)
+            | _ -> Error "")
+          ctx json
     | _ -> Error "")
 
 and span_data_of_json (ctx : of_json_ctx) (js : json) :
@@ -1392,8 +1403,7 @@ and trait_ref_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | json ->
-        dedup_val_of_json ctx.tref_dedup_tbl trait_ref_contents_of_json
-          ctx json
+        dedup_val_of_json ctx.tref_dedup_tbl trait_ref_contents_of_json ctx json
     | _ -> Error "")
 
 and trait_ref_contents_of_json (ctx : of_json_ctx) (js : json) :
@@ -1480,8 +1490,7 @@ and trait_type_constraint_id_of_json (ctx : of_json_ctx) (js : json) :
 and ty_of_json (ctx : of_json_ctx) (js : json) : (ty, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
-    | json ->
-        dedup_val_of_json ctx.ty_dedup_tbl ty_kind_of_json ctx json
+    | json -> dedup_val_of_json ctx.ty_dedup_tbl ty_kind_of_json ctx json
     | _ -> Error "")
 
 and ty_kind_of_json (ctx : of_json_ctx) (js : json) : (ty_kind, string) result =

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -18,7 +18,7 @@ open Generated_GAst
 open Generated_FullAst
 open Scalars
 module FileId = IdGen ()
-module HashConsId = IdGen ()
+module DedupId = IdGen ()
 
 (** The default logger *)
 let log = Logging.llbc_of_json_logger
@@ -30,41 +30,50 @@ module FileTbl = Hashtbl.Make (struct
   let hash = Hashtbl.hash
 end)
 
+(** Table of the values that were deduplicated in the serialized output, by id. *)
+module DedupTbl = Hashtbl.Make (struct
+  type t = DedupId.id
+
+  let equal = DedupId.equal_id
+  let hash = Hashtbl.hash
+end)
+
 type of_json_ctx = {
   id_to_file_map : file FileTbl.t;
-  ty_hashcons_map : ty HashConsId.Map.t ref;
-  tref_hashcons_map : trait_ref HashConsId.Map.t ref;
-  constant_expr_hashcons_map : constant_expr HashConsId.Map.t ref;
-  exact_size_expr_hashcons_map : exact_size_expr HashConsId.Map.t ref;
+  ty_dedup_tbl : ty DedupTbl.t;
+  tref_dedup_tbl : trait_ref DedupTbl.t;
+  constant_expr_dedup_tbl : constant_expr DedupTbl.t;
+  exact_size_expr_dedup_tbl : exact_size_expr DedupTbl.t;
 }
 
 let empty_of_json_ctx : of_json_ctx =
   {
     id_to_file_map = FileTbl.create 8;
-    ty_hashcons_map = ref HashConsId.Map.empty;
-    tref_hashcons_map = ref HashConsId.Map.empty;
-    constant_expr_hashcons_map = ref HashConsId.Map.empty;
-    exact_size_expr_hashcons_map = ref HashConsId.Map.empty;
+    ty_dedup_tbl = DedupTbl.create 1024;
+    tref_dedup_tbl = DedupTbl.create 1024;
+    constant_expr_dedup_tbl = DedupTbl.create 1024;
+    exact_size_expr_dedup_tbl = DedupTbl.create 1024;
   }
 
-let hash_consed_val_of_json (map : 'a HashConsId.Map.t ref)
+(** Values that come up often are deduplicated in the serialized output: the
+    first occurrence of a value is serialized in full along with an id, and later
+    occurrences only mention that id. *)
+let dedup_val_of_json (tbl : 'a DedupTbl.t)
     (of_json : of_json_ctx -> json -> ('a, string) result) (ctx : of_json_ctx)
     (js : json) : ('a, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Untagged", json) ] -> of_json ctx json
-    | `Assoc [ ("HashConsedValue", `List [ `Int id; json ]) ] ->
+    | `Assoc [ ("Value", `List [ `Int id; json ]) ] ->
         let* v = of_json ctx json in
-        let id = HashConsId.of_int id in
-        map := HashConsId.Map.add id v !map;
+        DedupTbl.replace tbl (DedupId.of_int id) v;
         Ok v
     | `Assoc [ ("Deduplicated", `Int id) ] -> begin
-        let id = HashConsId.of_int id in
-        match HashConsId.Map.find_opt id !map with
+        match DedupTbl.find_opt tbl (DedupId.of_int id) with
         | Some v -> Ok v
         | None ->
             Error
-              "Hash-consing key not found; there is a serialization mismatch \
+              "Deduplication key not found; there is a serialization mismatch \
                between Rust and OCaml"
       end
     | _ -> Error "")
@@ -481,7 +490,7 @@ and constant_expr_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | json ->
-        hash_consed_val_of_json ctx.constant_expr_hashcons_map
+        dedup_val_of_json ctx.constant_expr_dedup_tbl
           (fun ctx json ->
             let* contents =
               pair_of_json constant_expr_kind_of_json ty_of_json ctx json
@@ -839,7 +848,7 @@ and hash_consed_of_json :
  fun arg0_of_json ctx js ->
   combine_error_msgs js __FUNCTION__
     (match js with
-    | json -> Error "use `hash_consed_val_of_json` instead"
+    | json -> Error "use `dedup_val_of_json` instead"
     | _ -> Error "")
 
 and impl_elem_of_json (ctx : of_json_ctx) (js : json) :
@@ -1383,7 +1392,7 @@ and trait_ref_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | json ->
-        hash_consed_val_of_json ctx.tref_hashcons_map trait_ref_contents_of_json
+        dedup_val_of_json ctx.tref_dedup_tbl trait_ref_contents_of_json
           ctx json
     | _ -> Error "")
 
@@ -1472,7 +1481,7 @@ and ty_of_json (ctx : of_json_ctx) (js : json) : (ty, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | json ->
-        hash_consed_val_of_json ctx.ty_hashcons_map ty_kind_of_json ctx json
+        dedup_val_of_json ctx.ty_dedup_tbl ty_kind_of_json ctx json
     | _ -> Error "")
 
 and ty_kind_of_json (ctx : of_json_ctx) (js : json) : (ty_kind, string) result =
@@ -2512,7 +2521,7 @@ and exact_size_expr_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | json ->
-        hash_consed_val_of_json ctx.exact_size_expr_hashcons_map
+        dedup_val_of_json ctx.exact_size_expr_dedup_tbl
           exact_size_expr_kind_of_json ctx json
     | _ -> Error "")
 

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -47,10 +47,10 @@ type of_postcard_ctx = {
 let empty_of_postcard_ctx : of_postcard_ctx =
   {
     id_to_file_map = FileTbl.create 8;
-    ty_dedup_tbl = DedupTbl.create 1024;
+    ty_dedup_tbl = DedupTbl.create 2048;
     tref_dedup_tbl = DedupTbl.create 1024;
-    constant_expr_dedup_tbl = DedupTbl.create 1024;
-    exact_size_expr_dedup_tbl = DedupTbl.create 1024;
+    constant_expr_dedup_tbl = DedupTbl.create 64;
+    exact_size_expr_dedup_tbl = DedupTbl.create 16;
     span_dedup_tbl = DedupTbl.create 4096;
   }
 

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -26,7 +26,8 @@ module FileTbl = Hashtbl.Make (struct
   let hash = Hashtbl.hash
 end)
 
-(** Table of the values that were deduplicated in the serialized output, by id. *)
+(** Table of the values that were deduplicated in the serialized output, by id.
+*)
 module DedupTbl = Hashtbl.Make (struct
   type t = DedupId.id
 
@@ -40,6 +41,7 @@ type of_postcard_ctx = {
   tref_dedup_tbl : trait_ref DedupTbl.t;
   constant_expr_dedup_tbl : constant_expr DedupTbl.t;
   exact_size_expr_dedup_tbl : exact_size_expr DedupTbl.t;
+  span_dedup_tbl : span DedupTbl.t;
 }
 
 let empty_of_postcard_ctx : of_postcard_ctx =
@@ -49,11 +51,12 @@ let empty_of_postcard_ctx : of_postcard_ctx =
     tref_dedup_tbl = DedupTbl.create 1024;
     constant_expr_dedup_tbl = DedupTbl.create 1024;
     exact_size_expr_dedup_tbl = DedupTbl.create 1024;
+    span_dedup_tbl = DedupTbl.create 4096;
   }
 
 (** Values that come up often are deduplicated in the serialized output: the
-    first occurrence of a value is serialized in full along with an id, and later
-    occurrences only mention that id. *)
+    first occurrence of a value is serialized in full along with an id, and
+    later occurrences only mention that id. *)
 let dedup_val_of_postcard (tbl : 'a DedupTbl.t)
     (of_postcard : of_postcard_ctx -> postcard_state -> ('a, string) result)
     (ctx : of_postcard_ctx) (st : postcard_state) : ('a, string) result =
@@ -72,8 +75,8 @@ let dedup_val_of_postcard (tbl : 'a DedupTbl.t)
            | Some v -> Ok v
            | None ->
                Error
-                 "Deduplication key not found; there is a serialization mismatch \
-                  between Rust and OCaml"
+                 "Deduplication key not found; there is a serialization \
+                  mismatch between Rust and OCaml"
          end
      | 2 -> of_postcard ctx st
      | _ -> Error "invalid deduplicated value representation")
@@ -1158,11 +1161,14 @@ and scalar_value_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
 and span_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (span, string) result =
   combine_error_msgs st __FUNCTION__
-    (let* data = span_data_of_postcard ctx st in
-     let* generated_from_span =
-       option_of_postcard span_data_of_postcard ctx st
-     in
-     Ok ({ data; generated_from_span } : span))
+    (dedup_val_of_postcard ctx.span_dedup_tbl
+       (fun ctx st ->
+         let* data = span_data_of_postcard ctx st in
+         let* generated_from_span =
+           option_of_postcard span_data_of_postcard ctx st
+         in
+         Ok ({ data; generated_from_span } : span))
+       ctx st)
 
 and span_data_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (span_data, string) result =
@@ -1249,8 +1255,8 @@ and trait_param_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
 and trait_ref_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (trait_ref, string) result =
   combine_error_msgs st __FUNCTION__
-    (dedup_val_of_postcard ctx.tref_dedup_tbl
-       trait_ref_contents_of_postcard ctx st)
+    (dedup_val_of_postcard ctx.tref_dedup_tbl trait_ref_contents_of_postcard ctx
+       st)
 
 and trait_ref_contents_of_postcard (ctx : of_postcard_ctx) (st : postcard_state)
     : (trait_ref_contents, string) result =

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -855,8 +855,8 @@ and literal_type_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
 and loc_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (loc, string) result =
   combine_error_msgs st __FUNCTION__
-    (let* line = usize_of_postcard ctx st in
-     let* col = usize_of_postcard ctx st in
+    (let* line = u32_of_postcard ctx st in
+     let* col = u32_of_postcard ctx st in
      Ok ({ line; col } : loc))
 
 and local_id_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
@@ -2277,7 +2277,7 @@ and gexpr_body_of_postcard :
      let* body = arg0_of_postcard ctx st in
      let* _ =
        list_of_postcard
-         (pair_of_postcard usize_of_postcard
+         (pair_of_postcard u32_of_postcard
             (list_of_postcard string_of_postcard))
          ctx st
      in

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -17,7 +17,7 @@ open Generated_GAst
 open Generated_FullAst
 open Scalars
 module FileId = IdGen ()
-module HashConsId = IdGen ()
+module DedupId = IdGen ()
 
 module FileTbl = Hashtbl.Make (struct
   type t = FileId.id
@@ -26,46 +26,57 @@ module FileTbl = Hashtbl.Make (struct
   let hash = Hashtbl.hash
 end)
 
+(** Table of the values that were deduplicated in the serialized output, by id. *)
+module DedupTbl = Hashtbl.Make (struct
+  type t = DedupId.id
+
+  let equal = DedupId.equal_id
+  let hash = Hashtbl.hash
+end)
+
 type of_postcard_ctx = {
   id_to_file_map : file FileTbl.t;
-  ty_hashcons_map : ty HashConsId.Map.t ref;
-  tref_hashcons_map : trait_ref HashConsId.Map.t ref;
-  constant_expr_hashcons_map : constant_expr HashConsId.Map.t ref;
-  exact_size_expr_hashcons_map : exact_size_expr HashConsId.Map.t ref;
+  ty_dedup_tbl : ty DedupTbl.t;
+  tref_dedup_tbl : trait_ref DedupTbl.t;
+  constant_expr_dedup_tbl : constant_expr DedupTbl.t;
+  exact_size_expr_dedup_tbl : exact_size_expr DedupTbl.t;
 }
 
 let empty_of_postcard_ctx : of_postcard_ctx =
   {
     id_to_file_map = FileTbl.create 8;
-    ty_hashcons_map = ref HashConsId.Map.empty;
-    tref_hashcons_map = ref HashConsId.Map.empty;
-    constant_expr_hashcons_map = ref HashConsId.Map.empty;
-    exact_size_expr_hashcons_map = ref HashConsId.Map.empty;
+    ty_dedup_tbl = DedupTbl.create 1024;
+    tref_dedup_tbl = DedupTbl.create 1024;
+    constant_expr_dedup_tbl = DedupTbl.create 1024;
+    exact_size_expr_dedup_tbl = DedupTbl.create 1024;
   }
 
-let hash_consed_val_of_postcard (map : 'a HashConsId.Map.t ref)
+(** Values that come up often are deduplicated in the serialized output: the
+    first occurrence of a value is serialized in full along with an id, and later
+    occurrences only mention that id. *)
+let dedup_val_of_postcard (tbl : 'a DedupTbl.t)
     (of_postcard : of_postcard_ctx -> postcard_state -> ('a, string) result)
     (ctx : of_postcard_ctx) (st : postcard_state) : ('a, string) result =
   combine_error_msgs st __FUNCTION__
     (let* tag = int_of_postcard ctx st in
      match tag with
      | 0 ->
-         let* id = HashConsId.id_of_postcard ctx st in
+         let* id = DedupId.id_of_postcard ctx st in
          let* v = of_postcard ctx st in
-         map := HashConsId.Map.add id v !map;
+         DedupTbl.replace tbl id v;
          Ok v
      | 1 ->
-         let* id = HashConsId.id_of_postcard ctx st in
+         let* id = DedupId.id_of_postcard ctx st in
          begin
-           match HashConsId.Map.find_opt id !map with
+           match DedupTbl.find_opt tbl id with
            | Some v -> Ok v
            | None ->
                Error
-                 "Hash-consing key not found; there is a serialization \
-                  mismatch between Rust and OCaml"
+                 "Deduplication key not found; there is a serialization mismatch \
+                  between Rust and OCaml"
          end
      | 2 -> of_postcard ctx st
-     | _ -> Error "invalid hash-consed representation")
+     | _ -> Error "invalid deduplicated value representation")
 
 let path_buf_of_postcard = string_of_postcard
 
@@ -446,7 +457,7 @@ and const_generic_var_id_of_postcard (ctx : of_postcard_ctx)
 and constant_expr_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (constant_expr, string) result =
   combine_error_msgs st __FUNCTION__
-    (hash_consed_val_of_postcard ctx.constant_expr_hashcons_map
+    (dedup_val_of_postcard ctx.constant_expr_dedup_tbl
        (fun ctx st ->
          let* contents =
            pair_of_postcard constant_expr_kind_of_postcard ty_of_postcard ctx st
@@ -761,7 +772,7 @@ and hash_consed_of_postcard :
     ('a0 hash_consed, string) result =
  fun arg0_of_postcard ctx st ->
   combine_error_msgs st __FUNCTION__
-    (Error "use `hash_consed_val_of_postcard` instead")
+    (Error "use `dedup_val_of_postcard` instead")
 
 and impl_elem_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (impl_elem, string) result =
@@ -1238,7 +1249,7 @@ and trait_param_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
 and trait_ref_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (trait_ref, string) result =
   combine_error_msgs st __FUNCTION__
-    (hash_consed_val_of_postcard ctx.tref_hashcons_map
+    (dedup_val_of_postcard ctx.tref_dedup_tbl
        trait_ref_contents_of_postcard ctx st)
 
 and trait_ref_contents_of_postcard (ctx : of_postcard_ctx) (st : postcard_state)
@@ -1310,7 +1321,7 @@ and trait_type_constraint_id_of_postcard (ctx : of_postcard_ctx)
 and ty_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (ty, string) result =
   combine_error_msgs st __FUNCTION__
-    (hash_consed_val_of_postcard ctx.ty_hashcons_map ty_kind_of_postcard ctx st)
+    (dedup_val_of_postcard ctx.ty_dedup_tbl ty_kind_of_postcard ctx st)
 
 and ty_kind_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (ty_kind, string) result =
@@ -2132,7 +2143,7 @@ and error_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
 and exact_size_expr_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (exact_size_expr, string) result =
   combine_error_msgs st __FUNCTION__
-    (hash_consed_val_of_postcard ctx.exact_size_expr_hashcons_map
+    (dedup_val_of_postcard ctx.exact_size_expr_dedup_tbl
        exact_size_expr_kind_of_postcard ctx st)
 
 and exact_size_expr_kind_of_postcard (ctx : of_postcard_ctx)

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "charon"
-version = "0.1.249"
+version = "0.1.250"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -26,7 +26,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.249"
+version = "0.1.250"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/src/ast/bodies.rs
+++ b/charon/src/ast/bodies.rs
@@ -116,7 +116,7 @@ pub struct GExprBody<T> {
     /// For each line inside the body, we record any whole-line `//` comments found before it. They
     /// are added to statements in the late `recover_body_comments` pass.
     #[cfg_attr(feature = "charon_on_charon", charon::opaque)]
-    pub comments: Vec<(usize, Vec<String>)>,
+    pub comments: Vec<(u32, Vec<String>)>,
 }
 
 generate_index_type!(BranchId, "Branch");

--- a/charon/src/ast/bodies.rs
+++ b/charon/src/ast/bodies.rs
@@ -33,7 +33,7 @@ pub use values::*;
     EnumAsGetters,
     EnumToGetters,
 )]
-#[serde_state(state_implements = HashConsSerializerState)]
+#[serde_state(state_implements = DedupSerializerState)]
 #[cfg_attr(feature = "charon_on_charon", charon::variants_suffix("Body"))]
 pub enum Body {
     /// Body represented as a CFG. This is what ullbc is made of, and what we get after translating MIR.

--- a/charon/src/ast/bodies/expressions.rs
+++ b/charon/src/ast/bodies/expressions.rs
@@ -103,7 +103,7 @@ pub enum Rvalue {
     DriveMut,
     DriveTwo,
 )]
-#[serde_state(state_implements = HashConsSerializerState)] // Avoid corecursive impls due to perfect derive
+#[serde_state(state_implements = DedupSerializerState)] // Avoid corecursive impls due to perfect derive
 pub enum Operand {
     Copy(Place),
     Move(Place),

--- a/charon/src/ast/bodies/places.rs
+++ b/charon/src/ast/bodies/places.rs
@@ -7,7 +7,7 @@ use serde_state::{DeserializeState, SerializeState};
 #[derive(
     Debug, PartialEq, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo,
 )]
-#[serde_state(state_implements = HashConsSerializerState)] // Avoid corecursive impls due to perfect derive
+#[serde_state(state_implements = DedupSerializerState)] // Avoid corecursive impls due to perfect derive
 pub struct Place {
     pub kind: PlaceKind,
     pub ty: Ty,

--- a/charon/src/ast/bodies/structured.rs
+++ b/charon/src/ast/bodies/structured.rs
@@ -19,7 +19,7 @@ pub type ExprBody = GExprBody<Block>;
 
 /// A sequence of statements.
 #[derive(Debug, Eq, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
-#[serde_state(state_implements = HashConsSerializerState)] // Avoid corecursive impls due to perfect derive
+#[serde_state(state_implements = DedupSerializerState)] // Avoid corecursive impls due to perfect derive
 pub struct Block {
     pub span: Span,
     /// Integer uniquely identifying this block. To simplify things we generate globally-fresh ids

--- a/charon/src/ast/bodies/values.rs
+++ b/charon/src/ast/bodies/values.rs
@@ -23,7 +23,7 @@ use crate::ast::*;
     DriveMut,
     DriveTwo,
 )]
-#[serde_state(state_implements = HashConsSerializerState)] // Avoid corecursive impls due to perfect derive
+#[serde_state(state_implements = DedupSerializerState)] // Avoid corecursive impls due to perfect derive
 pub struct ConstantExpr(pub HashConsed<(ConstantExprKind, Ty)>);
 
 #[derive(

--- a/charon/src/ast/items/layout.rs
+++ b/charon/src/ast/items/layout.rs
@@ -53,7 +53,7 @@ pub struct VariantLayout {
 /// Decision tree used to determine the active variant by reading memory. Mirrors MiniRust's
 /// `Discriminator`.
 #[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
-#[serde_state(state_implements = HashConsSerializerState)]
+#[serde_state(state_implements = DedupSerializerState)]
 pub enum Discriminator {
     /// The variant is known.
     Known(VariantId),

--- a/charon/src/ast/items/layout_guarantees.rs
+++ b/charon/src/ast/items/layout_guarantees.rs
@@ -80,7 +80,7 @@ pub enum MetadataValue {
     DriveMut,
     DriveTwo,
 )]
-#[serde_state(state_implements = HashConsSerializerState)]
+#[serde_state(state_implements = DedupSerializerState)]
 pub struct ExactSizeExpr(pub HashConsed<ExactSizeExprKind>);
 
 #[derive(

--- a/charon/src/ast/items/type_decl.rs
+++ b/charon/src/ast/items/type_decl.rs
@@ -21,7 +21,7 @@ use crate::utils::serialize_map_to_array::SeqHashMapToArray;
 /// A type can only be an ADT (structure or enumeration), as type aliases are
 /// inlined in MIR.
 #[derive(Debug, Clone, SerializeState, DeserializeState, Drive, DriveMut, DriveTwo)]
-#[serde_state(state_implements = HashConsSerializerState)]
+#[serde_state(state_implements = DedupSerializerState)]
 pub struct TypeDecl {
     pub def_id: TypeDeclId,
     /// Meta information associated with the item.

--- a/charon/src/ast/krate.rs
+++ b/charon/src/ast/krate.rs
@@ -32,7 +32,7 @@ pub type TargetTriple = String;
 /// To get a `TranslatedCrate`, run `charon cargo` inside a Rust crate, then deserialize
 /// the resulting `crate_name.llbc` file using [`crate::deserialize_llbc`].
 #[derive(Default, Clone, Drive, DriveMut, DriveTwo, SerializeState, DeserializeState)]
-#[serde_state(state_implements = HashConsSerializerState)]
+#[serde_state(state_implements = DedupSerializerState)]
 pub struct TranslatedCrate {
     /// The name of the crate.
     pub crate_name: String,

--- a/charon/src/ast/meta/names.rs
+++ b/charon/src/ast/meta/names.rs
@@ -1,6 +1,7 @@
 //! User-visible names of items.
 use crate::ast::*;
 use derive_generic_visitor::{Drive, DriveMut, DriveTwo};
+use itertools::Itertools;
 use macros::{EnumAsGetters, EnumIsA};
 use serde::{Deserialize, Serialize};
 use serde_state::{DeserializeState, SerializeState};
@@ -290,6 +291,38 @@ impl Name {
             PathElem::Ident(str, _) => Some(str),
             _ => None,
         }
+    }
+
+    /// `Name` is a complex datastructure; to inspect it we serialize it a little bit.
+    /// This must only be used for debug printing; it is not reliable or exact.
+    pub fn debug_repr(&self, crate_data: &TranslatedCrate) -> String {
+        // Small helper
+        let trait_name = |impl_id: TraitImplId| {
+            crate_data
+                .trait_impls
+                .get(impl_id)
+                .and_then(|timpl| crate_data.trait_decls.get(timpl.impl_trait.id))
+                .and_then(|tr| tr.item_meta.name.name.last())
+                .and_then(|p| p.as_ident())
+                .map(|(name, _)| name)
+        };
+
+        self.name
+            .iter()
+            .map(|path_elem| match path_elem {
+                PathElem::Ident(i, _) => i.clone(),
+                PathElem::Impl(elem) => match elem {
+                    ImplElem::Trait(impl_id) => match trait_name(*impl_id) {
+                        None => format!("<trait impl#{impl_id}>"),
+                        Some(name) => format!("<impl {name} for ??>"),
+                    },
+                    ImplElem::Ty(..) => "<inherent impl>".to_string(),
+                },
+                PathElem::Instantiated(..) => "<mono>".to_string(),
+                PathElem::Target(target) => target.clone(),
+                PathElem::Builtin(builtin, _) => format!("<{}>", builtin.ident()),
+            })
+            .join("::")
     }
 }
 

--- a/charon/src/ast/meta/spans.rs
+++ b/charon/src/ast/meta/spans.rs
@@ -1,7 +1,5 @@
 use crate::utils::dedup::*;
-use derive_generic_visitor::{
-    Break, Continue, ControlFlow, Drive, DriveMut, DriveTwo, VisitMut, Visitor,
-};
+use derive_generic_visitor::{ControlFlow, Drive, DriveMut, DriveTwo, Visit, VisitMut, VisitTwo};
 use serde::{Deserialize, Serialize};
 use serde_state::{DeserializeState, SerializeState};
 use std::collections::HashMap;
@@ -131,8 +129,6 @@ pub struct SpanData {
 // - For serde 1.0.228, out of 246K spans, 12 didn't fit
 // - For regex 1.11.1, out of 136K spans, 25 didn't fit
 // - For syn 2.0.104, out of 800K spans, 36 didn't fit
-// Ordering is the ordering of the packed value: for packed spans the layout above makes this the
-// source order (file, then start, then extent); wide spans sort last.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Span(u64);
 
@@ -177,6 +173,9 @@ mod pack {
     Deserialize,
     SerializeState,
     DeserializeState,
+    Drive,
+    DriveMut,
+    DriveTwo,
 )]
 #[cfg_attr(feature = "charon_on_charon", charon::rename("Span"))]
 #[serde_state(stateless)]
@@ -329,33 +328,31 @@ impl std::fmt::Debug for Span {
     }
 }
 
-/// A `Span` has no contents to visit: what it contains is packed into an integer. We must however
-/// let mutable visitors edit the `FileId`s inside, as the multi-target export relies on this to
-/// renumber files.
-impl<'s, V: Visitor> Drive<'s, V> for Span {
-    fn drive_inner(&'s self, _v: &mut V) -> ControlFlow<V::Break> {
-        Continue(())
+impl<'s, V> Drive<'s, V> for Span
+where
+    V: for<'a> Visit<'a, SerializedSpan> + for<'a> Visit<'a, Option<SerializedSpan>>,
+{
+    fn drive_inner(&'s self, v: &mut V) -> ControlFlow<V::Break> {
+        v.visit(&self.unpack())
     }
 }
 impl<'s, V> DriveMut<'s, V> for Span
 where
-    V: for<'a> VisitMut<'a, SpanData> + for<'a> VisitMut<'a, Option<SpanData>>,
+    V: for<'a> VisitMut<'a, SerializedSpan> + for<'a> VisitMut<'a, Option<SerializedSpan>>,
 {
     fn drive_inner_mut(&'s mut self, v: &mut V) -> ControlFlow<V::Break> {
         let mut span = self.unpack();
-        v.visit(&mut span.data)?;
-        v.visit(&mut span.generated_from_span)?;
+        let res = v.visit(&mut span);
         *self = Span::from_unpacked(span);
-        Continue(())
+        res
     }
 }
-impl<'s, V: Visitor<Break: Default>> DriveTwo<'s, V> for Span {
-    fn drive_two_inner(&'s self, other: &'s Self, _v: &mut V) -> ControlFlow<V::Break> {
-        if self == other {
-            Continue(())
-        } else {
-            Break(Default::default())
-        }
+impl<'s, V> DriveTwo<'s, V> for Span
+where
+    V: for<'a> VisitTwo<'a, SerializedSpan> + for<'a> VisitTwo<'a, Option<SerializedSpan>>,
+{
+    fn drive_two_inner(&'s self, other: &'s Self, v: &mut V) -> ControlFlow<V::Break> {
+        v.visit(&self.unpack(), &other.unpack())
     }
 }
 

--- a/charon/src/ast/meta/spans.rs
+++ b/charon/src/ast/meta/spans.rs
@@ -1,6 +1,10 @@
-use derive_generic_visitor::{Drive, DriveMut, DriveTwo};
+use derive_generic_visitor::{
+    Break, Continue, ControlFlow, Drive, DriveMut, DriveTwo, VisitMut, Visitor,
+};
 use serde::{Deserialize, Serialize};
 use serde_state::{DeserializeState, SerializeState};
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
 use std::{borrow::Cow, cmp::Ordering, ops::Range, path::PathBuf};
 
 generate_index_type!(FileId);
@@ -73,9 +77,9 @@ pub struct File {
 )]
 pub struct Loc {
     /// The (1-based) line number.
-    pub line: usize,
+    pub line: u32,
     /// The (0-based) column offset.
-    pub col: usize,
+    pub col: u32,
 }
 
 /// A snippet of source code within a file.
@@ -91,48 +95,251 @@ pub struct SpanData {
     pub end: Loc,
 }
 
-/// A snippet of source code within a file.
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Serialize,
-    Deserialize,
-    SerializeState,
-    DeserializeState,
-    Drive,
-    DriveMut,
-    DriveTwo,
-)]
-#[serde_state(stateless)]
-pub struct Span {
-    /// The source code span.
-    ///
-    /// If this meta information is for a statement/terminator coming from a macro
-    /// expansion/inlining/etc., this span is (in case of macros) for the macro
-    /// before expansion (i.e., the location the code where the user wrote the call
-    /// to the macro).
-    ///
-    /// Ex:
-    /// ```text
-    /// // Below, we consider the spans for the statements inside `test`
-    ///
-    /// //   the statement we consider, which gets inlined in `test`
-    ///                          VV
-    /// macro_rules! macro { ... st ... } // `generated_from_span` refers to this location
-    ///
-    /// fn test() {
-    ///     macro!(); // <-- `data` refers to this location
-    /// }
-    /// ```
+/// A snippet of source code within a file, along with the place the code was generated from in
+/// case of macro expansion. This is a pair of the span itself (`data`) and an optional
+/// "generated from" span (`generated_from_span`).
+///
+/// For code coming from a macro expansion, `data` is the span of the macro before expansion, i.e.
+/// the location where the user wrote the call to the macro, and `generated_from_span` is where
+/// the code actually comes from.
+///
+/// Ex:
+/// ```text
+/// // Below, we consider the spans for the statements inside `test`
+///
+/// //   the statement we consider, which gets inlined in `test`
+///                          VV
+/// macro_rules! macro { ... st ... } // `generated_from_span` refers to this location
+///
+/// fn test() {
+///     macro!(); // <-- `data` refers to this location
+/// }
+/// ```
+// A `Span` is stored inline in most AST nodes, so we care about its size. Instead of storing the
+// two `SpanData`s, we pack the common case into 8 bytes:
+// ```text
+//     63     62..47     47..27      27..17    17..10     10..0
+//   +------+----------+-----------+---------+----------+---------+
+//   | wide | file(16) | beg.line  | beg.col | nb lines | end.col |
+//   +------+----------+-----------+---------+----------+---------+
+// ```
+// The spans that don't fit this layout -- because they come from a macro expansion, span many
+// lines, or point into a very large file or a very long line -- are stored in `WIDE_SPANS` and
+// referred to by index.
+// Some numbers to back this up:
+// - For serde 1.0.228, out of 246K spans, 12 didn't fit
+// - For regex 1.11.1, out of 136K spans, 25 didn't fit
+// - For syn 2.0.104, out of 800K spans, 36 didn't fit
+// Ordering is the ordering of the packed value: for packed spans the layout above makes this the
+// source order (file, then start, then extent); wide spans sort last.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Span(u64);
+
+/// Bit layout of the packed representation of [`Span`].
+mod pack {
+    /// Set when the rest of the bits is an index into `WIDE_SPANS` instead of a packed span.
+    pub const WIDE_FLAG: u64 = 1 << 63;
+    pub const FILE_BITS: u32 = 16;
+    pub const LINE_BITS: u32 = 20;
+    pub const COL_BITS: u32 = 10;
+    pub const NLINES_BITS: u32 = 7;
+
+    pub const END_COL_SHIFT: u32 = 0;
+    pub const NLINES_SHIFT: u32 = END_COL_SHIFT + COL_BITS;
+    pub const BEG_COL_SHIFT: u32 = NLINES_SHIFT + NLINES_BITS;
+    pub const BEG_LINE_SHIFT: u32 = BEG_COL_SHIFT + COL_BITS;
+    pub const FILE_SHIFT: u32 = BEG_LINE_SHIFT + LINE_BITS;
+
+    /// Extract the `bits` bits of `x` starting at `shift`.
+    #[inline]
+    pub fn get(x: u64, shift: u32, bits: u32) -> u32 {
+        ((x >> shift) & ((1 << bits) - 1)) as u32
+    }
+
+    /// Put `x` in its place, if it fits in `bits` bits.
+    #[inline]
+    pub fn put(x: u32, shift: u32, bits: u32) -> Option<u64> {
+        (u64::from(x) < (1 << bits)).then_some(u64::from(x) << shift)
+    }
+}
+
+/// A [`Span`] with its contents laid out, used for serialization and unpacking into a
+/// more readable format.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename = "Span")]
+pub struct SerializedSpan {
+    /// The source code span; for code coming from a macro expansion, the location of the macro
+    /// call.
     pub data: SpanData,
     /// Where the code actually comes from, in case of macro expansion/inlining/etc.
     pub generated_from_span: Option<SpanData>,
+}
+
+/// The spans that don't fit the packed representation of [`Span`]. We store them here once and
+/// refer to them by index. Entries are deduplicated so equal spans have equal representations.
+///
+/// This table is global and never shrinks. In practice this is fine; for instance, syn 2.0.104
+/// only had distinct 36 spans here.
+static WIDE_SPANS: LazyLock<Mutex<WideSpans>> = LazyLock::new(Default::default);
+
+#[derive(Default)]
+struct WideSpans {
+    spans: Vec<SerializedSpan>,
+    indices: HashMap<SerializedSpan, u64>,
+}
+
+impl Span {
+    #[inline]
+    pub fn new(data: SpanData, generated_from_span: Option<SpanData>) -> Self {
+        Self::from_unpacked(SerializedSpan {
+            data,
+            generated_from_span,
+        })
+    }
+
+    /// The source code span; for code coming from a macro expansion, the location of the macro
+    /// call.
+    #[inline]
+    pub fn data(self) -> SpanData {
+        self.unpack().data
+    }
+
+    /// Where the code actually comes from, in case of macro expansion/inlining/etc.
+    #[inline]
+    pub fn generated_from_span(self) -> Option<SpanData> {
+        self.unpack().generated_from_span
+    }
+
+    fn from_unpacked(span: SerializedSpan) -> Self {
+        match Self::pack(span) {
+            Some(packed) => packed,
+            None => Self::store_wide(span),
+        }
+    }
+
+    fn pack(span: SerializedSpan) -> Option<Self> {
+        use pack::*;
+        if span.generated_from_span.is_some() {
+            return None;
+        }
+        let data = span.data;
+        let nb_lines = data.end.line.checked_sub(data.beg.line)?;
+        let bits = put(data.file_id.index() as u32, FILE_SHIFT, FILE_BITS)?
+            | put(data.beg.line, BEG_LINE_SHIFT, LINE_BITS)?
+            | put(data.beg.col, BEG_COL_SHIFT, COL_BITS)?
+            | put(nb_lines, NLINES_SHIFT, NLINES_BITS)?
+            | put(data.end.col, END_COL_SHIFT, COL_BITS)?;
+        Some(Span(bits))
+    }
+
+    fn unpack(self) -> SerializedSpan {
+        use pack::*;
+        if self.0 & WIDE_FLAG != 0 {
+            return WIDE_SPANS.lock().unwrap().spans[(self.0 ^ WIDE_FLAG) as usize];
+        }
+        let beg_line = get(self.0, BEG_LINE_SHIFT, LINE_BITS);
+        let data = SpanData {
+            file_id: FileId::from_raw(get(self.0, FILE_SHIFT, FILE_BITS)),
+            beg: Loc {
+                line: beg_line,
+                col: get(self.0, BEG_COL_SHIFT, COL_BITS),
+            },
+            end: Loc {
+                line: beg_line + get(self.0, NLINES_SHIFT, NLINES_BITS),
+                col: get(self.0, END_COL_SHIFT, COL_BITS),
+            },
+        };
+        SerializedSpan {
+            data,
+            generated_from_span: None,
+        }
+    }
+
+    #[cold]
+    fn store_wide(span: SerializedSpan) -> Self {
+        let mut wide_spans = WIDE_SPANS.lock().unwrap();
+        let index = match wide_spans.indices.get(&span) {
+            Some(index) => *index,
+            None => {
+                let index = wide_spans.spans.len() as u64;
+                assert!(index & pack::WIDE_FLAG == 0, "too many wide spans");
+                wide_spans.spans.push(span);
+                wide_spans.indices.insert(span, index);
+                index
+            }
+        };
+        Span(index | pack::WIDE_FLAG)
+    }
+}
+
+impl Serialize for Span {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.unpack().serialize(serializer)
+    }
+}
+impl<'de> Deserialize<'de> for Span {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Span::from_unpacked(SerializedSpan::deserialize(
+            deserializer,
+        )?))
+    }
+}
+impl<State: ?Sized> SerializeState<State> for Span {
+    fn serialize_state<S: serde::Serializer>(
+        &self,
+        _state: &State,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        self.serialize(serializer)
+    }
+}
+impl<'de, State: ?Sized> DeserializeState<'de, State> for Span {
+    fn deserialize_state<D: serde::Deserializer<'de>>(
+        _state: &State,
+        deserializer: D,
+    ) -> Result<Self, D::Error> {
+        Self::deserialize(deserializer)
+    }
+}
+
+impl std::fmt::Debug for Span {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let span = self.unpack();
+        f.debug_struct("Span")
+            .field("data", &span.data)
+            .field("generated_from_span", &span.generated_from_span)
+            .finish()
+    }
+}
+
+/// A `Span` has no contents to visit: what it contains is packed into an integer. We must however
+/// let mutable visitors edit the `FileId`s inside, as the multi-target export relies on this to
+/// renumber files.
+impl<'s, V: Visitor> Drive<'s, V> for Span {
+    fn drive_inner(&'s self, _v: &mut V) -> ControlFlow<V::Break> {
+        Continue(())
+    }
+}
+impl<'s, V> DriveMut<'s, V> for Span
+where
+    V: for<'a> VisitMut<'a, SpanData> + for<'a> VisitMut<'a, Option<SpanData>>,
+{
+    fn drive_inner_mut(&'s mut self, v: &mut V) -> ControlFlow<V::Break> {
+        let mut span = self.unpack();
+        v.visit(&mut span.data)?;
+        v.visit(&mut span.generated_from_span)?;
+        *self = Span::from_unpacked(span);
+        Continue(())
+    }
+}
+impl<'s, V: Visitor<Break: Default>> DriveTwo<'s, V> for Span {
+    fn drive_two_inner(&'s self, other: &'s Self, _v: &mut V) -> ControlFlow<V::Break> {
+        if self == other {
+            Continue(())
+        } else {
+            Break(Default::default())
+        }
+    }
 }
 
 /// Given a line number within a source file, get the byte of the start of the line. Obviously not
@@ -150,7 +357,7 @@ fn line_to_start_byte(source: &str, line_nbr: usize) -> usize {
 }
 
 impl Loc {
-    fn dummy() -> Self {
+    const fn dummy() -> Self {
         Loc { line: 0, col: 0 }
     }
 
@@ -177,14 +384,14 @@ impl Loc {
     }
 
     pub fn to_byte(self, source: &str) -> usize {
-        line_to_start_byte(source, self.line) + self.col
+        line_to_start_byte(source, self.line as usize) + self.col as usize
     }
 }
 
 impl SpanData {
-    pub fn dummy() -> Self {
+    pub const fn dummy() -> Self {
         SpanData {
-            file_id: FileId::from_raw(0),
+            file_id: FileId::ZERO,
             beg: Loc::dummy(),
             end: Loc::dummy(),
         }
@@ -213,32 +420,29 @@ impl Ord for SpanData {
 }
 
 impl Span {
-    pub fn dummy() -> Self {
-        Span {
-            data: SpanData::dummy(),
-            generated_from_span: None,
-        }
+    pub const fn dummy() -> Self {
+        // Every field of `SpanData::dummy()` packs to zero, so this is just zero!
+        // Actually tested below for correctness
+        Span(0)
     }
 }
 
 /// Combine some span information (useful when we need to compute the
 /// span-information of, say, a sequence).
 pub fn combine_span(m0: &Span, m1: &Span) -> Span {
+    let (d0, d1) = (m0.data(), m1.data());
     // Merge the spans
-    if m0.data.file_id == m1.data.file_id {
+    if d0.file_id == d1.file_id {
         let data = SpanData {
-            file_id: m0.data.file_id,
-            beg: Loc::min(&m0.data.beg, &m1.data.beg),
-            end: Loc::max(&m0.data.end, &m1.data.end),
+            file_id: d0.file_id,
+            beg: Loc::min(&d0.beg, &d1.beg),
+            end: Loc::max(&d0.end, &d1.end),
         };
 
         // We don't attempt to merge the "generated from" spans: they might
         // come from different files, and even if they come from the same files
         // they might come from different macros, etc.
-        Span {
-            data,
-            generated_from_span: None,
-        }
+        Span::new(data, None)
     } else {
         // It happens that the spans don't come from the same file. In this
         // situation, we just return the first span. TODO: improve this.
@@ -270,4 +474,53 @@ impl Default for Span {
     fn default() -> Self {
         Self::dummy()
     }
+}
+
+/// `Span` is stored inline in most ast nodes, so its size matters
+#[test]
+fn span_is_small() {
+    assert_eq!(size_of::<Span>(), 8);
+}
+
+/// Check that `Span::dummy()` is correct.
+#[test]
+fn span_dummy_is_zero() {
+    assert_eq!(Span::dummy(), Span::new(SpanData::dummy(), None));
+    assert_eq!(Span::dummy().data(), SpanData::dummy());
+}
+
+/// Check that we roundtrip both the spans that fit the packed representation and the ones that
+/// don't.
+#[test]
+fn span_roundtrip() {
+    let data = |file: usize, beg: (u32, u32), end: (u32, u32)| SpanData {
+        file_id: FileId::from_usize(file),
+        beg: Loc {
+            line: beg.0,
+            col: beg.1,
+        },
+        end: Loc {
+            line: end.0,
+            col: end.1,
+        },
+    };
+    let packed = data(12, (34, 56), (78, 90));
+    let huge_file = data(1 << 20, (34, 56), (78, 90));
+    let long_line = data(12, (34, 5678), (78, 90));
+    let backwards = data(12, (78, 56), (34, 90));
+    for (d, generated) in [
+        (packed, None),
+        (packed, Some(packed)),
+        (huge_file, None),
+        (long_line, None),
+        (backwards, None),
+    ] {
+        let span = Span::new(d, generated);
+        assert_eq!(span.data(), d);
+        assert_eq!(span.generated_from_span(), generated);
+    }
+    // Only the first span above fits the packed representation.
+    assert!(Span::new(packed, None).0 & pack::WIDE_FLAG == 0);
+    // Equal spans have equal representations, even when they don't fit.
+    assert_eq!(Span::new(backwards, None), Span::new(backwards, None));
 }

--- a/charon/src/ast/meta/spans.rs
+++ b/charon/src/ast/meta/spans.rs
@@ -129,7 +129,7 @@ pub struct SpanData {
 // - For serde 1.0.228, out of 246K spans, 12 didn't fit
 // - For regex 1.11.1, out of 136K spans, 25 didn't fit
 // - For syn 2.0.104, out of 800K spans, 36 didn't fit
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Span(u64);
 
 /// Bit layout of the packed representation of [`Span`].
@@ -168,6 +168,8 @@ mod pack {
     Clone,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
     Hash,
     Serialize,
     Deserialize,
@@ -281,6 +283,23 @@ impl Span {
             }
         };
         Span(index | pack::WIDE_FLAG)
+    }
+}
+
+impl Ord for Span {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if (self.0 | other.0) & pack::WIDE_FLAG == 0 {
+            // Both spans are packed: the bit layout is such that comparing the packed values is
+            // the same as comparing `(file, beg, end)`, so take the fast path.
+            self.0.cmp(&other.0)
+        } else {
+            self.unpack().cmp(&other.unpack())
+        }
+    }
+}
+impl PartialOrd for Span {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/charon/src/ast/meta/spans.rs
+++ b/charon/src/ast/meta/spans.rs
@@ -1,3 +1,4 @@
+use crate::utils::dedup::*;
 use derive_generic_visitor::{
     Break, Continue, ControlFlow, Drive, DriveMut, DriveTwo, VisitMut, Visitor,
 };
@@ -165,8 +166,20 @@ mod pack {
 
 /// A [`Span`] with its contents laid out, used for serialization and unpacking into a
 /// more readable format.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename = "Span")]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    SerializeState,
+    DeserializeState,
+)]
+#[cfg_attr(feature = "charon_on_charon", charon::rename("Span"))]
+#[serde_state(stateless)]
 pub struct SerializedSpan {
     /// The source code span; for code coming from a macro expansion, the location of the macro
     /// call.
@@ -274,31 +287,35 @@ impl Span {
 
 impl Serialize for Span {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.unpack().serialize(serializer)
+        SerDedup::Untagged(self.unpack()).serialize(serializer)
     }
 }
 impl<'de> Deserialize<'de> for Span {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Span::from_unpacked(SerializedSpan::deserialize(
-            deserializer,
-        )?))
+        use serde::de::Error;
+        match SerDedup::<SerializedSpan>::deserialize(deserializer)? {
+            SerDedup::Untagged(span) => Ok(Span::from_unpacked(span)),
+            SerDedup::Value { .. } | SerDedup::Deduplicated { .. } => {
+                Err(D::Error::custom(stateless_deserialize_error::<Span>()))
+            }
+        }
     }
 }
-impl<State: ?Sized> SerializeState<State> for Span {
+impl<State: DedupSerializerState> SerializeState<State> for Span {
     fn serialize_state<S: serde::Serializer>(
         &self,
-        _state: &State,
+        state: &State,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
-        self.serialize(serializer)
+        serialize_dedup(self, self.unpack(), state, serializer)
     }
 }
-impl<'de, State: ?Sized> DeserializeState<'de, State> for Span {
+impl<'de, State: DedupSerializerState> DeserializeState<'de, State> for Span {
     fn deserialize_state<D: serde::Deserializer<'de>>(
-        _state: &State,
+        state: &State,
         deserializer: D,
     ) -> Result<Self, D::Error> {
-        Self::deserialize(deserializer)
+        deserialize_dedup(state, deserializer, Span::from_unpacked)
     }
 }
 

--- a/charon/src/ast/mod.rs
+++ b/charon/src/ast/mod.rs
@@ -23,6 +23,7 @@ pub use std::ops::ControlFlow;
 
 pub use crate::errors::Error;
 pub use crate::ids::{IndexMap, IndexVec};
+pub use crate::utils::dedup::*;
 pub use crate::utils::hash_cons::*;
 
 pub use bodies::*;

--- a/charon/src/ast/type_level/trait_proofs.rs
+++ b/charon/src/ast/type_level/trait_proofs.rs
@@ -21,7 +21,7 @@ use serde_state::{DeserializeState, SerializeState};
     DriveMut,
     DriveTwo,
 )]
-#[serde_state(state_implements = HashConsSerializerState)] // Avoid corecursive impls due to perfect derive
+#[serde_state(state_implements = DedupSerializerState)] // Avoid corecursive impls due to perfect derive
 pub struct TraitRef(pub HashConsed<TraitRefContents>);
 
 #[derive(

--- a/charon/src/ast/type_level/types.rs
+++ b/charon/src/ast/type_level/types.rs
@@ -19,7 +19,7 @@ use serde_state::{DeserializeState, SerializeState};
     DriveMut,
     DriveTwo,
 )]
-#[serde_state(state_implements = HashConsSerializerState)] // Avoid corecursive impls due to perfect derive
+#[serde_state(state_implements = DedupSerializerState)] // Avoid corecursive impls due to perfect derive
 pub struct Ty(pub HashConsed<TyKind>);
 
 #[derive(
@@ -354,7 +354,7 @@ pub struct DynPredicate {
     DriveMut,
     DriveTwo,
 )]
-#[serde_state(state_implements = HashConsSerializerState)] // Avoid corecursive impls due to perfect derive
+#[serde_state(state_implements = DedupSerializerState)] // Avoid corecursive impls due to perfect derive
 pub enum TypePattern {
     Range(ConstantExpr, ConstantExpr),
     OrPattern(Vec<TypePattern>),

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -77,7 +77,7 @@ use derive_generic_visitor::*;
         Discriminator,
         SizeExpr, OffsetExpr, SizeGuarantee, OffsetGuarantee,
         PtrMetadata,
-        SpanData,
+        SpanData, SerializedSpan,
         ItemByVal, VTableField, AssocItemNames,
         for<Id: AstVisitable> DeclRef<Id>, ItemId,
         for<T: AstVisitable> Box<T>,

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -47,7 +47,7 @@ use derive_generic_visitor::*;
     visitor(drive_two(&two ZipAst)),
     // Types that are skipped by normal visitors but compared for equality by `ZipAst`.
     skip_but_eq(
-        (), String, PathBuf, bool, char, i128, u8, u64, u128, usize, ustr::Ustr,
+        (), String, PathBuf, bool, char, i128, u8, u32, u64, u128, usize, ustr::Ustr,
         crate::options::CliOpts,
         Abi, BuiltinImplData, Byte, DeprecatedSince, DropKind, Error, FileName,
         GlobalKind, ItemOpacity, LangItem, LifetimeMutability, OptimizeAttr, OverflowMode,
@@ -199,7 +199,7 @@ impl<K: BodyVisitable + Hash + Eq, T: BodyVisitable> BodyVisitable for SeqHashMa
         AbortKind, BinOp, BorrowKind, BranchId, BuiltinAssertKind, ConstantExpr, FieldId,
         TypeDeclRef, FunDeclId, FunDeclRef, FnPtrKind, GenericArgs, GlobalDeclRef, IntegerTy, IntTy, UIntTy,
         NullOp, RefKind, ScalarValue, Span, Ty, TypeDeclId,  UnOp, VariantId,
-        TraitRef, LiteralTy, Literal, Region, RegionId, (), String, PathBuf, bool, usize,
+        TraitRef, LiteralTy, Literal, Region, RegionId, (), String, PathBuf, bool, u32, usize,
         DropKind, Error, Variance, WithRetag, BuiltinTy, BuiltinPathElem,
         llbc_ast::BlockId, llbc_ast::StatementId,
     ),

--- a/charon/src/bin/charon-driver/translate/translate_bodies.rs
+++ b/charon/src/bin/charon-driver/translate/translate_bodies.rs
@@ -644,7 +644,7 @@ impl<'tcx> BodyTransCtx<'tcx, '_, '_> {
         &mut self,
         source_text: &Option<String>,
         charon_span: Span,
-    ) -> Vec<(usize, Vec<String>)> {
+    ) -> Vec<(u32, Vec<String>)> {
         if let Some(body_text) = source_text {
             let mut comments = body_text
                 .lines()
@@ -652,7 +652,9 @@ impl<'tcx> BodyTransCtx<'tcx, '_, '_> {
                 .rev()
                 .enumerate()
                 // Compute the absolute line number
-                .filter_map(|(i, line)| Some((charon_span.data.end.line.checked_sub(i)?, line)))
+                .filter_map(|(i, line)| {
+                    Some(((charon_span.data().end.line).checked_sub(i as u32)?, line))
+                })
                 // Extract the comment if this line starts with `//`
                 .map(|(line_nbr, line)| (line_nbr, line.trim_start().strip_prefix("//")))
                 .peekable()

--- a/charon/src/bin/charon-driver/translate/translate_meta.rs
+++ b/charon/src/bin/charon-driver/translate/translate_meta.rs
@@ -153,8 +153,8 @@ impl<'tcx> TranslateCtx<'tcx> {
         let convert_loc = |pos: rustc_span::BytePos| -> Loc {
             let loc = smap.lookup_char_pos(pos);
             Loc {
-                line: loc.line,
-                col: loc.col_display,
+                line: loc.line as u32,
+                col: loc.col_display as u32,
             }
         };
         let beg = convert_loc(span.lo());
@@ -183,23 +183,14 @@ impl<'tcx> TranslateCtx<'tcx> {
 
         if let Some(parent_span) = parent_span {
             let parent_span = self.translate_span_data(parent_span);
-            Span {
-                data: parent_span,
-                generated_from_span: Some(data),
-            }
+            Span::new(parent_span, Some(data))
         } else {
-            Span {
-                data,
-                generated_from_span: None,
-            }
+            Span::new(data, None)
         }
     }
 
     pub(crate) fn translate_span(&mut self, span: &rustc_span::Span) -> Span {
-        Span {
-            data: self.translate_span_data(*span),
-            generated_from_span: None,
-        }
+        Span::new(self.translate_span_data(*span), None)
     }
 
     pub(crate) fn def_span(&mut self, def_id: &hax::DefId) -> Span {

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -319,7 +319,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
 
         // Supertrait fields.
         for (i, pred) in implied_predicates.iter_trait_clauses().enumerate() {
-            let trait_clause_id = TraitClauseId::from_raw(i); // One trait clause id per trait clause
+            let trait_clause_id = TraitClauseId::from_usize(i); // One trait clause id per trait clause
             let clause = &pred.clause;
             let hax::ClauseKind::Trait(pred) = clause.kind.hax_skip_binder_ref() else {
                 unreachable!()

--- a/charon/src/bin/generate-asts/generate_ml.rs
+++ b/charon/src/bin/generate-asts/generate_ml.rs
@@ -15,7 +15,6 @@ use std::fs;
 use std::path::PathBuf;
 
 use self::to_ocaml_ty::DeriveVisitors;
-use self::util::*;
 
 mod of_json;
 mod of_postcard;
@@ -41,7 +40,7 @@ impl<'a> GenerateCtx<'a> {
         let mut name_to_type: HashMap<String, &TypeDecl> = Default::default();
         let mut type_tree = HashMap::default();
         for ty in &crate_data.type_decls {
-            let long_name = repr_name(&ty.item_meta.name);
+            let long_name = ty.item_meta.name.debug_repr(crate_data);
             if long_name.starts_with("charon_lib")
                 && let Some(short_name) = ty.item_meta.name.short_str()
             {

--- a/charon/src/bin/generate-asts/generate_ml/of_json.rs
+++ b/charon/src/bin/generate-asts/generate_ml/of_json.rs
@@ -58,23 +58,20 @@ const MANUAL_IMPLS: &[(&str, &str)] = &[
             "#
         ),
     ),
-    (
-        "HashConsed",
-        r#"Error "use `hash_consed_val_of_json` instead""#,
-    ), // Not actually used
+    ("HashConsed", r#"Error "use `dedup_val_of_json` instead""#), // Not actually used
     (
         "Ty",
-        "hash_consed_val_of_json ctx.ty_hashcons_map ty_kind_of_json ctx json",
+        "dedup_val_of_json ctx.ty_dedup_tbl ty_kind_of_json ctx json",
     ),
     (
         "TraitRef",
-        "hash_consed_val_of_json ctx.tref_hashcons_map trait_ref_contents_of_json ctx json",
+        "dedup_val_of_json ctx.tref_dedup_tbl trait_ref_contents_of_json ctx json",
     ),
     (
         "ConstantExpr",
         indoc!(
             r#"
-            hash_consed_val_of_json ctx.constant_expr_hashcons_map
+            dedup_val_of_json ctx.constant_expr_dedup_tbl
               (fun ctx json ->
                 let* contents = pair_of_json constant_expr_kind_of_json ty_of_json ctx json in
                 let kind, ty = contents in
@@ -85,7 +82,7 @@ const MANUAL_IMPLS: &[(&str, &str)] = &[
     ),
     (
         "ExactSizeExpr",
-        "hash_consed_val_of_json ctx.exact_size_expr_hashcons_map exact_size_expr_kind_of_json ctx json",
+        "dedup_val_of_json ctx.exact_size_expr_dedup_tbl exact_size_expr_kind_of_json ctx json",
     ),
 ];
 

--- a/charon/src/bin/generate-asts/generate_ml/of_json.rs
+++ b/charon/src/bin/generate-asts/generate_ml/of_json.rs
@@ -84,6 +84,25 @@ const MANUAL_IMPLS: &[(&str, &str)] = &[
         "ExactSizeExpr",
         "dedup_val_of_json ctx.exact_size_expr_dedup_tbl exact_size_expr_kind_of_json ctx json",
     ),
+    // Hand-written because spans are deduplicated in the serialized output.
+    (
+        "Span",
+        indoc!(
+            r#"
+            dedup_val_of_json ctx.span_dedup_tbl
+              (fun ctx json ->
+                match json with
+                | `Assoc [ ("data", data); ("generated_from_span", generated_from_span) ] ->
+                    let* data = span_data_of_json ctx data in
+                    let* generated_from_span =
+                      option_of_json span_data_of_json ctx generated_from_span
+                    in
+                    Ok ({ data; generated_from_span } : span)
+                | _ -> Error "")
+              ctx json
+            "#
+        ),
+    ),
 ];
 
 impl<'a> GenerateCtx<'a> {

--- a/charon/src/bin/generate-asts/generate_ml/of_postcard.rs
+++ b/charon/src/bin/generate-asts/generate_ml/of_postcard.rs
@@ -80,6 +80,20 @@ const MANUAL_IMPLS: &[(&str, &str)] = &[
         "ExactSizeExpr",
         "dedup_val_of_postcard ctx.exact_size_expr_dedup_tbl exact_size_expr_kind_of_postcard ctx st",
     ),
+    // Hand-written because spans are deduplicated in the serialized output.
+    (
+        "Span",
+        indoc!(
+            r#"
+            dedup_val_of_postcard ctx.span_dedup_tbl
+              (fun ctx st ->
+                let* data = span_data_of_postcard ctx st in
+                let* generated_from_span = option_of_postcard span_data_of_postcard ctx st in
+                Ok ({ data; generated_from_span } : span))
+              ctx st
+            "#
+        ),
+    ),
 ];
 
 impl<'a> GenerateCtx<'a> {

--- a/charon/src/bin/generate-asts/generate_ml/of_postcard.rs
+++ b/charon/src/bin/generate-asts/generate_ml/of_postcard.rs
@@ -53,21 +53,21 @@ const MANUAL_IMPLS: &[(&str, &str)] = &[
     ),
     (
         "HashConsed",
-        r#"Error "use `hash_consed_val_of_postcard` instead""#,
+        r#"Error "use `dedup_val_of_postcard` instead""#,
     ),
     (
         "Ty",
-        "hash_consed_val_of_postcard ctx.ty_hashcons_map ty_kind_of_postcard ctx st",
+        "dedup_val_of_postcard ctx.ty_dedup_tbl ty_kind_of_postcard ctx st",
     ),
     (
         "TraitRef",
-        "hash_consed_val_of_postcard ctx.tref_hashcons_map trait_ref_contents_of_postcard ctx st",
+        "dedup_val_of_postcard ctx.tref_dedup_tbl trait_ref_contents_of_postcard ctx st",
     ),
     (
         "ConstantExpr",
         indoc!(
             r#"
-            hash_consed_val_of_postcard ctx.constant_expr_hashcons_map
+            dedup_val_of_postcard ctx.constant_expr_dedup_tbl
               (fun ctx st ->
                 let* contents = pair_of_postcard constant_expr_kind_of_postcard ty_of_postcard ctx st in
                 let kind, ty = contents in
@@ -78,7 +78,7 @@ const MANUAL_IMPLS: &[(&str, &str)] = &[
     ),
     (
         "ExactSizeExpr",
-        "hash_consed_val_of_postcard ctx.exact_size_expr_hashcons_map exact_size_expr_kind_of_postcard ctx st",
+        "dedup_val_of_postcard ctx.exact_size_expr_dedup_tbl exact_size_expr_kind_of_postcard ctx st",
     ),
 ];
 

--- a/charon/src/bin/generate-asts/generate_ml/templates/OfJson.ml
+++ b/charon/src/bin/generate-asts/generate_ml/templates/OfJson.ml
@@ -51,10 +51,10 @@ type of_json_ctx = {
 let empty_of_json_ctx : of_json_ctx =
   {
     id_to_file_map = FileTbl.create 8;
-    ty_dedup_tbl = DedupTbl.create 1024;
+    ty_dedup_tbl = DedupTbl.create 2048;
     tref_dedup_tbl = DedupTbl.create 1024;
-    constant_expr_dedup_tbl = DedupTbl.create 1024;
-    exact_size_expr_dedup_tbl = DedupTbl.create 1024;
+    constant_expr_dedup_tbl = DedupTbl.create 64;
+    exact_size_expr_dedup_tbl = DedupTbl.create 16;
     span_dedup_tbl = DedupTbl.create 4096;
   }
 

--- a/charon/src/bin/generate-asts/generate_ml/templates/OfJson.ml
+++ b/charon/src/bin/generate-asts/generate_ml/templates/OfJson.ml
@@ -45,6 +45,7 @@ type of_json_ctx = {
   tref_dedup_tbl : trait_ref DedupTbl.t;
   constant_expr_dedup_tbl : constant_expr DedupTbl.t;
   exact_size_expr_dedup_tbl : exact_size_expr DedupTbl.t;
+  span_dedup_tbl : span DedupTbl.t;
 }
 
 let empty_of_json_ctx : of_json_ctx =
@@ -54,6 +55,7 @@ let empty_of_json_ctx : of_json_ctx =
     tref_dedup_tbl = DedupTbl.create 1024;
     constant_expr_dedup_tbl = DedupTbl.create 1024;
     exact_size_expr_dedup_tbl = DedupTbl.create 1024;
+    span_dedup_tbl = DedupTbl.create 4096;
   }
 
 (** Values that come up often are deduplicated in the serialized output: the first

--- a/charon/src/bin/generate-asts/generate_ml/templates/OfJson.ml
+++ b/charon/src/bin/generate-asts/generate_ml/templates/OfJson.ml
@@ -19,7 +19,7 @@ open Generated_GAst
 open Generated_FullAst
 open Scalars
 module FileId = IdGen ()
-module HashConsId = IdGen ()
+module DedupId = IdGen ()
 
 (** The default logger *)
 let log = Logging.llbc_of_json_logger
@@ -31,41 +31,50 @@ module FileTbl = Hashtbl.Make (struct
   let hash = Hashtbl.hash
 end)
 
+(** Table of the values that were deduplicated in the serialized output, by id. *)
+module DedupTbl = Hashtbl.Make (struct
+  type t = DedupId.id
+
+  let equal = DedupId.equal_id
+  let hash = Hashtbl.hash
+end)
+
 type of_json_ctx = {
   id_to_file_map : file FileTbl.t;
-  ty_hashcons_map : ty HashConsId.Map.t ref;
-  tref_hashcons_map : trait_ref HashConsId.Map.t ref;
-  constant_expr_hashcons_map : constant_expr HashConsId.Map.t ref;
-  exact_size_expr_hashcons_map : exact_size_expr HashConsId.Map.t ref;
+  ty_dedup_tbl : ty DedupTbl.t;
+  tref_dedup_tbl : trait_ref DedupTbl.t;
+  constant_expr_dedup_tbl : constant_expr DedupTbl.t;
+  exact_size_expr_dedup_tbl : exact_size_expr DedupTbl.t;
 }
 
 let empty_of_json_ctx : of_json_ctx =
   {
     id_to_file_map = FileTbl.create 8;
-    ty_hashcons_map = ref HashConsId.Map.empty;
-    tref_hashcons_map = ref HashConsId.Map.empty;
-    constant_expr_hashcons_map = ref HashConsId.Map.empty;
-    exact_size_expr_hashcons_map = ref HashConsId.Map.empty;
+    ty_dedup_tbl = DedupTbl.create 1024;
+    tref_dedup_tbl = DedupTbl.create 1024;
+    constant_expr_dedup_tbl = DedupTbl.create 1024;
+    exact_size_expr_dedup_tbl = DedupTbl.create 1024;
   }
 
-let hash_consed_val_of_json (map : 'a HashConsId.Map.t ref)
+(** Values that come up often are deduplicated in the serialized output: the first
+    occurrence of a value is serialized in full along with an id, and later
+    occurrences only mention that id. *)
+let dedup_val_of_json (tbl : 'a DedupTbl.t)
     (of_json : of_json_ctx -> json -> ('a, string) result) (ctx : of_json_ctx)
     (js : json) : ('a, string) result =
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Untagged", json) ] -> of_json ctx json
-    | `Assoc [ ("HashConsedValue", `List [ `Int id; json ]) ] ->
+    | `Assoc [ ("Value", `List [ `Int id; json ]) ] ->
         let* v = of_json ctx json in
-        let id = HashConsId.of_int id in
-        map := HashConsId.Map.add id v !map;
+        DedupTbl.replace tbl (DedupId.of_int id) v;
         Ok v
     | `Assoc [ ("Deduplicated", `Int id) ] -> begin
-        let id = HashConsId.of_int id in
-        match HashConsId.Map.find_opt id !map with
+        match DedupTbl.find_opt tbl (DedupId.of_int id) with
         | Some v -> Ok v
         | None ->
             Error
-              "Hash-consing key not found; there is a serialization mismatch \
+              "Deduplication key not found; there is a serialization mismatch \
                between Rust and OCaml"
       end
     | _ -> Error "")

--- a/charon/src/bin/generate-asts/generate_ml/templates/OfPostcard.ml
+++ b/charon/src/bin/generate-asts/generate_ml/templates/OfPostcard.ml
@@ -18,7 +18,7 @@ open Generated_GAst
 open Generated_FullAst
 open Scalars
 module FileId = IdGen ()
-module HashConsId = IdGen ()
+module DedupId = IdGen ()
 
 module FileTbl = Hashtbl.Make (struct
   type t = FileId.id
@@ -27,46 +27,57 @@ module FileTbl = Hashtbl.Make (struct
   let hash = Hashtbl.hash
 end)
 
+(** Table of the values that were deduplicated in the serialized output, by id. *)
+module DedupTbl = Hashtbl.Make (struct
+  type t = DedupId.id
+
+  let equal = DedupId.equal_id
+  let hash = Hashtbl.hash
+end)
+
 type of_postcard_ctx = {
   id_to_file_map : file FileTbl.t;
-  ty_hashcons_map : ty HashConsId.Map.t ref;
-  tref_hashcons_map : trait_ref HashConsId.Map.t ref;
-  constant_expr_hashcons_map : constant_expr HashConsId.Map.t ref;
-  exact_size_expr_hashcons_map : exact_size_expr HashConsId.Map.t ref;
+  ty_dedup_tbl : ty DedupTbl.t;
+  tref_dedup_tbl : trait_ref DedupTbl.t;
+  constant_expr_dedup_tbl : constant_expr DedupTbl.t;
+  exact_size_expr_dedup_tbl : exact_size_expr DedupTbl.t;
 }
 
 let empty_of_postcard_ctx : of_postcard_ctx =
   {
     id_to_file_map = FileTbl.create 8;
-    ty_hashcons_map = ref HashConsId.Map.empty;
-    tref_hashcons_map = ref HashConsId.Map.empty;
-    constant_expr_hashcons_map = ref HashConsId.Map.empty;
-    exact_size_expr_hashcons_map = ref HashConsId.Map.empty;
+    ty_dedup_tbl = DedupTbl.create 1024;
+    tref_dedup_tbl = DedupTbl.create 1024;
+    constant_expr_dedup_tbl = DedupTbl.create 1024;
+    exact_size_expr_dedup_tbl = DedupTbl.create 1024;
   }
 
-let hash_consed_val_of_postcard (map : 'a HashConsId.Map.t ref)
+(** Values that come up often are deduplicated in the serialized output: the first
+    occurrence of a value is serialized in full along with an id, and later
+    occurrences only mention that id. *)
+let dedup_val_of_postcard (tbl : 'a DedupTbl.t)
     (of_postcard : of_postcard_ctx -> postcard_state -> ('a, string) result)
     (ctx : of_postcard_ctx) (st : postcard_state) : ('a, string) result =
   combine_error_msgs st __FUNCTION__
     (let* tag = int_of_postcard ctx st in
      match tag with
      | 0 ->
-         let* id = HashConsId.id_of_postcard ctx st in
+         let* id = DedupId.id_of_postcard ctx st in
          let* v = of_postcard ctx st in
-         map := HashConsId.Map.add id v !map;
+         DedupTbl.replace tbl id v;
          Ok v
      | 1 ->
-         let* id = HashConsId.id_of_postcard ctx st in
+         let* id = DedupId.id_of_postcard ctx st in
          begin
-           match HashConsId.Map.find_opt id !map with
+           match DedupTbl.find_opt tbl id with
            | Some v -> Ok v
            | None ->
                Error
-                 "Hash-consing key not found; there is a serialization mismatch \
+                 "Deduplication key not found; there is a serialization mismatch \
                   between Rust and OCaml"
          end
      | 2 -> of_postcard ctx st
-     | _ -> Error "invalid hash-consed representation")
+     | _ -> Error "invalid deduplicated value representation")
 
 let path_buf_of_postcard = string_of_postcard
 

--- a/charon/src/bin/generate-asts/generate_ml/templates/OfPostcard.ml
+++ b/charon/src/bin/generate-asts/generate_ml/templates/OfPostcard.ml
@@ -47,10 +47,10 @@ type of_postcard_ctx = {
 let empty_of_postcard_ctx : of_postcard_ctx =
   {
     id_to_file_map = FileTbl.create 8;
-    ty_dedup_tbl = DedupTbl.create 1024;
+    ty_dedup_tbl = DedupTbl.create 2048;
     tref_dedup_tbl = DedupTbl.create 1024;
-    constant_expr_dedup_tbl = DedupTbl.create 1024;
-    exact_size_expr_dedup_tbl = DedupTbl.create 1024;
+    constant_expr_dedup_tbl = DedupTbl.create 64;
+    exact_size_expr_dedup_tbl = DedupTbl.create 16;
     span_dedup_tbl = DedupTbl.create 4096;
   }
 

--- a/charon/src/bin/generate-asts/generate_ml/templates/OfPostcard.ml
+++ b/charon/src/bin/generate-asts/generate_ml/templates/OfPostcard.ml
@@ -41,6 +41,7 @@ type of_postcard_ctx = {
   tref_dedup_tbl : trait_ref DedupTbl.t;
   constant_expr_dedup_tbl : constant_expr DedupTbl.t;
   exact_size_expr_dedup_tbl : exact_size_expr DedupTbl.t;
+  span_dedup_tbl : span DedupTbl.t;
 }
 
 let empty_of_postcard_ctx : of_postcard_ctx =
@@ -50,6 +51,7 @@ let empty_of_postcard_ctx : of_postcard_ctx =
     tref_dedup_tbl = DedupTbl.create 1024;
     constant_expr_dedup_tbl = DedupTbl.create 1024;
     exact_size_expr_dedup_tbl = DedupTbl.create 1024;
+    span_dedup_tbl = DedupTbl.create 4096;
   }
 
 (** Values that come up often are deduplicated in the serialized output: the first

--- a/charon/src/bin/generate-asts/generate_ml/util.rs
+++ b/charon/src/bin/generate-asts/generate_ml/util.rs
@@ -5,21 +5,6 @@ use std::collections::{HashMap, HashSet};
 
 use super::GenerateCtx;
 
-/// `Name` is a complex datastructure; to inspect it we serialize it a little bit.
-pub fn repr_name(n: &Name) -> String {
-    n.name
-        .iter()
-        .map(|path_elem| match path_elem {
-            PathElem::Ident(i, _) => i.clone(),
-            PathElem::Impl(..) => "<impl>".to_string(),
-            PathElem::Instantiated(..) => "<mono>".to_string(),
-            PathElem::Target(target) => target.clone(),
-            PathElem::Builtin(BuiltinPathElem::Tuple(n), _) => format!("<tuple_{n}>"),
-            PathElem::Builtin(builtin, _) => format!("<{}>", builtin.ident()),
-        })
-        .join("::")
-}
-
 pub fn make_ocaml_ident(name: &str) -> String {
     let leading_underscores = name.len() - name.trim_start_matches('_').len();
     let mut name = "_".repeat(leading_underscores) + &name.to_case(Case::Snake);
@@ -162,7 +147,10 @@ impl<'a> GenerateCtx<'a> {
                                 self.type_to_ocaml_ident(tdecl)
                             } else {
                                 let name = self.crate_data.item_name(tref.id);
-                                eprintln!("Warning: type {} missing from llbc", repr_name(name));
+                                eprintln!(
+                                    "Warning: type {} missing from llbc",
+                                    name.debug_repr(self.crate_data)
+                                );
                                 name.short_str().unwrap().to_lowercase()
                             };
                         if base_ty == "vec" {

--- a/charon/src/bin/generate-asts/generate_rust.rs
+++ b/charon/src/bin/generate-asts/generate_rust.rs
@@ -380,17 +380,7 @@ impl<'a> Generator<'a> {
         self.crate_data[id]
             .item_meta
             .name
-            .name
-            .iter()
-            .map(|elem| match elem {
-                PathElem::Ident(name, _) => name.clone(),
-                PathElem::Impl(_) => "<impl>".to_string(),
-                PathElem::Instantiated(_) => "<mono>".to_string(),
-                PathElem::Target(target) => target.clone(),
-                PathElem::Builtin(BuiltinPathElem::Tuple(n), _) => format!("<tuple_{n}>"),
-                PathElem::Builtin(builtin, _) => format!("<{}>", builtin.ident()),
-            })
-            .join("::")
+            .debug_repr(self.crate_data)
     }
 
     fn datatype_for(&self, id: TypeDeclId) -> Option<&RustcDatatype> {

--- a/charon/src/bin/generate-asts/main.rs
+++ b/charon/src/bin/generate-asts/main.rs
@@ -18,6 +18,7 @@ fn run_charon(charon_llbc: &Path, rustc_datatypes: &generate_rust::RustcDatatype
     cmd.arg("--ullbc");
     cmd.arg("--start-from=charon_lib::ast::krate::TranslatedCrate");
     cmd.arg("--start-from=charon_lib::ast::bodies::unstructured::BodyContents");
+    cmd.arg("--start-from=charon_lib::ast::meta::spans::SerializedSpan");
     cmd.arg("--exclude=charon_lib::utils::hash_by_addr::HashByAddr");
     for path in rustc_datatypes.paths_to_start_from() {
         cmd.arg(format!("--start-from={path}"));
@@ -52,6 +53,23 @@ fn translate_charon_itself(
         .with_context(|| format!("Failed to deserialize {}", charon_llbc.display()))
 }
 
+/// Substitute the declaration of `Span` (optimised for low memory) with that of `SerializedSpan`,
+/// so OCaml doesn't deal with bit manipulations.
+fn use_serialized_span(crate_data: &mut TranslatedCrate) -> Result<()> {
+    let find = |name: &str| {
+        crate_data
+            .type_decls
+            .iter()
+            .find(|ty| ty.item_meta.name.debug_repr(crate_data) == name)
+            .map(|ty| ty.def_id)
+            .with_context(|| format!("Could not find type `{name}`"))
+    };
+    let serialized_span = find("charon_lib::ast::meta::spans::SerializedSpan")?;
+    let span = find("charon_lib::ast::meta::spans::Span")?;
+    crate_data.type_decls[span].kind = crate_data.type_decls[serialized_span].kind.clone();
+    Ok(())
+}
+
 fn main() -> Result<()> {
     let dir = PathBuf::from("src/bin/generate-asts");
     let generated_dir = dir.join("generated");
@@ -59,7 +77,8 @@ fn main() -> Result<()> {
         .with_context(|| format!("Failed to create {}", generated_dir.display()))?;
 
     let rustc_datatypes = generate_rust::RustcDatatypes::new();
-    let crate_data = translate_charon_itself(&generated_dir, &rustc_datatypes)?;
+    let mut crate_data = translate_charon_itself(&generated_dir, &rustc_datatypes)?;
+    use_serialized_span(&mut crate_data)?;
 
     let ml_output_dir = if std::env::var("IN_CI").as_deref() == Ok("1") {
         generated_dir

--- a/charon/src/errors.rs
+++ b/charon/src/errors.rs
@@ -75,7 +75,7 @@ impl Error {
 
     pub(crate) fn render(&self, krate: &TranslatedCrate, level: Level) -> String {
         use annotate_snippets::*;
-        let span = self.span.data;
+        let span = self.span.data();
 
         let mut group = Group::with_title(level.primary_title(&self.msg));
         let origin;
@@ -90,8 +90,8 @@ impl Error {
             } else {
                 // Show just the file and line/col.
                 let origin = Origin::path(&origin)
-                    .line(span.beg.line)
-                    .char_column(span.beg.col + 1);
+                    .line(span.beg.line as usize)
+                    .char_column(span.beg.col as usize + 1);
                 group = group.element(origin);
             }
         }
@@ -304,7 +304,7 @@ impl ErrorCtx {
                 DepNode::External(_) => None,
                 DepNode::Local(_, span) => Some(*span),
             })
-            .into_group_map_by(|span| span.data.file_id);
+            .into_group_map_by(|span| span.data().file_id);
 
         // Collect to a `Vec` to be able to sort it and to borrow `origin` (needed by
         // `Snippet::source`).
@@ -322,16 +322,15 @@ impl ErrorCtx {
         by_file.sort_by_key(|(file_id, ..)| *file_id);
 
         let level = Level::NOTE;
-        let snippets = by_file.iter().map(|(_, origin, source, spans)| {
-            Snippet::source(*source)
-                .path(origin)
-                .fold(true)
-                .annotations(
-                    spans
-                        .iter()
-                        .map(|span| AnnotationKind::Context.span(span.data.to_byte_range(source))),
-                )
-        });
+        let snippets =
+            by_file.iter().map(|(_, origin, source, spans)| {
+                Snippet::source(*source)
+                    .path(origin)
+                    .fold(true)
+                    .annotations(spans.iter().map(|span| {
+                        AnnotationKind::Context.span(span.data().to_byte_range(source))
+                    }))
+            });
 
         let msg = format!(
             "the error occurred when translating `{}`, \

--- a/charon/src/export.rs
+++ b/charon/src/export.rs
@@ -32,7 +32,7 @@ impl Serialize for CrateData {
         if self.translated.options.no_dedup_serialized_ast {
             self.serialize_state(&(), serializer)
         } else {
-            let state = HashConsDedupSerializer::default();
+            let state = DedupSerializer::default();
             self.serialize_state(&state, serializer)
         }
     }
@@ -44,7 +44,7 @@ impl<'de> Deserialize<'de> for CrateData {
         D: Deserializer<'de>,
     {
         // Always provide the state, just in case.
-        let state = HashConsDedupSerializer::default();
+        let state = DedupSerializer::default();
         Self::deserialize_state(&state, deserializer)
     }
 }

--- a/charon/src/ids/mod.rs
+++ b/charon/src/ids/mod.rs
@@ -21,15 +21,14 @@ macro_rules! generate_index_type {
     ($name:ident, $pretty_name:expr) => {
         index_vec::define_index_type! {
             #[derive(Default, derive_generic_visitor::Drive, derive_generic_visitor::DriveMut, derive_generic_visitor::DriveTwo)]
-            pub struct $name = usize;
-            // Must fit in an u32 for serialization.
+            pub struct $name = u32;
             MAX_INDEX = u32::MAX as usize;
         }
 
         impl $name {
             pub const ZERO: Self = Self { _raw: 0 };
             pub const MAX: Self = Self {
-                _raw: Self::MAX_INDEX,
+                _raw: Self::MAX_INDEX as u32,
             };
             pub fn is_zero(&self) -> bool {
                 self.index() == 0

--- a/charon/src/transform/add_missing_info/recover_body_comments.rs
+++ b/charon/src/transform/add_missing_info/recover_body_comments.rs
@@ -37,11 +37,11 @@ impl IsStatement for ullbc_ast::Terminator {
 }
 
 struct CommentsCtx {
-    comments: Vec<(usize, Vec<String>)>,
+    comments: Vec<(u32, Vec<String>)>,
 }
 impl CommentsCtx {
     fn visit<St: IsStatement>(&mut self, st: &mut St) {
-        let st_line = st.get_span().data.beg.line;
+        let st_line = st.get_span().data().beg.line;
         self.comments = mem::take(&mut self.comments)
             .into_iter()
             .filter_map(|(line, comments)| {

--- a/charon/src/transform/add_missing_info/reorder_decls.rs
+++ b/charon/src/transform/add_missing_info/reorder_decls.rs
@@ -426,7 +426,7 @@ fn compute_reordered_decls(ctx: &mut TransformCtx) -> Vec<DeclarationGroup> {
     // then local items. Within a crate, we sort by file then by source order.
     let sort_by = |item: &ItemRef| {
         let item_meta = item.item_meta();
-        let span = item_meta.span.data;
+        let span = item_meta.span.data();
         let file_name_order = sorted_file_ids.get(span.file_id);
         (
             item_meta.is_local,

--- a/charon/src/utils.rs
+++ b/charon/src/utils.rs
@@ -1,7 +1,9 @@
 use itertools::Itertools;
 use macros::EnumAsGetters;
 
+pub mod dedup;
 pub mod hash_cons;
+pub use dedup::*;
 pub use hash_cons::*;
 
 pub static TAB_INCR: &str = "    ";

--- a/charon/src/utils/dedup.rs
+++ b/charon/src/utils/dedup.rs
@@ -1,0 +1,174 @@
+//! Deduplication of repeated values in the serialized output.
+//!
+//! Note that the deduplication scheme is order-dependent: it relies on the fact that
+//! serialization and deserialization traverse the value in the same order.
+
+use indexmap::IndexMap as SeqHashMap;
+use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
+use serde_state::{DeserializeState, SerializeState};
+use std::any::type_name;
+use std::cell::RefCell;
+use std::hash::Hash;
+
+use crate::utils::type_map::{Mappable, Mapper, TypeMap};
+
+/// Identifies a deduplicated value amongst the values of its type within a single serialized
+/// output. Ids are allocated in the order in which we serialize the values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DedupId(u32);
+
+/// A value that we deduplicate in the serialized output. We identify values by equality, hence
+/// the bounds.
+pub trait Dedup: Mappable + Clone + Eq + Hash {}
+impl<T> Dedup for T where T: Mappable + Clone + Eq + Hash {}
+
+/// The state threaded through (de)serialization to deduplicate values. Use `()` to serialize
+/// values normally and [`DedupSerializer`] to deduplicate them.
+pub trait DedupSerializerState: Sized {
+    /// Record that we're serializing this value. Returns `None` if we're not deduplicating
+    /// values, `Some(Ok(id))` the first time we meet a given value (it must then be serialized
+    /// in full), and `Some(Err(id))` afterwards (only the id must be serialized).
+    fn record_serialized<T: Dedup>(&self, value: &T) -> Option<Result<DedupId, DedupId>>;
+    /// Record that we deserialized the value with this id.
+    fn record_deserialized<T: Dedup>(&self, id: DedupId, value: T);
+    /// Find the previously-deserialized value with that id.
+    fn get_deserialized<T: Dedup>(&self, id: DedupId) -> Option<T>;
+}
+
+/// Don't deduplicate anything.
+impl DedupSerializerState for () {
+    fn record_serialized<T: Dedup>(&self, _value: &T) -> Option<Result<DedupId, DedupId>> {
+        None
+    }
+    fn record_deserialized<T: Dedup>(&self, _id: DedupId, _value: T) {}
+    fn get_deserialized<T: Dedup>(&self, _id: DedupId) -> Option<T> {
+        None
+    }
+}
+
+struct SerializeTableMapper;
+impl Mapper for SerializeTableMapper {
+    type Value<T: Mappable> = FxHashMap<T, DedupId>;
+}
+struct DeserializeTableMapper;
+impl Mapper for DeserializeTableMapper {
+    type Value<T: Mappable> = SeqHashMap<DedupId, T>;
+}
+
+/// Deduplicate the values of each type, in one table per type.
+#[derive(Default)]
+pub struct DedupSerializer {
+    // Table used for serialization: the values we've already emitted, with the id we gave them.
+    ser: RefCell<TypeMap<SerializeTableMapper>>,
+    // Table used for deserialization: the values we've read so far, by id.
+    de: RefCell<TypeMap<DeserializeTableMapper>>,
+}
+
+impl DedupSerializerState for DedupSerializer {
+    fn record_serialized<T: Dedup>(&self, value: &T) -> Option<Result<DedupId, DedupId>> {
+        let mut ser = self.ser.borrow_mut();
+        let table = ser.or_default::<T>();
+        Some(match table.get(value) {
+            Some(&id) => Err(id),
+            None => {
+                let id = DedupId(table.len().try_into().unwrap());
+                table.insert(value.clone(), id);
+                Ok(id)
+            }
+        })
+    }
+    fn record_deserialized<T: Dedup>(&self, id: DedupId, value: T) {
+        self.de.borrow_mut().or_default::<T>().insert(id, value);
+    }
+    fn get_deserialized<T: Dedup>(&self, id: DedupId) -> Option<T> {
+        self.de
+            .borrow()
+            .get::<T>()
+            .and_then(|table| table.get(&id))
+            .cloned()
+    }
+}
+
+/// How we represent a deduplicated value in the serialized output. `T` is the serialized form of
+/// the value.
+#[derive(Serialize, Deserialize, SerializeState, DeserializeState)]
+#[serde_state(state_implements = DedupSerializerState)]
+pub enum SerDedup<T> {
+    /// A value represented normally, accompanied by its id. This is emitted the first time we
+    /// serialize a given value: subsequent times will use `SerDedup::Deduplicated` instead.
+    Value(#[serde_state(stateless)] DedupId, T),
+    /// A value represented by its id. The actual value must have been emitted as a
+    /// `SerDedup::Value` with that same id earlier.
+    #[serde_state(stateless)]
+    Deduplicated(DedupId),
+    /// A plain value without an id, emitted when we're not deduplicating.
+    Untagged(T),
+}
+
+/// Serialize `value`, deduplicating it if the state says so. `repr` is the serialized form of
+/// `value`, only used the first time we meet it.
+pub fn serialize_dedup<T, R, State, S>(
+    value: &T,
+    repr: R,
+    state: &State,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    T: Dedup,
+    R: SerializeState<State>,
+    State: DedupSerializerState,
+    S: serde::Serializer,
+{
+    let repr = match state.record_serialized(value) {
+        Some(Ok(id)) => SerDedup::Value(id, repr),
+        Some(Err(id)) => SerDedup::Deduplicated(id),
+        None => SerDedup::Untagged(repr),
+    };
+    repr.serialize_state(state, serializer)
+}
+
+/// Deserialize a value that may have been deduplicated. `build` reconstructs the value from its
+/// serialized form.
+pub fn deserialize_dedup<'de, T, R, State, D>(
+    state: &State,
+    deserializer: D,
+    build: impl FnOnce(R) -> T,
+) -> Result<T, D::Error>
+where
+    T: Dedup,
+    R: DeserializeState<'de, State>,
+    State: DedupSerializerState,
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+    Ok(
+        match SerDedup::<R>::deserialize_state(state, deserializer)? {
+            SerDedup::Value(id, repr) => {
+                let value = build(repr);
+                state.record_deserialized(id, value.clone());
+                value
+            }
+            SerDedup::Deduplicated(id) => state.get_deserialized(id).ok_or_else(|| {
+                let msg = format!(
+                    "can't deserialize deduplicated value of type {}; \
+                were you careful with managing the deduplication state?",
+                    type_name::<T>()
+                );
+                D::Error::custom(msg)
+            })?,
+            SerDedup::Untagged(repr) => build(repr),
+        },
+    )
+}
+
+/// The error we report when a deduplicated value is deserialized with serde's stateless
+/// `Deserialize` impl, which can't resolve the ids.
+pub fn stateless_deserialize_error<T>() -> String {
+    format!(
+        "trying to deserialize a deduplicated value using serde's `{ty}::deserialize` method. \
+        This won't work, use serde_state's \
+        `{ty}::deserialize_state(&DedupSerializer::default(), _)` instead",
+        ty = type_name::<T>(),
+    )
+}

--- a/charon/src/utils/hash_cons.rs
+++ b/charon/src/utils/hash_cons.rs
@@ -1,5 +1,4 @@
 use derive_generic_visitor::{Drive, DriveMut, DriveTwo, Visit, VisitMut, VisitTwo};
-use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 use std::ops::{ControlFlow, Deref};
 use std::sync::Arc;
@@ -42,10 +41,6 @@ impl<T: Ord> Ord for HashConsed<T> {
 pub trait HashConsable: Hash + PartialEq + Eq + Clone + Mappable {}
 impl<T> HashConsable for T where T: Hash + PartialEq + Eq + Clone + Mappable {}
 
-/// Unique id identifying a hashconsed value amongst all hashconsed values.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct HashConsId(u64);
-
 // Private module that contains the static we'll use as interning map. A value of type
 // `HashCons` MUST NOT be created in any other way than this table, else hashing and euqality
 // on it will be broken. Note that this likely means that if a crate uses charon both as a
@@ -54,20 +49,13 @@ pub struct HashConsId(u64);
 mod intern_table {
     use rustc_hash::FxBuildHasher;
     use std::borrow::Borrow;
-    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, LazyLock, RwLock};
 
-    use super::{HashConsId, HashConsable, HashConsed};
+    use super::{HashConsable, HashConsed};
     use crate::utils::hash_by_addr::HashByAddr;
     use crate::utils::type_map::{Mappable, Mapper, TypeMap};
 
-    type SeqHashMap<K, V> = indexmap::IndexMap<K, V, FxBuildHasher>;
-
-    // Only way we create a `HashConsId`.
-    fn fresh_id() -> HashConsId {
-        static ID: AtomicU64 = AtomicU64::new(0);
-        HashConsId(ID.fetch_add(1, Ordering::Relaxed))
-    }
+    type SeqHashSet<T> = indexmap::IndexSet<T, FxBuildHasher>;
 
     // This is a static mutable `SeqHashSet<Arc<T>>` that records for each `T` value a unique
     // `Arc<T>` that contains the same value. Values inside the set are hashed/compared
@@ -75,11 +63,9 @@ mod intern_table {
     // Once we've gotten an `Arc` out of the set however, we're sure that "T-equality"
     // implies address-equality, hence the `HashByAddr` wrapper preserves correct equality
     // and hashing behavior.
-    // Note that we also store a `HashConsId` for each item so this is a map instead of a set, but
-    // what matters is really the map keys.
     struct InternMapper;
     impl Mapper for InternMapper {
-        type Value<T: Mappable> = SeqHashMap<Arc<T>, HashConsId>;
+        type Value<T: Mappable> = SeqHashSet<Arc<T>>;
     }
     static INTERNED: LazyLock<RwLock<TypeMap<InternMapper>>> = LazyLock::new(Default::default);
 
@@ -92,19 +78,19 @@ mod intern_table {
     {
         // Fast read-only check.
         let arc = if let read_guard = INTERNED.read().unwrap()
-            && let Some(map) = read_guard.get::<T>()
-            && let Some((arc, _id)) = map.get_key_value(&inner)
+            && let Some(set) = read_guard.get::<T>()
+            && let Some(arc) = set.get(&inner)
         {
             arc.clone()
         } else {
             // Concurrent access is possible right here, so we have to check everything again.
             let mut write_guard = INTERNED.write().unwrap();
-            let map: &mut SeqHashMap<Arc<T>, _> = write_guard.or_default::<T>();
-            if let Some((arc, _id)) = map.get_key_value(&inner) {
+            let set: &mut SeqHashSet<Arc<T>> = write_guard.or_default::<T>();
+            if let Some(arc) = set.get(&inner) {
                 arc.clone()
             } else {
                 let arc: Arc<T> = inner.into();
-                map.insert(arc.clone(), fresh_id());
+                set.insert(arc.clone());
                 arc
             }
         };
@@ -130,7 +116,7 @@ mod intern_table {
             if Arc::strong_count(arc) != 2 {
                 return Err(f);
             }
-            if let Some((other_arc, _)) = write_guard.or_default::<T>().swap_remove_entry(&*arc) {
+            if let Some(other_arc) = write_guard.or_default::<T>().swap_take(&*arc) {
                 drop(other_arc);
             } else {
                 // Nothing was removed, early return.
@@ -148,17 +134,6 @@ mod intern_table {
         // meantime, we'll get a pointer to that.
         *x = HashConsed::from_arc(arc.clone());
         ret
-    }
-
-    /// Identify this value uniquely amongst values of its type. The id depends on insertion
-    /// order into the interning table which makes them in principle deterministic.
-    pub fn id<T: HashConsable>(x: &HashConsed<T>) -> HashConsId {
-        // `HashConsed` can only be constructed via `intern`, so we know this value exists in the
-        // table.
-        let read_guard = INTERNED.read().unwrap();
-        let map = read_guard.get::<T>().unwrap();
-        let (_arc, id) = map.get_key_value(&x.0.0).unwrap();
-        *id
     }
 }
 
@@ -189,10 +164,6 @@ where
                 ret
             }
         }
-    }
-
-    pub fn id(&self) -> HashConsId {
-        intern_table::id(self)
     }
 }
 
@@ -231,90 +202,13 @@ where
     }
 }
 
-/// `HashCons` supports serializing each value to a unique id in order to serialize
-/// highly-shared values without explosion.
-///
-/// Note that the deduplication scheme is highly order-dependent: we serialize the real value
-/// the first time it comes up, and use ids only subsequent times. This relies on the fact that
-/// `derive(Serialize, Deserialize)` traverse the value in the same order.
-pub use serialize::{HashConsDedupSerializer, HashConsSerializerState};
+/// `HashCons` values are deduplicated in the serialized output: see [`crate::utils::dedup`].
 mod serialize {
-    use indexmap::IndexMap as SeqHashMap;
     use serde::{Deserialize, Serialize};
     use serde_state::{DeserializeState, SerializeState};
-    use std::any::type_name;
-    use std::cell::RefCell;
-    use std::collections::HashSet;
 
-    use super::{HashConsId, HashConsable, HashConsed};
-    use crate::utils::type_map::{Mappable, Mapper, TypeMap};
-
-    pub trait HashConsSerializerState: Sized {
-        /// Record that this type is being serialized. Return `None` if we're not deduplicating
-        /// values, otherwise return whether this item was newly recorded.
-        fn record_serialized<T: Mappable>(&self, id: HashConsId) -> Option<bool>;
-        /// Record that we deserialized this type.
-        fn record_deserialized<T: Mappable>(&self, id: HashConsId, value: HashConsed<T>);
-        /// Find the previously-deserialized type with that id.
-        fn get_deserialized_val<T: Mappable>(&self, id: HashConsId) -> Option<HashConsed<T>>;
-    }
-
-    impl HashConsSerializerState for () {
-        fn record_serialized<T: Mappable>(&self, _id: HashConsId) -> Option<bool> {
-            None
-        }
-        fn record_deserialized<T: Mappable>(&self, _id: HashConsId, _value: HashConsed<T>) {}
-        fn get_deserialized_val<T: Mappable>(&self, _id: HashConsId) -> Option<HashConsed<T>> {
-            None
-        }
-    }
-
-    struct SerializeTableMapper;
-    impl Mapper for SerializeTableMapper {
-        type Value<T: Mappable> = HashSet<HashConsId>;
-    }
-    struct DeserializeTableMapper;
-    impl Mapper for DeserializeTableMapper {
-        type Value<T: Mappable> = SeqHashMap<HashConsId, HashConsed<T>>;
-    }
-    #[derive(Default)]
-    pub struct HashConsDedupSerializer {
-        // Table used for serialization.
-        ser: RefCell<TypeMap<SerializeTableMapper>>,
-        // Table used for deserialization.
-        de: RefCell<TypeMap<DeserializeTableMapper>>,
-    }
-    impl HashConsSerializerState for HashConsDedupSerializer {
-        fn record_serialized<T: Mappable>(&self, id: HashConsId) -> Option<bool> {
-            Some(self.ser.borrow_mut().or_default::<T>().insert(id))
-        }
-        fn record_deserialized<T: Mappable>(&self, id: HashConsId, val: HashConsed<T>) {
-            self.de.borrow_mut().or_default::<T>().insert(id, val);
-        }
-        fn get_deserialized_val<T: Mappable>(&self, id: HashConsId) -> Option<HashConsed<T>> {
-            self.de
-                .borrow()
-                .get::<T>()
-                .and_then(|map| map.get(&id))
-                .cloned()
-        }
-    }
-
-    /// A dummy enum used when serializing/deserializing a `HashConsed<T>`.
-    #[derive(Serialize, Deserialize, SerializeState, DeserializeState)]
-    #[serde_state(state_implements = HashConsSerializerState)]
-    enum SerRepr<T> {
-        /// A value represented normally, accompanied by its id. This is emitted the first time
-        /// we serialize a given value: subsequent times will use `SerRepr::Deduplicate`
-        /// instead.
-        HashConsedValue(#[serde_state(stateless)] HashConsId, T),
-        /// A value represented by its id. The actual value must have been emitted as a
-        /// `SerRepr::Value` with that same id earlier.
-        #[serde_state(stateless)]
-        Deduplicated(HashConsId),
-        /// A plain value without an id.
-        Untagged(T),
-    }
+    use super::{HashConsable, HashConsed};
+    use crate::utils::dedup::*;
 
     impl<T> Serialize for HashConsed<T>
     where
@@ -324,27 +218,21 @@ mod serialize {
         where
             S: serde::Serializer,
         {
-            SerRepr::Untagged(self.inner()).serialize(serializer)
+            SerDedup::Untagged(self.inner()).serialize(serializer)
         }
     }
-    /// Options for the state are `()` to serialize values normally and `HashConsDedupSerializer`
+    /// Options for the state are `()` to serialize values normally and `DedupSerializer`
     /// to deduplicate identical values in the serialized output.
     impl<T, State> SerializeState<State> for HashConsed<T>
     where
         T: SerializeState<State> + HashConsable,
-        State: HashConsSerializerState,
+        State: DedupSerializerState,
     {
         fn serialize_state<S>(&self, state: &State, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer,
         {
-            let hash_cons_id = self.id();
-            let repr = match state.record_serialized::<T>(hash_cons_id) {
-                Some(true) => SerRepr::HashConsedValue(hash_cons_id, self.inner()),
-                Some(false) => SerRepr::Deduplicated(hash_cons_id),
-                None => SerRepr::Untagged(self.inner()),
-            };
-            repr.serialize_state(state, serializer)
+            serialize_dedup(self, self.inner(), state, serializer)
         }
     }
 
@@ -357,50 +245,25 @@ mod serialize {
             D: serde::Deserializer<'de>,
         {
             use serde::de::Error;
-            let repr: SerRepr<T> = SerRepr::deserialize(deserializer)?;
+            let repr: SerDedup<T> = SerDedup::deserialize(deserializer)?;
             match repr {
-                SerRepr::HashConsedValue { .. } | SerRepr::Deduplicated { .. } => {
-                    let msg = format!(
-                        "trying to deserialize a deduplicated value using serde's `{ty}::deserialize` method. \
-                        This won't work, use serde_state's \
-                        `{ty}::deserialize_state(&HashConsDedupSerializer::default(), _)` instead",
-                        ty = type_name::<T>(),
-                    );
-                    Err(D::Error::custom(msg))
+                SerDedup::Value { .. } | SerDedup::Deduplicated { .. } => {
+                    Err(D::Error::custom(stateless_deserialize_error::<T>()))
                 }
-                SerRepr::Untagged(val) => Ok(HashConsed::new(val)),
+                SerDedup::Untagged(val) => Ok(HashConsed::new(val)),
             }
         }
     }
     impl<'de, T, State> DeserializeState<'de, State> for HashConsed<T>
     where
         T: DeserializeState<'de, State> + HashConsable,
-        State: HashConsSerializerState,
+        State: DedupSerializerState,
     {
         fn deserialize_state<D>(state: &State, deserializer: D) -> Result<Self, D::Error>
         where
             D: serde::Deserializer<'de>,
         {
-            use serde::de::Error;
-            let repr: SerRepr<T> = SerRepr::deserialize_state(state, deserializer)?;
-            Ok(match repr {
-                SerRepr::HashConsedValue(hash_cons_id, value) => {
-                    let val = HashConsed::new(value);
-                    state.record_deserialized(hash_cons_id, val.clone());
-                    val
-                }
-                SerRepr::Deduplicated(hash_cons_id) => {
-                    state.get_deserialized_val(hash_cons_id).ok_or_else(|| {
-                        let msg = format!(
-                            "can't deserialize deduplicated value of type {}; \
-                            were you careful with managing the deduplication state?",
-                            type_name::<T>()
-                        );
-                        D::Error::custom(msg)
-                    })?
-                }
-                SerRepr::Untagged(val) => HashConsed::new(val),
-            })
+            deserialize_dedup(state, deserializer, HashConsed::new)
         }
     }
 }
@@ -427,10 +290,11 @@ fn test_hash_cons_concurrent() {
 
 #[test]
 fn test_hash_cons_dedup() {
+    use crate::utils::dedup::DedupSerializer;
     use serde_state::{DeserializeState, SerializeState};
     type Ty = HashConsed<TyKind>;
     #[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeState, DeserializeState)]
-    #[serde_state(state = HashConsDedupSerializer)]
+    #[serde_state(state = DedupSerializer)]
     enum TyKind {
         Bool,
         Pair(Ty, Ty),
@@ -442,11 +306,11 @@ fn test_hash_cons_dedup() {
     let pair = HashConsed::new(TyKind::Pair(bool1.clone(), bool2));
     let triple = HashConsed::new(TyKind::Pair(bool1, pair));
 
-    let state = HashConsDedupSerializer::default();
+    let state = DedupSerializer::default();
     let json_val = triple
         .serialize_state(&state, serde_json::value::Serializer)
         .unwrap();
-    let state = HashConsDedupSerializer::default();
+    let state = DedupSerializer::default();
     let round_tripped = Ty::deserialize_state(&state, json_val).unwrap();
 
     assert_eq!(triple, round_tripped);

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -47,7 +47,7 @@ fn items_by_name<'c>(crate_data: &'c TranslatedCrate) -> HashMap<String, Item<'c
                 generics.trait_clauses = tdecl.implied_clauses.clone();
             }
             Item {
-                name_str: repr_name(crate_data, &item.item_meta().name),
+                name_str: item.item_meta().name.debug_repr(crate_data),
                 generics,
                 kind: item,
             }
@@ -66,7 +66,7 @@ fn type_decl() -> anyhow::Result<()> {
     )?;
     let type_decls = user_type_decls(&crate_data);
     assert_eq!(
-        repr_name(&crate_data, &type_decls[0].item_meta.name),
+        type_decls[0].item_meta.name.debug_repr(&crate_data),
         "test_crate::Struct"
     );
     Ok(())
@@ -158,14 +158,14 @@ fn file_name() -> anyhow::Result<()> {
     )?;
     let type_decls = user_type_decls(&crate_data);
     assert_eq!(
-        repr_name(&crate_data, &type_decls[0].item_meta.name),
+        type_decls[0].item_meta.name.debug_repr(&crate_data),
         "test_crate::Foo"
     );
     assert_eq!(
-        repr_name(&crate_data, &type_decls[1].item_meta.name),
+        type_decls[1].item_meta.name.debug_repr(&crate_data),
         "core::option::Option"
     );
-    let file_id = type_decls[1].item_meta.span.data.file_id;
+    let file_id = type_decls[1].item_meta.span.data().file_id;
     let file = &crate_data.files[file_id];
     assert_eq!(file.name.to_string(), "/rustc/library/core/src/option.rs");
     Ok(())
@@ -318,7 +318,8 @@ fn predicate_origins() -> anyhow::Result<()> {
         let clauses = &item.generics.trait_clauses;
         assert_eq!(origins.len(), clauses.len(), "failed for {item_name}");
         for (clause, (expected_origin, expected_trait_name)) in clauses.iter().zip(origins) {
-            let trait_name = trait_name(&crate_data, clause.trait_.skip_binder.id);
+            let trait_decl = &crate_data[clause.trait_.skip_binder.id];
+            let trait_name = trait_decl.item_meta.name.short_str().unwrap();
             assert_eq!(trait_name, expected_trait_name, "failed for {item_name}");
             assert_eq!(&clause.origin, &expected_origin, "failed for {item_name}");
         }
@@ -340,7 +341,8 @@ fn predicate_origins() -> anyhow::Result<()> {
     let clauses = &method.params.trait_clauses;
     assert_eq!(origins.len(), clauses.len(), "failed for trait_method");
     for (clause, (expected_origin, expected_trait_name)) in clauses.iter().zip(origins) {
-        let trait_name = trait_name(&crate_data, clause.trait_.skip_binder.id);
+        let trait_decl = &crate_data[clause.trait_.skip_binder.id];
+        let trait_name = trait_decl.item_meta.name.short_str().unwrap();
         assert_eq!(trait_name, expected_trait_name, "failed for trait_method");
         assert_eq!(&clause.origin, &expected_origin, "failed for trait_method");
     }
@@ -451,19 +453,19 @@ fn visibility() -> anyhow::Result<()> {
     )?;
     let type_decls = user_type_decls(&crate_data);
     assert_eq!(
-        repr_name(&crate_data, &type_decls[0].item_meta.name),
+        type_decls[0].item_meta.name.debug_repr(&crate_data),
         "test_crate::Pub"
     );
     assert!(type_decls[0].item_meta.attr_info.public);
     assert_eq!(
-        repr_name(&crate_data, &type_decls[1].item_meta.name),
+        type_decls[1].item_meta.name.debug_repr(&crate_data),
         "test_crate::Priv"
     );
     assert!(!type_decls[1].item_meta.attr_info.public);
     // Note how we think `PubInPriv` is public. It kind of is but there is no path to it. This is
     // probably fine.
     assert_eq!(
-        repr_name(&crate_data, &type_decls[2].item_meta.name),
+        type_decls[2].item_meta.name.debug_repr(&crate_data),
         "test_crate::private::PubInPriv"
     );
     assert!(type_decls[2].item_meta.attr_info.public);
@@ -739,7 +741,7 @@ fn adt_constructor_source() -> anyhow::Result<()> {
         .fun_decls
         .iter()
         .filter(|fun| matches!(fun.src, FunSource::AdtConstructor))
-        .map(|fun| repr_name(&crate_data, &fun.item_meta.name))
+        .map(|fun| fun.item_meta.name.debug_repr(&crate_data))
         .collect_vec();
     assert_eq!(
         constructor_names,
@@ -801,7 +803,7 @@ fn known_trait_method_call() -> anyhow::Result<()> {
     )?;
     let function = &crate_data.fun_decls[0];
     assert_eq!(
-        repr_name(&crate_data, &function.item_meta.name),
+        function.item_meta.name.debug_repr(&crate_data),
         "test_crate::use_default"
     );
     let body = &function.body.as_structured().unwrap().body;
@@ -823,7 +825,7 @@ fn known_trait_method_call() -> anyhow::Result<()> {
     // This is the function that gets called.
     let function = &crate_data.fun_decls[*id];
     assert_eq!(
-        repr_name(&crate_data, &function.item_meta.name),
+        function.item_meta.name.debug_repr(&crate_data),
         "test_crate::<impl Default for ??>::default"
     );
     let FunSource::TraitImpl { .. } = &function.src else {

--- a/charon/tests/dynamic-sized-type-info.rs
+++ b/charon/tests/dynamic-sized-type-info.rs
@@ -73,10 +73,7 @@ fn ptr_metadata() -> anyhow::Result<()> {
     let meta_kinds: SeqHashMap<String, &PtrMetadata> = crate_data
         .type_decls
         .iter()
-        .map(|td| {
-            let name = repr_name(&crate_data, &td.item_meta.name);
-            (name, &td.ptr_metadata)
-        })
+        .map(|td| (td.item_meta.name.debug_repr(&crate_data), &td.ptr_metadata))
         .collect();
     let str = serde_json::to_string_pretty(&meta_kinds)?;
     compare_or_overwrite(str, &PathBuf::from("./tests/ptr-metadata.json"))?;

--- a/charon/tests/layout.rs
+++ b/charon/tests/layout.rs
@@ -188,7 +188,7 @@ fn type_layout() -> anyhow::Result<()> {
         if let Some(layout) = tdecl.layout.get(&the_target)
             && let Some(discriminator) = &layout.discriminator
         {
-            let name = repr_name(&crate_data, &tdecl.item_meta.name);
+            let name = tdecl.item_meta.name.debug_repr(&crate_data);
             for (var_id, variant) in layout.variant_layouts.iter_enumerated() {
                 if layout.is_variant_uninhabited(var_id) {
                     if let Some(variant) = variant {
@@ -251,7 +251,7 @@ fn type_layout() -> anyhow::Result<()> {
             if !is_local {
                 return None;
             }
-            let name = repr_name(&crate_data, &tdecl.item_meta.name);
+            let name = tdecl.item_meta.name.debug_repr(&crate_data);
             let opt_layout = tdecl.layout.get(&the_target).cloned();
             let serializable = opt_layout.map(|l| WithState::new(l, &()));
             Some((name, serializable))

--- a/charon/tests/ptr-metadata.json
+++ b/charon/tests/ptr-metadata.json
@@ -1,5 +1,5 @@
 {
-  "<tuple_0>": "None",
+  "<unit>": "None",
   "test_crate::Alias": "Length",
   "test_crate::StrDst": "Length",
   "test_crate::SliceDst": "Length",

--- a/charon/tests/util/mod.rs
+++ b/charon/tests/util/mod.rs
@@ -6,7 +6,6 @@
 // module.
 #![allow(dead_code)]
 use assert_cmd::prelude::{CommandCargoExt, OutputAssertExt};
-use itertools::Itertools;
 use snapbox::filter::Filter;
 use std::fmt::Display;
 use std::path::Path;
@@ -103,39 +102,7 @@ pub fn translate_rust_text(
     Ok(crate_data.translated)
 }
 
-/// `Name` is a complex datastructure; to inspect it we serialize it a little bit.
-pub fn repr_name(crate_data: &TranslatedCrate, n: &Name) -> String {
-    n.name
-        .iter()
-        .map(|path_elem| match path_elem {
-            PathElem::Ident(i, _) => i.clone(),
-            PathElem::Impl(elem) => match elem {
-                ImplElem::Trait(impl_id) => match crate_data.trait_impls.get(*impl_id) {
-                    None => format!("<trait impl#{impl_id}>"),
-                    Some(timpl) => {
-                        let trait_name = trait_name(crate_data, timpl.impl_trait.id);
-                        format!("<impl {trait_name} for ??>")
-                    }
-                },
-                ImplElem::Ty(..) => "<inherent impl>".to_string(),
-            },
-            PathElem::Instantiated(..) => "<mono>".to_string(),
-            PathElem::Target(target) => target.clone(),
-            PathElem::Builtin(BuiltinPathElem::Tuple(n), _) => format!("<tuple_{n}>"),
-            PathElem::Builtin(builtin, _) => format!("<{}>", builtin.ident()),
-        })
-        .join("::")
-}
-
 pub fn repr_span(span: Span) -> String {
     let span_data = span.data;
     format!("{}-{}", span_data.beg, span_data.end)
-}
-
-pub fn trait_name(crate_data: &TranslatedCrate, trait_id: TraitDeclId) -> &str {
-    let tr = &crate_data.trait_decls[trait_id];
-    let PathElem::Ident(trait_name, _) = tr.item_meta.name.name.last().unwrap() else {
-        panic!()
-    };
-    trait_name
 }

--- a/charon/tests/util/mod.rs
+++ b/charon/tests/util/mod.rs
@@ -103,6 +103,6 @@ pub fn translate_rust_text(
 }
 
 pub fn repr_span(span: Span) -> String {
-    let span_data = span.data;
+    let span_data = span.data();
     format!("{}-{}", span_data.beg, span_data.end)
 }


### PR DESCRIPTION
Fixes #1115 

Make `Span` on the Rust side a single `u64`, to reduce the memory foot print of most types. To do this, we encode the span the following way:

| 63 | 62..47 | 47..27 | 27..17 | 17..10 | 10..0 |
| -- | -- | -- | -- | -- | -- |
| wide | file(16) | beg.line | beg.col | nb lines | end.col |

From compiling syn, serde and regex, a quick analysis shows that basically all spans are not wide (i.e. `generated_from_span` is `None`), and range over very small values. So we use this small layout for the very vast majority of cases, and if the span doesn't fit we set the upper bit (`wide`) to 1 and have a global table of 63-bit index to full span, using the pre-existing (large) AST.

In practice, basically all spans fit the u64 and don't need further work. The crate with the most translated spans, `syn`, with 800K spans, only had 36 wide spans in the global table.

This improves performance a bit and memory usage a lot! The numbers don't seem massive, but peak RSS includes rustc, which is about 70% of total memory usage. e.g. for `syn`, rustc's memory usage is of about 250MB, so we made Charon's usage go from ~200MB to ~150MB! 

| crate | time | peak RSS | charon's RSS |
| --- | -- | -- | -- | 
| regex | -1.4% |  −6.8% (235→219 MB)  | −19.3% (83→67 MB) |
| serde | −1.5% | −8.0% (249→229 MB)  | −18.9% (106→86 MB) | 
| syn | −1.8% | −10.7% (467→417 MB) |  −23.5% (213→163 MB) |

Small analysis, for the curious:

| observation | serde | regex | syn |
| --- | -- | -- | -- |
| spans with `generated_from_span` | < 1% | < 1% | < 1% | 
| `beg.line == end.line` | 90% | 90% | 89% |
| max column | 141 | 145 | 145 |
| max line | 4423 | 4401 | 4380 |

| crate | `Span`s constructed | distinct entries in `WIDE_SPANS` |
| --- | -- | -- |
| serde 1.0.228 | 246,402 | 12 |
| regex 1.11.1  | 135,786 | 25 |
| syn 2.0.104 | 800,203 | 36 |