### PR TITLE
Fix some bugs

### DIFF
--- a/charon/src/transform/mod.rs
+++ b/charon/src/transform/mod.rs
@@ -324,7 +324,9 @@ impl TransformCtx {
                     }
                 });
                 for pass in passes.iter() {
-                    pass.finalize(self);
+                    if pass.should_run(&self.options) {
+                        pass.finalize(self);
+                    }
                 }
             }
             Pass::FusedStructuredBody(passes) => {

--- a/charon/tests/ui/consts/ref-constant.out
+++ b/charon/tests/ui/consts/ref-constant.out
@@ -1,6 +1,20 @@
 # Final LLBC before serialization:
 
-struct () {}
+// Full name: test_crate::REF::{promoted_const}
+fn {promoted_const}() -> &'_ u32
+{
+    let _0: &'0 u32; // return
+    let _1: u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_1)
+    _1 = const 42u32
+    _0 = &_1
+    return
+}
+
+// Full name: test_crate::REF::{promoted_const}
+const {promoted_const}: &'_ u32 = {promoted_const}()
 
 // Full name: test_crate::REF
 fn REF() -> &'static u32
@@ -21,19 +35,6 @@ fn REF() -> &'static u32
 
 // Full name: test_crate::REF
 const REF: &'static u32 = REF()
-
-// Full name: test_crate::REF::{promoted_const}
-fn {promoted_const}() -> &'_ u32
-{
-    let _0: &'0 u32; // return
-    let _1: u32; // anonymous local
-
-    storage_live(_0)
-    storage_live(_1)
-    _1 = const 42u32
-    _0 = &_1
-    return
-}
 
 
 

--- a/charon/tests/ui/simple/promoted.out
+++ b/charon/tests/ui/simple/promoted.out
@@ -2,6 +2,22 @@
 
 struct () {}
 
+// Full name: test_crate::foo::{promoted_const}
+fn {promoted_const}() -> &'_ i32
+{
+    let _0: &'0 i32; // return
+    let _1: i32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_1)
+    _1 = const 42i32
+    _0 = &_1
+    return
+}
+
+// Full name: test_crate::foo::{promoted_const}
+const {promoted_const}: &'_ i32 = {promoted_const}()
+
 // Full name: test_crate::foo
 fn foo()
 {
@@ -18,19 +34,6 @@ fn foo()
     storage_dead(_1)
     _0 = const ()
     storage_dead(_2)
-    return
-}
-
-// Full name: test_crate::foo::{promoted_const}
-fn {promoted_const}() -> &'_ i32
-{
-    let _0: &'0 i32; // return
-    let _1: i32; // anonymous local
-
-    storage_live(_0)
-    storage_live(_1)
-    _1 = const 42i32
-    _0 = &_1
     return
 }
 


### PR DESCRIPTION
Fix three bugs encountering when evaluating Charon

- The `Discriminator` translation was wrong, and wasn't marking some tags as invalid. I redid the whole translation there, copying more closely what MiniRust does. I think it also reads a bit more clearly.
- Fix a panic with closures in const and static contexts, which had the wrong generics applied to them, causing a panic.
- Fix globals being removed by the const inlining pass even in the presence of `--raw-consts`