### PR TITLE
Improve unsizing algorithm for `Rc` & co

### DIFF
--- a/charon/src/bin/charon-driver/hax/types/ty.rs
+++ b/charon/src/bin/charon-driver/hax/types/ty.rs
@@ -990,17 +990,37 @@ pub fn compute_unsizing_metadata<'tcx, S: UnderOwnerState<'tcx>>(
     src_ty: ty::Ty<'tcx>,
     tgt_ty: ty::Ty<'tcx>,
 ) -> UnsizingMetadata {
-    // TODO: to properly find out what field we want, we should use the query
-    // `coerce_unsized_info`, which we call recursively to get the list of fields
-    // to go into until we reach a pointer/reference.
-    // We should also pass this list of field IDs in the unsizing metadata.
-
-    let (Some(src_ty), Some(tgt_ty)) = (src_ty.builtin_deref(true), tgt_ty.builtin_deref(true))
-    else {
-        return UnsizingMetadata::Unknown;
-    };
+    // TODO: also pass the list of fields we go through in the unsizing metadata.
 
     let tcx = s.base().tcx;
+    let (Some(src_ty), Some(tgt_ty)) = (src_ty.builtin_deref(true), tgt_ty.builtin_deref(true))
+    else {
+        // Like `rustc_monomorphize::custom_coerce_unsize_info`: for a `CoerceUnsized` struct
+        // (e.g. `Rc`), find the impl and recurse into the field it coerces.
+        return match (src_ty.kind(), tgt_ty.kind()) {
+            (ty::Adt(def, src_args), ty::Adt(_, tgt_args)) => {
+                let coerce_trait = tcx.lang_items().coerce_unsized_trait().unwrap();
+                let tref = ty::TraitRef::new(tcx, coerce_trait, [src_ty, tgt_ty]);
+                let proof =
+                    s.with_predicate_searcher(|ps, ctx| ps.resolve(ctx, &ty::Binder::dummy(tref)));
+                let elaboration::TraitProofKind::Concrete(impl_ref) = &proof.contents().kind else {
+                    unreachable!("`CoerceUnsized` between ADTs is always proven by a concrete impl")
+                };
+                let info = tcx
+                    .coerce_unsized_info(impl_ref.def_id.real_rust_def_id())
+                    .unwrap();
+                // TODO: just accumulate this field index as we recurse down, for the consumer.
+                let ty::adjustment::CustomCoerceUnsized::Struct(i) = info.custom_kind.unwrap();
+                let field = &def.non_enum_variant().fields[i];
+                let typing_env = s.typing_env();
+                let src_ty = normalize(tcx, typing_env, field.ty(tcx, src_args));
+                let tgt_ty = normalize(tcx, typing_env, field.ty(tcx, tgt_args));
+                compute_unsizing_metadata(s, src_ty, tgt_ty)
+            }
+            (ty::Pat(a, _), ty::Pat(b, _)) => compute_unsizing_metadata(s, *a, *b),
+            _ => UnsizingMetadata::Unknown,
+        };
+    };
     let typing_env = s.typing_env();
     let (src_ty, tgt_ty) =
         tcx.struct_lockstep_tails_raw(src_ty, tgt_ty, |ty| normalize(tcx, typing_env, ty));

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -52,6 +52,45 @@ impl "impl_Copy_for_i32" Copy for i32 {
     non-dyn-compatible
 }
 
+// Full name: core::marker::Unsize
+#[lang_item(Unsize)]
+pub trait Unsize<Self, T>
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+// Full name: core::marker::CoercePointeeValidated
+#[lang_item(CoercePointeeValidated)]
+pub trait CoercePointeeValidated<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    vtable: core::marker::CoercePointeeValidated::{vtable}
+}
+
+// Full name: core::ops::unsize::CoerceUnsized
+#[lang_item(CoerceUnsized)]
+pub trait CoerceUnsized<Self, T>
+{
+    proof ImpliedClause0: (Self: Sized)
+    non-dyn-compatible
+}
+
+// Full name: core::ops::unsize::DispatchFromDyn
+#[lang_item(DispatchFromDyn)]
+pub trait DispatchFromDyn<Self, T>
+{
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (T: Sized)
+    non-dyn-compatible
+}
+
 // Full name: alloc::alloc::Global
 #[lang_item(GlobalAlloc)]
 pub struct Global {}
