### PR TITLE
Fix signature mixup when translating fn impls for methods

### DIFF
--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -642,13 +642,11 @@ where
     let tcx = s.base().tcx;
     let type_of_self = || inst_binder(tcx, s.typing_env(), args, hax_def_id.type_of(s));
     let args_or_default = || args.unwrap_or_else(|| hax_def_id.identity_args(s));
-    let fn_def_trait_impls = |def_id: RDefId, sig: ty::EarlyBinder<'tcx, ty::PolyFnSig<'tcx>>| {
-        if sig.skip_binder().is_fn_trait_compatible()
+    let fn_def_trait_impls = |def_id: RDefId, fn_sig: ty::PolyFnSig<'tcx>| {
+        if fn_sig.is_fn_trait_compatible()
             && tcx.codegen_fn_attrs(def_id).target_features.is_empty()
         {
             let fn_args = args_or_default();
-            let fn_sig = inst_binder(tcx, s.typing_env(), args, sig);
-
             let self_ty = ty::Ty::new_fn_def(tcx, def_id, fn_sig.rebind(fn_args));
             let fn_sig = tcx.liberate_late_bound_regions(def_id, fn_sig);
             let input_ty = ty::Ty::new_tup(tcx, fn_sig.inputs());
@@ -871,8 +869,8 @@ where
         }
         RDefKind::Fn { .. } => {
             let sig = tcx.fn_sig(def_id);
-            let fn_trait_impls = fn_def_trait_impls(def_id, sig);
             let sig = inst_binder(tcx, s.typing_env(), args, sig);
+            let fn_trait_impls = fn_def_trait_impls(def_id, sig);
             FullDefKind::Fn {
                 param_env: get_param_env(s, args),
                 inline: tcx.codegen_fn_attrs(def_id).inline.sinto(s),
@@ -888,8 +886,8 @@ where
         }
         RDefKind::AssocFn { .. } => {
             let item = tcx.associated_item(def_id);
-            let fn_trait_impls = fn_def_trait_impls(def_id, tcx.fn_sig(def_id));
             let sig = get_method_sig(tcx, s.typing_env(), def_id, args);
+            let fn_trait_impls = fn_def_trait_impls(def_id, sig);
             FullDefKind::AssocFn {
                 param_env: get_param_env(s, args),
                 associated_item: AssocItem::sfrom_instantiated(s, &item, args),
@@ -1010,7 +1008,6 @@ where
             let args = args_or_default();
             let ctor_of = ctor_of.sinto(s);
             let sig = tcx.fn_sig(def_id);
-            let fn_trait_impls = fn_def_trait_impls(def_id, sig);
 
             // The def_id of the adt this ctor belongs to.
             let adt_def_id = match ctor_of {
@@ -1027,6 +1024,7 @@ where
                 .collect();
             let output_ty = ty::Ty::new_adt(tcx, adt_def, args).sinto(s);
             let sig = inst_binder(tcx, s.typing_env(), Some(args), sig);
+            let fn_trait_impls = fn_def_trait_impls(def_id, sig);
             FullDefKind::Ctor {
                 adt_def_id: adt_def_id.sinto(s),
                 ctor_of,

--- a/charon/tests/ui/issue-1409-anonymous-method-lifetime.out
+++ b/charon/tests/ui/issue-1409-anonymous-method-lifetime.out
@@ -1,0 +1,205 @@
+# Final LLBC before serialization:
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+// Full name: core::convert::From
+#[lang_item(From)]
+#[diagnostic_item("From")]
+pub trait From<Self, T>
+{
+    proof ImpliedClause0: (Self: Sized)
+    proof ImpliedClause1: (T: Sized)
+    fn from;
+    non-dyn-compatible
+}
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+// Full name: core::marker::Tuple
+#[fundamental]
+#[lang_item(Tuple)]
+pub trait Tuple<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+// Full name: core::ops::function::FnOnce
+#[fundamental]
+#[lang_item(FnOnce)]
+pub trait FnOnce<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Args: Sized)
+    proof ImpliedClause2: (Args: Tuple)
+    proof ImpliedClause3: (Self::Output: Sized)
+    type Output
+    fn call_once;
+    vtable: core::ops::function::FnOnce::{vtable}<Args, Self::Output>
+}
+
+// Full name: core::ops::function::FnMut
+#[fundamental]
+#[lang_item(FnMut)]
+pub trait FnMut<Self, Args>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self: FnOnce<Args>)
+    proof ImpliedClause2: (Args: Sized)
+    proof ImpliedClause3: (Args: Tuple)
+    fn call_mut<'_0_1>;
+    vtable: core::ops::function::FnMut::{vtable}<Args, Self::ImpliedClause1::Output>
+}
+
+struct (_,)<A> {
+  _0: A,
+}
+
+// Full name: test_crate::S
+pub struct S {}
+
+// Full name: test_crate::{impl From<&'_0 u64> for S}::from
+pub fn from<'_0>(_1: &'_0 u64) -> S
+{
+    let _0: S; // return
+    let _1: &'1 u64; // arg #1
+
+    storage_live(_0)
+    _0 = S {  }
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl From<&'_0 u64> for S}
+impl<'_0> "impl_From_for_S" From<&'_0 u64> for S {
+    proof ImpliedClause0: (S: Sized) = {built_in impl Sized for S}
+    proof ImpliedClause1: (&'_0 u64: Sized) = {built_in impl Sized for &'_0 u64}
+    fn from = from<'_0>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl From<&'_0 u64> for S}::{impl FnMut<(&'_0 u64,)> for from<'_0>}::call_mut
+pub fn call_mut<'_0, '_1>(state: &'_1 mut from<'_0>, args: (&'_0 u64,)) -> S
+where
+    RegionOutlives0: '_0: '_1,
+{
+    let _0: S; // return
+    let state: &'_1 mut from<'_0>; // arg #1
+    let args: (&'_0 u64,); // arg #2
+
+    storage_live(_0)
+    _0 = from<'_0>(move args._0)
+    ↳⚡ storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::{impl From<&'_0 u64> for S}::{impl FnOnce<(&'_0 u64,)> for from<'_0>}::call_once
+pub fn call_once<'_0>(state: from<'_0>, args: (&'_0 u64,)) -> S
+{
+    let _0: S; // return
+    let state: from<'_0>; // arg #1
+    let args: (&'_0 u64,); // arg #2
+
+    storage_live(_0)
+    _0 = from<'_0>(move args._0)
+    ↳⚡ storage_dead(args)
+        storage_dead(state)
+        unwind_continue
+    storage_dead(args)
+    storage_dead(state)
+    return
+}
+
+// Full name: test_crate::{impl From<&'_0 u64> for S}::{impl FnOnce<(&'_0 u64,)> for from<'_0>}
+impl<'_0> FnOnce<(&'_0 u64,)> for from<'_0> {
+    proof ImpliedClause0: (from<'_0>: MetaSized) = {built_in impl MetaSized for from<'_0>}
+    proof ImpliedClause1: ((&'_0 u64,): Sized) = {built_in impl Sized for (&'_0 u64,)}
+    proof ImpliedClause2: ((&'_0 u64,): Tuple) = {built_in impl Tuple for (&'_0 u64,)}
+    proof ImpliedClause3: (S: Sized) = {built_in impl Sized for S}
+    type Output = S
+    fn call_once = call_once<'_0>
+    vtable: {impl FnOnce<(&'_0 u64,)> for from<'_0>}::{vtable}<'_0>
+}
+
+// Full name: test_crate::{impl From<&'_0 u64> for S}::{impl FnMut<(&'_0 u64,)> for from<'_0>}
+impl<'_0> FnMut<(&'_0 u64,)> for from<'_0> {
+    proof ImpliedClause0: (from<'_0>: MetaSized) = {built_in impl MetaSized for from<'_0>}
+    proof ImpliedClause1: (from<'_0>: FnOnce<(&'_0 u64,)>) = {impl FnOnce<(&'_0 u64,)> for from<'_0>}<'_0>
+    proof ImpliedClause2: ((&'_0 u64,): Sized) = {built_in impl Sized for (&'_0 u64,)}
+    proof ImpliedClause3: ((&'_0 u64,): Tuple) = {built_in impl Tuple for (&'_0 u64,)}
+    fn call_mut<'_0_1> = call_mut<'_0, '_0_1>
+    vtable: {impl FnMut<(&'_0 u64,)> for from<'_0>}::{vtable}<'_0>
+}
+
+// Full name: test_crate::use_fn
+pub fn use_fn<'a, F>(_1: &'a u64, _2: F)
+where
+    TraitClause0: (F: Sized),
+    TraitClause1: (F: FnMut<(&'a u64,)>),
+    TypeConstraint0: TraitClause1::ImpliedClause1::Output = S,
+{
+    let _0: (); // return
+    let _1: &'1 u64; // arg #1
+    let _2: F; // arg #2
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    conditional_drop[{built_in impl Destruct for F}::drop_glue<'2>] _2
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::test
+pub fn test<'a>(x: &'a u64)
+{
+    let _0: (); // return
+    let x: &'1 u64; // arg #1
+    let _2: (); // anonymous local
+    let _3: &'2 u64; // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(_2)
+    storage_live(_3)
+    _3 = &(*x)
+    _2 = use_fn<'3, from<'5>>[{built_in impl Sized for from<'7>}, {impl FnMut<(&'_0 u64,)> for from<'_0>}<'3>](move _3, const from<'19>)
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    _0 = ()
+    storage_dead(x)
+    return
+}
+
+
+

--- a/charon/tests/ui/issue-1409-anonymous-method-lifetime.rs
+++ b/charon/tests/ui/issue-1409-anonymous-method-lifetime.rs
@@ -1,0 +1,13 @@
+pub struct S;
+
+impl From<&u64> for S {
+    fn from(_: &u64) -> S {
+        S
+    }
+}
+
+pub fn use_fn<'a, F: FnMut(&'a u64) -> S>(_: &'a u64, _: F) {}
+
+pub fn test<'a>(x: &'a u64) {
+    use_fn(x, S::from);
+}


### PR DESCRIPTION
When the implemented method has a more precise signature than the declared method, we were using the wrong one for generating `Fn` impls.

Fixes #1409.