### PR TITLE
Add `FunSource::AdtConstructor`

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.247"
+let supported_charon_version = "0.1.248"

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -150,6 +150,8 @@ and fn_operand =
 (** Where a given function came from. *)
 and fun_source =
   | NormalFun  (** A normal function. *)
+  | AdtConstructorFun
+      (** A synthetic function representing an ADT constructor. *)
   | TraitDefaultFun of trait_decl_ref * trait_method_id
       (** A default method in a trait declaration.
 

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -2633,6 +2633,7 @@ and fun_source_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | `String "Normal" -> Ok NormalFun
+    | `String "AdtConstructor" -> Ok AdtConstructorFun
     | `Assoc
         [
           ( "TraitDefault",

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -2215,21 +2215,22 @@ and fun_source_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (let* __tag = int_of_postcard ctx st in
      match __tag with
      | 0 -> Ok NormalFun
-     | 1 ->
+     | 1 -> Ok AdtConstructorFun
+     | 2 ->
          let* trait_ref = trait_decl_ref_of_postcard ctx st in
          let* item_id = trait_method_id_of_postcard ctx st in
          Ok (TraitDefaultFun (trait_ref, item_id))
-     | 2 ->
+     | 3 ->
          let* impl_ref = trait_impl_ref_of_postcard ctx st in
          let* trait_ref = trait_decl_ref_of_postcard ctx st in
          let* item_id = trait_method_id_of_postcard ctx st in
          let* reuses_default = bool_of_postcard ctx st in
          Ok (TraitImplFun (impl_ref, trait_ref, item_id, reuses_default))
-     | 3 -> Ok VTableShimFun
-     | 4 ->
+     | 4 -> Ok VTableShimFun
+     | 5 ->
          let* _0 = global_decl_ref_of_postcard ctx st in
          Ok (GlobalInitializerFun _0)
-     | 5 ->
+     | 6 ->
          let* dispatcher = fun_decl_ref_of_postcard ctx st in
          Ok (TargetDependentFun dispatcher)
      | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "charon"
-version = "0.1.247"
+version = "0.1.248"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -26,7 +26,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.247"
+version = "0.1.248"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/src/ast/items/fun_decl.rs
+++ b/charon/src/ast/items/fun_decl.rs
@@ -77,6 +77,8 @@ pub enum Abi {
 pub enum FunSource {
     /// A normal function.
     Normal,
+    /// A synthetic function representing an ADT constructor.
+    AdtConstructor,
     /// A default method in a trait declaration.
     TraitDefault {
         /// The trait declaration this item belongs to.

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -509,6 +509,8 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                 id: global_id,
                 generics: Box::new(self.outermost_generics().identity_args()),
             })
+        } else if matches!(def.kind(), hax::FullDefKind::Ctor { .. }) {
+            FunSource::AdtConstructor
         } else {
             match self.get_trait_item_source(span, def)? {
                 None => FunSource::Normal,

--- a/charon/src/transform/normalize/expand_associated_types.rs
+++ b/charon/src/transform/normalize/expand_associated_types.rs
@@ -1315,6 +1315,7 @@ impl VisitAstMut for UpdateItemBody<'_> {
     fn enter_fun_source(&mut self, kind: &mut FunSource) {
         match kind {
             FunSource::Normal
+            | FunSource::AdtConstructor
             | FunSource::GlobalInitializer(_)
             | FunSource::TargetDependent { .. }
             | FunSource::VTableShim => {}

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -720,6 +720,36 @@ fn declaration_groups() -> anyhow::Result<()> {
 }
 
 #[test]
+fn adt_constructor_source() -> anyhow::Result<()> {
+    let crate_data = translate(
+        r#"
+        struct TupleStruct(u32);
+        enum Enum {
+            Variant(u32),
+        }
+
+        fn constructor_refs() {
+            let _: fn(u32) -> TupleStruct = TupleStruct;
+            let _: fn(u32) -> Enum = Enum::Variant;
+        }
+        "#,
+    )?;
+
+    let constructor_names = crate_data
+        .fun_decls
+        .iter()
+        .filter(|fun| matches!(fun.src, FunSource::AdtConstructor))
+        .map(|fun| repr_name(&crate_data, &fun.item_meta.name))
+        .collect_vec();
+    assert_eq!(
+        constructor_names,
+        ["test_crate::TupleStruct", "test_crate::Enum::Variant"]
+    );
+
+    Ok(())
+}
+
+#[test]
 fn source_text() -> anyhow::Result<()> {
     let crate_data = translate(
         r#"


### PR DESCRIPTION
This PR was AI assisted and carefully reviewed.

If we write:
```rust
pub struct Wrapper<T>(T);

pub fn make_wrapper<T>(x: Option<T>) -> Option<Wrapper<T>> {
    x.map(Wrapper)
}
```

rustc introduces the following auxiliary function for the argument to `map`:
```rust
fn Wrapper(x: T) -> Wrapper<T> {
  Wrapper(x)
}
```

This PR introduces the corresponding `FunSource::AdtConstructor`.