@@ -63,8 +102,6 @@ pub opaque type Box<T>
 where
     TraitClause0: (T: MetaSized),
     TraitClause1: (type_error("removed allocator parameter"): Sized),
-
-struct () {}
 
 // Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
 unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
@@ -131,6 +168,132 @@ impl "impl_Display_for_String" Display for String {
     vtable: impl_Display_for_String::{vtable}
 }
 
+// Full name: alloc::sync::Arc
+#[diagnostic_item("Arc")]
+pub opaque type Arc<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+// Full name: alloc::sync::Arc::{impl Destruct for Arc<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Arc::drop_glue<'_0, T, A>(_1: &'_0 mut Arc<T>[TraitClause0, TraitClause1])
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TypeOutlives0: T: '_0,
+    TypeOutlives1: A: '_0,
+= <opaque>
+
+pub fn alloc::sync::{Arc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<T>(_1: T) -> Arc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+where
+    TraitClause0: (T: Sized),
+= <opaque>
+
+// Full name: test_crate::MyPtr
+struct MyPtr<T>
+where
+    TraitClause0: (T: MetaSized),
+{
+  _0: Box<T>[TraitClause0, {built_in impl Sized for Global}],
+}
+
+// Full name: test_crate::{impl CoercePointeeValidated for MyPtr<T>[TraitClause0]}
+impl<T> "impl_CoercePointeeValidated_for_MyPtr" CoercePointeeValidated for MyPtr<T>[TraitClause0]
+where
+    TraitClause0: (T: MetaSized),
+{
+    proof ImpliedClause0: (MyPtr<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for MyPtr<T>[TraitClause0]}
+    vtable: impl_CoercePointeeValidated_for_MyPtr::{vtable}<T>[TraitClause0]
+}
+
+// Full name: test_crate::{impl DispatchFromDyn<MyPtr<__S>[TraitClause1]> for MyPtr<T>[TraitClause0]}
+impl<T, __S> "impl_DispatchFromDyn_MyPtr_for_MyPtr" DispatchFromDyn<MyPtr<__S>[TraitClause1]> for MyPtr<T>[TraitClause0]
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (__S: MetaSized),
+    TraitClause2: (T: Unsize<__S>),
+{
+    proof ImpliedClause0: (MyPtr<T>[TraitClause0]: Sized) = {built_in impl Sized for MyPtr<T>[TraitClause0]}
+    proof ImpliedClause1: (MyPtr<__S>[TraitClause1]: Sized) = {built_in impl Sized for MyPtr<__S>[TraitClause1]}
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl CoerceUnsized<MyPtr<__S>[TraitClause1]> for MyPtr<T>[TraitClause0]}
+impl<T, __S> "impl_CoerceUnsized_MyPtr_for_MyPtr" CoerceUnsized<MyPtr<__S>[TraitClause1]> for MyPtr<T>[TraitClause0]
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (__S: MetaSized),
+    TraitClause2: (T: Unsize<__S>),
+{
+    proof ImpliedClause0: (MyPtr<T>[TraitClause0]: Sized) = {built_in impl Sized for MyPtr<T>[TraitClause0]}
+    non-dyn-compatible
+}
+
+// Full name: test_crate::MyPtr::{impl Destruct for MyPtr<T>[TraitClause0]}::drop_glue
+unsafe fn impl_Destruct_for_MyPtr::drop_glue<'_0, T>(_1: &'_0 mut MyPtr<T>[TraitClause0])
+where
+    TraitClause0: (T: MetaSized),
+    TypeOutlives0: T: '_0,
+{
+    let _0: (); // return
+    let _1: &'1 mut MyPtr<T>[TraitClause0]; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    drop[impl_Destruct_for_Box::drop_glue<'2, T, Global>[TraitClause0, {built_in impl Sized for Global}]] (*_1)._0
+    ↳⚡ storage_dead(_1)
+        unwind_continue
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::MyPtr::{impl Destruct for MyPtr<T>[TraitClause0]}
+impl<T> "impl_Destruct_for_MyPtr" Destruct for MyPtr<T>[TraitClause0]
+where
+    TraitClause0: (T: MetaSized),
+{
+    fn drop_glue<'_0_1> = impl_Destruct_for_MyPtr::drop_glue<'_0_1, T>[TraitClause0]
+    non-dyn-compatible
+}
+
+fn test_crate::{MyPtr<T>[TraitClause0::ImpliedClause0]}::new<T>(x: T) -> MyPtr<T>[TraitClause0::ImpliedClause0]
+where
+    TraitClause0: (T: Sized),
+{
+    let _0: MyPtr<T>[TraitClause0::ImpliedClause0]; // return
+    let x: T; // arg #1
+    let _2: Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]; // anonymous local
+    let _3: T; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    storage_live(_3)
+    _3 = move x
+    _2 = alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<T>[TraitClause0](move _3)
+    ↳⚡ conditional_drop[{built_in impl Destruct for T}::drop_glue<'0>] _3
+        ↳⚡ storage_dead(x)
+            unwind_terminate
+        conditional_drop[{built_in impl Destruct for T}::drop_glue<'2>] x
+        ↳⚡ storage_dead(x)
+            unwind_terminate
+        storage_dead(x)
+        unwind_continue
+    storage_dead(_3)
+    _0 = MyPtr { _0: move _2 }
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'1, T, Global>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]] _2
+    ↳⚡ conditional_drop[{built_in impl Destruct for T}::drop_glue<'2>] x
+        ↳⚡ storage_dead(x)
+            unwind_terminate
+        storage_dead(x)
+        unwind_continue
+    storage_dead(_2)
+    conditional_drop[{built_in impl Destruct for T}::drop_glue<'3>] x
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    storage_dead(x)
+    return
+}
+
 // Full name: test_crate::foo
 fn foo()
 {
@@ -145,18 +308,32 @@ fn foo()
     let _8: Rc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]; // anonymous local
     let _9: Rc<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]; // anonymous local
     let _10: [i32; 2usize]; // anonymous local
+    let _11: Arc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]; // anonymous local
+    let _12: Arc<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]; // anonymous local
+    let _13: [i32; 2usize]; // anonymous local
+    let _14: MyPtr<[i32]>[{built_in impl MetaSized for [i32]}]; // anonymous local
+    let _15: MyPtr<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}]; // anonymous local
+    let _16: [i32; 2usize]; // anonymous local
     let string: String; // local
