### PR TITLE
Nested statics can't be turned into standalone globals

### DIFF
--- a/charon/src/bin/charon-driver/hax/constant_utils/uneval.rs
+++ b/charon/src/bin/charon-driver/hax/constant_utils/uneval.rs
@@ -259,11 +259,13 @@ fn op_to_const<'tcx, S: UnderOwnerState<'tcx>>(
         })
     };
     let kind = match ty.kind() {
-        // Detect statics
+        // Preserve references to statics. Nested statics are are synthetic items that make the
+        // rest of the machinery ICE, so we don't turn them into named globals here.
         _ if let Some(place) = op.as_mplace_or_imm().left()
             && let ptr = place.ptr()
             && let Some((alloc_id, _, _)) = ecx.ptr_get_alloc_id(ptr, 0).discard_err()
-            && let interpret::GlobalAlloc::Static(did) = tcx.global_alloc(alloc_id) =>
+            && let interpret::GlobalAlloc::Static(did) = tcx.global_alloc(alloc_id)
+            && let rustc_hir::def::DefKind::Static { nested: false, .. } = tcx.def_kind(did) =>
         {
             let item = translate_item_ref(s, did, ty::GenericArgsRef::default());
             ConstantExprKind::NamedGlobal(item)

--- a/charon/tests/ui/consts/issue-1413-nested-static.out
+++ b/charon/tests/ui/consts/issue-1413-nested-static.out
@@ -1,0 +1,49 @@
+# Final LLBC before serialization:
+
+struct () {}
+
+// Full name: test_crate::FOO
+fn FOO() -> &'static mut u32
+{
+    let _0: &'1 mut u32; // return
+    let _1: &'2 mut u32; // anonymous local
+    let _2: u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_1)
+    storage_live(_2)
+    _2 = const 42u32
+    _1 = &mut _2
+    _0 = &mut (*_1)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::FOO
+static FOO: &'static mut u32 = FOO()
+
+// Full name: test_crate::SHARED
+static SHARED: &'static u32 = &42u32
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let _1: *mut &'2 mut u32; // anonymous local
+    let _2: *mut &'3 mut u32; // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(_1)
+    storage_live(_2)
+    _2 = &raw mut FOO
+    _1 = move _2
+    (*(*_1)) = const 43u32
+    storage_dead(_1)
+    _0 = ()
+    storage_dead(_2)
+    return
+}
+
+
+

--- a/charon/tests/ui/consts/issue-1413-nested-static.rs
+++ b/charon/tests/ui/consts/issue-1413-nested-static.rs
@@ -1,0 +1,10 @@
+//@ charon-args=--consts=values
+
+static mut FOO: &mut u32 = &mut 42;
+static SHARED: &u32 = &42;
+
+fn main() {
+    unsafe {
+        *FOO = 43;
+    }
+}


### PR DESCRIPTION
They have a `DefId` but no type information; we could potentially PR rustc to add the type info but rn they can't become a `FullDefKind::Static`. Instead we let the rest of the eval machinery handle it. This could lose sharing if the same nexted `DefId` ends up in multiple places, I hope that can't happen ><

Fixes #1413.