-    let _12: &'8 (dyn Display + '9); // anonymous local
-    let _13: &'11 String; // anonymous local
-    let _14: &'12 String; // anonymous local
-    let _15: Box<(dyn Display + '17)>[{built_in impl MetaSized for (dyn Display + '19)}, {built_in impl Sized for Global}]; // anonymous local
-    let _16: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
-    let _17: String; // anonymous local
-    let _18: &'20 String; // anonymous local
-    let _19: Rc<(dyn Display + '25)>[{built_in impl MetaSized for (dyn Display + '27)}, {built_in impl Sized for Global}]; // anonymous local
-    let _20: Rc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
-    let _21: String; // anonymous local
-    let _22: &'28 String; // anonymous local
+    let _18: &'8 (dyn Display + '9); // anonymous local
+    let _19: &'11 String; // anonymous local
+    let _20: &'12 String; // anonymous local
+    let _21: Box<(dyn Display + '17)>[{built_in impl MetaSized for (dyn Display + '19)}, {built_in impl Sized for Global}]; // anonymous local
+    let _22: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
+    let _23: String; // anonymous local
+    let _24: &'20 String; // anonymous local
+    let _25: Rc<(dyn Display + '25)>[{built_in impl MetaSized for (dyn Display + '27)}, {built_in impl Sized for Global}]; // anonymous local
+    let _26: Rc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
+    let _27: String; // anonymous local
+    let _28: &'28 String; // anonymous local
+    let _29: Arc<(dyn Display + '33)>[{built_in impl MetaSized for (dyn Display + '35)}, {built_in impl Sized for Global}]; // anonymous local
+    let _30: Arc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
+    let _31: String; // anonymous local
+    let _32: &'36 String; // anonymous local
+    let _33: MyPtr<(dyn Display + '41)>[{built_in impl MetaSized for (dyn Display + '43)}]; // anonymous local
+    let _34: MyPtr<String>[{built_in impl MetaSized for String}]; // anonymous local
+    let _35: String; // anonymous local
+    let _36: &'44 String; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -173,7 +350,7 @@ fn foo()
     _2 = @ArrayToSliceShared<'_, i32, 2usize>[{built_in impl Sized for i32}](move _3)
     ↳⚡ undefined_behavior
     storage_dead(_3)
-    set_type(typeof(_2) <= &'30 [i32])
+    set_type(typeof(_2) <= &'46 [i32])
     storage_dead(_4)
     storage_dead(_2)
     storage_live(_5)
@@ -183,14 +360,14 @@ fn foo()
     _6 = alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<[i32; 2usize]>[{built_in impl Sized for [i32; 2usize]}](move _7)
     ↳⚡ unwind_continue
     _5 = unsize_cast<Box<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}], Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 2usize>(move _6)
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'31, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _6
-    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'33, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'47, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _6
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'49, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_7)
     storage_dead(_6)
     set_type(typeof(_5) <= Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'32, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'48, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
     ↳⚡ unwind_continue
     storage_dead(_5)
     storage_live(_8)
@@ -199,99 +376,199 @@ fn foo()
     _10 = copy array
     _9 = alloc::rc::{Rc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<[i32; 2usize]>[{built_in impl Sized for [i32; 2usize]}](move _10)
     ↳⚡ unwind_continue
-    _8 = unsize_cast<Rc<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}], Rc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], ?>(move _9)
-    conditional_drop[impl_Destruct_for_Rc::drop_glue<'34, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _9
-    ↳⚡ conditional_drop[impl_Destruct_for_Rc::drop_glue<'36, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _8
+    _8 = unsize_cast<Rc<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}], Rc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 2usize>(move _9)
+    conditional_drop[impl_Destruct_for_Rc::drop_glue<'50, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _9
+    ↳⚡ conditional_drop[impl_Destruct_for_Rc::drop_glue<'52, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _8
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_10)
     storage_dead(_9)
     set_type(typeof(_8) <= Rc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Rc::drop_glue<'35, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _8
+    conditional_drop[impl_Destruct_for_Rc::drop_glue<'51, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _8
     ↳⚡ unwind_continue
     storage_dead(_8)
+    storage_live(_11)
+    storage_live(_12)
+    storage_live(_13)
+    _13 = copy array
+    _12 = alloc::sync::{Arc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<[i32; 2usize]>[{built_in impl Sized for [i32; 2usize]}](move _13)
+    ↳⚡ unwind_continue
+    _11 = unsize_cast<Arc<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}], Arc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 2usize>(move _12)
+    conditional_drop[impl_Destruct_for_Arc::drop_glue<'53, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _12
+    ↳⚡ conditional_drop[impl_Destruct_for_Arc::drop_glue<'55, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _11
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_13)
+    storage_dead(_12)
+    set_type(typeof(_11) <= Arc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}])
+    conditional_drop[impl_Destruct_for_Arc::drop_glue<'54, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _11
+    ↳⚡ unwind_continue
+    storage_dead(_11)
+    storage_live(_14)
+    storage_live(_15)
+    storage_live(_16)
+    _16 = copy array
+    _15 = test_crate::{MyPtr<T>[TraitClause0::ImpliedClause0]}::new<[i32; 2usize]>[{built_in impl Sized for [i32; 2usize]}](move _16)
+    ↳⚡ unwind_continue
+    _14 = unsize_cast<MyPtr<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}], MyPtr<[i32]>[{built_in impl MetaSized for [i32]}], 2usize>(move _15)
+    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'56, [i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}]] _15
+    ↳⚡ conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'58, [i32]>[{built_in impl MetaSized for [i32]}]] _14
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_16)
+    storage_dead(_15)
+    set_type(typeof(_14) <= MyPtr<[i32]>[{built_in impl MetaSized for [i32]}])
+    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'57, [i32]>[{built_in impl MetaSized for [i32]}]] _14
+    ↳⚡ unwind_continue
+    storage_dead(_14)
     storage_live(string)
     string = alloc::string::{String}::new()
     ↳⚡ unwind_continue
     fake_read(string)
-    storage_live(_12)
-    storage_live(_13)
-    storage_live(_14)
-    _14 = &string
-    _13 = &(*_14)
-    _12 = unsize_cast<&'11 String, &'37 (dyn Display + '38), &impl_Display_for_String::{vtable}>(move _13)
-    storage_dead(_13)
-    set_type(typeof(_12) <= &'39 (dyn Display + '40))
-    storage_dead(_14)
-    storage_dead(_12)
-    storage_live(_15)
-    storage_live(_16)
-    storage_live(_17)
     storage_live(_18)
-    _18 = &string
-    _17 = impl_Clone_for_String::clone<'42>(move _18)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'43>] string
-        ↳⚡ unwind_terminate
-        unwind_continue
-    storage_dead(_18)
-    _16 = alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<String>[{built_in impl Sized for String}](move _17)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'44>] _17
-        ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'43>] string
-        ↳⚡ unwind_terminate
-        unwind_continue
-    _15 = unsize_cast<Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Box<(dyn Display + '45)>[{built_in impl MetaSized for (dyn Display + '47)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _16)
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'48, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _16
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] _17
-        ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_Box::drop_glue<'80, (dyn Display + '76), Global>[{built_in impl MetaSized for (dyn Display + '76)}, {built_in impl Sized for Global}]] _15
-        ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'43>] string
-        ↳⚡ unwind_terminate
-        unwind_continue
-    storage_dead(_17)
-    storage_dead(_16)
-    set_type(typeof(_15) <= Box<(dyn Display + '49)>[{built_in impl MetaSized for (dyn Display + '51)}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'64, (dyn Display + '60), Global>[{built_in impl MetaSized for (dyn Display + '60)}, {built_in impl Sized for Global}]] _15
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'43>] string
-        ↳⚡ unwind_terminate
-        unwind_continue
-    storage_dead(_15)
     storage_live(_19)
     storage_live(_20)
+    _20 = &string
+    _19 = &(*_20)
+    _18 = unsize_cast<&'11 String, &'59 (dyn Display + '60), &impl_Display_for_String::{vtable}>(move _19)
+    storage_dead(_19)
+    set_type(typeof(_18) <= &'61 (dyn Display + '62))
+    storage_dead(_20)
+    storage_dead(_18)
     storage_live(_21)
     storage_live(_22)
-    _22 = &string
-    _21 = impl_Clone_for_String::clone<'67>(move _22)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'43>] string
+    storage_live(_23)
+    storage_live(_24)
+    _24 = &string
+    _23 = impl_Clone_for_String::clone<'64>(move _24)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
         ↳⚡ unwind_terminate
         unwind_continue
+    storage_dead(_24)
+    _22 = alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<String>[{built_in impl Sized for String}](move _23)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'66>] _23
+        ↳⚡ unwind_terminate
+        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        ↳⚡ unwind_terminate
+        unwind_continue
+    _21 = unsize_cast<Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Box<(dyn Display + '67)>[{built_in impl MetaSized for (dyn Display + '69)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _22)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'70, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _22
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'87>] _23
+        ↳⚡ unwind_terminate
+        conditional_drop[impl_Destruct_for_Box::drop_glue<'102, (dyn Display + '98), Global>[{built_in impl MetaSized for (dyn Display + '98)}, {built_in impl Sized for Global}]] _21
+        ↳⚡ unwind_terminate
+        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_23)
     storage_dead(_22)
-    _20 = alloc::rc::{Rc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<String>[{built_in impl Sized for String}](move _21)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'81>] _21
-        ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'43>] string
-        ↳⚡ unwind_terminate
-        unwind_continue
-    _19 = unsize_cast<Rc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Rc<(dyn Display + '82)>[{built_in impl MetaSized for (dyn Display + '84)}, {built_in impl Sized for Global}], ?>(move _20)
-    conditional_drop[impl_Destruct_for_Rc::drop_glue<'85, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _20
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'102>] _21
-        ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_Rc::drop_glue<'116, (dyn Display + '112), Global>[{built_in impl MetaSized for (dyn Display + '112)}, {built_in impl Sized for Global}]] _19
-        ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'43>] string
+    set_type(typeof(_21) <= Box<(dyn Display + '71)>[{built_in impl MetaSized for (dyn Display + '73)}, {built_in impl Sized for Global}])
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'86, (dyn Display + '82), Global>[{built_in impl MetaSized for (dyn Display + '82)}, {built_in impl Sized for Global}]] _21
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_21)
-    storage_dead(_20)
-    set_type(typeof(_19) <= Rc<(dyn Display + '86)>[{built_in impl MetaSized for (dyn Display + '88)}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Rc::drop_glue<'101, (dyn Display + '97), Global>[{built_in impl MetaSized for (dyn Display + '97)}, {built_in impl Sized for Global}]] _19
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'43>] string
+    storage_live(_25)
+    storage_live(_26)
+    storage_live(_27)
+    storage_live(_28)
+    _28 = &string
+    _27 = impl_Clone_for_String::clone<'89>(move _28)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
         ↳⚡ unwind_terminate
         unwind_continue
-    storage_dead(_19)
+    storage_dead(_28)
+    _26 = alloc::rc::{Rc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<String>[{built_in impl Sized for String}](move _27)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'103>] _27
+        ↳⚡ unwind_terminate
+        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        ↳⚡ unwind_terminate
+        unwind_continue
+    _25 = unsize_cast<Rc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Rc<(dyn Display + '104)>[{built_in impl MetaSized for (dyn Display + '106)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _26)
+    conditional_drop[impl_Destruct_for_Rc::drop_glue<'107, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _26
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'124>] _27
+        ↳⚡ unwind_terminate
+        conditional_drop[impl_Destruct_for_Rc::drop_glue<'139, (dyn Display + '135), Global>[{built_in impl MetaSized for (dyn Display + '135)}, {built_in impl Sized for Global}]] _25
+        ↳⚡ unwind_terminate
+        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_27)
+    storage_dead(_26)
+    set_type(typeof(_25) <= Rc<(dyn Display + '108)>[{built_in impl MetaSized for (dyn Display + '110)}, {built_in impl Sized for Global}])
+    conditional_drop[impl_Destruct_for_Rc::drop_glue<'123, (dyn Display + '119), Global>[{built_in impl MetaSized for (dyn Display + '119)}, {built_in impl Sized for Global}]] _25
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_25)
+    storage_live(_29)
+    storage_live(_30)
+    storage_live(_31)
+    storage_live(_32)
+    _32 = &string
+    _31 = impl_Clone_for_String::clone<'126>(move _32)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_32)
+    _30 = alloc::sync::{Arc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<String>[{built_in impl Sized for String}](move _31)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'140>] _31
+        ↳⚡ unwind_terminate
+        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        ↳⚡ unwind_terminate
+        unwind_continue
+    _29 = unsize_cast<Arc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Arc<(dyn Display + '141)>[{built_in impl MetaSized for (dyn Display + '143)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _30)
+    conditional_drop[impl_Destruct_for_Arc::drop_glue<'144, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _30
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'161>] _31
+        ↳⚡ unwind_terminate
+        conditional_drop[impl_Destruct_for_Arc::drop_glue<'176, (dyn Display + '172), Global>[{built_in impl MetaSized for (dyn Display + '172)}, {built_in impl Sized for Global}]] _29
+        ↳⚡ unwind_terminate
+        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_31)
+    storage_dead(_30)
+    set_type(typeof(_29) <= Arc<(dyn Display + '145)>[{built_in impl MetaSized for (dyn Display + '147)}, {built_in impl Sized for Global}])
+    conditional_drop[impl_Destruct_for_Arc::drop_glue<'160, (dyn Display + '156), Global>[{built_in impl MetaSized for (dyn Display + '156)}, {built_in impl Sized for Global}]] _29
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_29)
+    storage_live(_33)
+    storage_live(_34)
+    storage_live(_35)
+    storage_live(_36)
+    _36 = &string
+    _35 = impl_Clone_for_String::clone<'163>(move _36)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_36)
+    _34 = test_crate::{MyPtr<T>[TraitClause0::ImpliedClause0]}::new<String>[{built_in impl Sized for String}](move _35)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'177>] _35
+        ↳⚡ unwind_terminate
+        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        ↳⚡ unwind_terminate
+        unwind_continue
+    _33 = unsize_cast<MyPtr<String>[{built_in impl MetaSized for String}], MyPtr<(dyn Display + '178)>[{built_in impl MetaSized for (dyn Display + '180)}], &impl_Display_for_String::{vtable}>(move _34)
+    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'181, String>[{built_in impl MetaSized for String}]] _34
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'198>] _35
+        ↳⚡ unwind_terminate
+        conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'212, (dyn Display + '208)>[{built_in impl MetaSized for (dyn Display + '208)}]] _33
+        ↳⚡ unwind_terminate
+        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_35)
+    storage_dead(_34)
+    set_type(typeof(_33) <= MyPtr<(dyn Display + '182)>[{built_in impl MetaSized for (dyn Display + '184)}])
+    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'197, (dyn Display + '193)>[{built_in impl MetaSized for (dyn Display + '193)}]] _33
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_33)
     _0 = ()
-    conditional_drop[impl_Destruct_for_String::drop_glue<'103>] string
+    conditional_drop[impl_Destruct_for_String::drop_glue<'199>] string
     ↳⚡ unwind_continue
     storage_dead(string)
     storage_dead(array)

--- a/charon/tests/ui/unsize.rs
+++ b/charon/tests/ui/unsize.rs
@@ -1,14 +1,31 @@
+#![feature(derive_coerce_pointee)]
 use std::fmt::Display;
+use std::marker::CoercePointee;
 use std::rc::Rc;
+use std::sync::Arc;
+
+#[derive(CoercePointee)]
+#[repr(transparent)]
+struct MyPtr<T: ?Sized>(Box<T>);
+
+impl<T> MyPtr<T> {
+    fn new(x: T) -> Self {
+        MyPtr(Box::new(x))
+    }
+}
 
 fn foo() {
     let array: [_; 2] = [0, 0];
     let _: &[_] = &array;
     let _: Box<[_]> = Box::new(array);
     let _: Rc<[_]> = Rc::new(array);
+    let _: Arc<[_]> = Arc::new(array);
+    let _: MyPtr<[_]> = MyPtr::new(array);
 
     let string = String::new();
     let _: &dyn Display = &string;
     let _: Box<dyn Display> = Box::new(string.clone());
     let _: Rc<dyn Display> = Rc::new(string.clone());
+    let _: Arc<dyn Display> = Arc::new(string.clone());
+    let _: MyPtr<dyn Display> = MyPtr::new(string.clone());
 }


### PR DESCRIPTION
Fix missing unsizing metadata for custom pointers. This doesn't entirely close #855 , as we don't desugar the coercion or pass the field indices, which have to be recomputed in the client. I would like changing this (which should require a minor representation change), but I'll leave it for later :) 