### PR TITLE
Remove `FunId`

### DIFF
--- a/charon-ml/src/CharonVersion.ml
+++ b/charon-ml/src/CharonVersion.ml
@@ -1,3 +1,3 @@
 (* This is an automatically generated file, generated from `charon/Cargo.toml`. *)
 (* To re-generate this file, rune `make` in the root directory *)
-let supported_charon_version = "0.1.253"
+let supported_charon_version = "0.1.254"

--- a/charon-ml/src/GAstUtils.ml
+++ b/charon-ml/src/GAstUtils.ml
@@ -227,7 +227,7 @@ let has_body : body -> bool = function
     [global_decl.init] field. *)
 let init_fun_id_of_global (global : global_decl) : fun_decl_id option =
   match global.value.kind with
-  | CCall ({ kind = FunId (FRegular id); _ }, []) -> Some id
+  | CCall ({ kind = Fun id; _ }, []) -> Some id
   | _ -> None
 
 (** Split a module's declarations between types, functions and globals *)

--- a/charon-ml/src/NameMatcher.ml
+++ b/charon-ml/src/NameMatcher.ml
@@ -717,7 +717,7 @@ and match_expr_with_const_generic (ctx : ctx) (c : match_config) (m : maps)
 let match_fn_ptr (ctx : ctx) (c : match_config) (p : pattern) (func : T.fn_ptr)
     : bool =
   match func.kind with
-  | FunId (FRegular fid) ->
+  | Fun fid ->
       (* Lookup the function decl *)
       let d = Types.FunDeclId.Map.find fid ctx.crate.fun_decls in
       (* Match the pattern on the name of the function. *)
@@ -1150,7 +1150,7 @@ let fn_ptr_to_pattern (ctx : ctx) (c : to_pat_config)
   let args = generic_args_to_pattern ctx c m func.generics in
   let pat =
     match func.kind with
-    | FunId (FRegular fid) ->
+    | Fun fid ->
         let d = Types.FunDeclId.Map.find fid ctx.crate.fun_decls in
         name_with_generics_to_pattern_aux ctx c m d.item_meta.name func.generics
     | TraitMethod (tr, method_id) ->

--- a/charon-ml/src/Print.ml
+++ b/charon-ml/src/Print.ml
@@ -130,9 +130,6 @@ let type_decl_ref_to_string env tref =
 let fun_decl_id_to_string env id =
   PrintFmt.pp_to_string (fun fmt -> PrintFmt.pp_fun_decl_id env fmt id)
 
-let fun_id_to_string env id =
-  PrintFmt.pp_to_string (fun fmt -> PrintFmt.pp_fun_id env fmt id)
-
 let fun_decl_ref_to_string env fn =
   PrintFmt.pp_to_string (fun fmt -> PrintFmt.pp_fun_decl_ref env fmt fn)
 

--- a/charon-ml/src/PrintFmt.ml
+++ b/charon-ml/src/PrintFmt.ml
@@ -546,10 +546,6 @@ and pp_match_pattern (env : fmt_env) (fmt : Format.formatter)
 and constant_expr_to_string env cv =
   pp_to_string (fun fmt -> pp_constant_expr env fmt cv)
 
-and pp_fun_id (env : fmt_env) (fmt : Format.formatter) (fid : fun_id) : unit =
-  match fid with
-  | FRegular fid -> pp_fun_decl_id env fmt fid
-
 and pp_fn_ptr_kind (env : fmt_env) (fmt : Format.formatter) (r : fn_ptr_kind) :
     unit =
   match r with
@@ -559,7 +555,7 @@ and pp_fn_ptr_kind (env : fmt_env) (fmt : Format.formatter) (r : fn_ptr_kind) :
           trait_ref.trait_decl_ref.binder_value.id method_id
       in
       Format.fprintf fmt "%a::%s" (pp_trait_ref env) trait_ref method_name
-  | FunId fid -> pp_fun_id env fmt fid
+  | Fun fid -> pp_fun_decl_id env fmt fid
 
 and pp_fn_ptr (env : fmt_env) (fmt : Format.formatter) (ptr : fn_ptr) : unit =
   Format.fprintf fmt "%a%a" (pp_fn_ptr_kind env) ptr.kind

--- a/charon-ml/src/Substitute.ml
+++ b/charon-ml/src/Substitute.ml
@@ -677,7 +677,7 @@ let lookup_flat_method_sig (crate : crate) (trait_id : trait_decl_id)
 let lookup_fndef_sig (crate : crate) (fn_ptr : fn_ptr region_binder) :
     fun_sig region_binder option =
   match fn_ptr.binder_value.kind with
-  | FunId (FRegular fun_decl_id) ->
+  | Fun fun_decl_id ->
       let* fun_decl =
         LlbcAst.FunDeclId.Map.find_opt fun_decl_id crate.fun_decls
       in

--- a/charon-ml/src/generated/Generated_GAst.ml
+++ b/charon-ml/src/generated/Generated_GAst.ml
@@ -21,7 +21,6 @@ module BranchId = IdGen ()
 (* Imports *)
 type fn_ptr_kind = Types.fn_ptr_kind [@@deriving show, ord]
 type fun_decl_id = Types.fun_decl_id [@@deriving show, ord]
-type fun_id = Types.fun_id [@@deriving show, ord]
 
 (** (U)LLBC is a language with side-effects: a statement may abort in a way that
     isn't tracked by control-flow. The three kinds of abort are:

--- a/charon-ml/src/generated/Generated_OfJson.ml
+++ b/charon-ml/src/generated/Generated_OfJson.ml
@@ -669,8 +669,8 @@ and fn_ptr_kind_of_json (ctx : of_json_ctx) (js : json) :
   combine_error_msgs js __FUNCTION__
     (match js with
     | `Assoc [ ("Fun", _0) ] ->
-        let* _0 = fun_id_of_json ctx _0 in
-        Ok (FunId _0)
+        let* _0 = fun_decl_id_of_json ctx _0 in
+        Ok (Fun _0)
     | `Assoc [ ("Trait", `List [ _0; _1 ]) ] ->
         let* _0 = trait_ref_of_json ctx _0 in
         let* _1 = trait_method_id_of_json ctx _1 in
@@ -692,14 +692,6 @@ and fun_decl_ref_of_json (ctx : of_json_ctx) (js : json) :
         let* id = fun_decl_id_of_json ctx id in
         let* generics = box_of_json generic_args_of_json ctx generics in
         Ok ({ id; generics } : fun_decl_ref)
-    | _ -> Error "")
-
-and fun_id_of_json (ctx : of_json_ctx) (js : json) : (fun_id, string) result =
-  combine_error_msgs js __FUNCTION__
-    (match js with
-    | `Assoc [ ("Regular", _0) ] ->
-        let* _0 = fun_decl_id_of_json ctx _0 in
-        Ok (FRegular _0)
     | _ -> Error "")
 
 and fun_sig_of_json (ctx : of_json_ctx) (js : json) : (fun_sig, string) result =

--- a/charon-ml/src/generated/Generated_OfPostcard.ml
+++ b/charon-ml/src/generated/Generated_OfPostcard.ml
@@ -639,8 +639,8 @@ and fn_ptr_kind_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (let* __tag = int_of_postcard ctx st in
      match __tag with
      | 0 ->
-         let* _0 = fun_id_of_postcard ctx st in
-         Ok (FunId _0)
+         let* _0 = fun_decl_id_of_postcard ctx st in
+         Ok (Fun _0)
      | 1 ->
          let* _0 = trait_ref_of_postcard ctx st in
          let* _1 = trait_method_id_of_postcard ctx st in
@@ -657,16 +657,6 @@ and fun_decl_ref_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (let* id = fun_decl_id_of_postcard ctx st in
      let* generics = box_of_postcard generic_args_of_postcard ctx st in
      Ok ({ id; generics } : fun_decl_ref))
-
-and fun_id_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
-    (fun_id, string) result =
-  combine_error_msgs st __FUNCTION__
-    (let* __tag = int_of_postcard ctx st in
-     match __tag with
-     | 0 ->
-         let* _0 = fun_decl_id_of_postcard ctx st in
-         Ok (FRegular _0)
-     | _ -> Error ("unknown enum variant tag: " ^ string_of_int __tag))
 
 and fun_sig_of_postcard (ctx : of_postcard_ctx) (st : postcard_state) :
     (fun_sig, string) result =

--- a/charon-ml/src/generated/Generated_Types.ml
+++ b/charon-ml/src/generated/Generated_Types.ml
@@ -357,7 +357,7 @@ and field_id = (FieldId.id[@visitors.opaque])
 and fn_ptr = { kind : fn_ptr_kind; generics : generic_args }
 
 and fn_ptr_kind =
-  | FunId of fun_id
+  | Fun of fun_decl_id
   | TraitMethod of trait_ref * trait_method_id
       (** If a trait: the reference to the trait and the id of the trait method.
       *)
@@ -367,12 +367,6 @@ and fun_decl_ref = {
   id : fun_decl_id;
   generics : generic_args;  (** Generic arguments passed to the function. *)
 }
-
-(** A regular function. *)
-and fun_id =
-  | FRegular of fun_decl_id
-      (** A "regular" function (function local to the crate, external function
-          not treated as a primitive one). *)
 
 (** A function signature. *)
 and fun_sig = {

--- a/charon-ml/tests/Test_NameMatcher.ml
+++ b/charon-ml/tests/Test_NameMatcher.ml
@@ -140,7 +140,7 @@ module PatternTest = struct
           let generics =
             TypesUtils.generic_args_of_params decl.item_meta.span decl.generics
           in
-          Types.{ kind = FunId (FRegular decl.def_id); generics }
+          Types.{ kind = Fun decl.def_id; generics }
       | Some idx ->
           (* Find the nth function call in the function body. *)
           let rec list_stmt_calls (statement : statement) : call list =

--- a/charon/Cargo.lock
+++ b/charon/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "charon"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/charon/Cargo.toml
+++ b/charon/Cargo.toml
@@ -26,7 +26,7 @@ tracing = { version = "0.1", features = ["max_level_trace"] }
 
 [package]
 name = "charon"
-version = "0.1.253"
+version = "0.1.254"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/charon/src/ast/items/global_decl.rs
+++ b/charon/src/ast/items/global_decl.rs
@@ -92,7 +92,7 @@ impl GlobalDecl {
     pub fn init_fun_id(&self) -> Option<FunDeclId> {
         match self.value.kind() {
             ConstantExprKind::Call(fn_ptr, _) => match &*fn_ptr.kind {
-                FnPtrKind::Fun(FunId::Regular(id)) => Some(*id),
+                FnPtrKind::Fun(id) => Some(*id),
                 _ => None,
             },
             _ => None,

--- a/charon/src/ast/items/item_ids.rs
+++ b/charon/src/ast/items/item_ids.rs
@@ -156,32 +156,6 @@ pub struct FunDeclRef {
     pub generics: BoxedArgs,
 }
 
-/// A regular function.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    EnumIsA,
-    EnumAsGetters,
-    VariantName,
-    SerializeState,
-    DeserializeState,
-    Drive,
-    DriveMut,
-    DriveTwo,
-)]
-#[cfg_attr(feature = "charon_on_charon", charon::variants_prefix("F"))]
-#[serde_state(stateless)]
-pub enum FunId {
-    /// A "regular" function (function local to the crate, external function
-    /// not treated as a primitive one).
-    Regular(FunDeclId),
-}
-
 #[derive(
     Debug,
     Clone,
@@ -198,8 +172,7 @@ pub enum FunId {
     Hash,
 )]
 pub enum FnPtrKind {
-    #[cfg_attr(feature = "charon_on_charon", charon::rename("FunId"))]
-    Fun(FunId),
+    Fun(FunDeclId),
     /// If a trait: the reference to the trait and the id of the trait method.
     #[cfg_attr(feature = "charon_on_charon", charon::rename("TraitMethod"))]
     Trait(TraitRef, TraitMethodId),
@@ -346,7 +319,7 @@ impl FnPtr {
     /// Get the generics for the pre-monomorphization item.
     pub fn pre_mono_generics<'a>(&'a self, krate: &'a TranslatedCrate) -> &'a GenericArgs {
         match *self.kind {
-            FnPtrKind::Fun(FunId::Regular(fun_id)) => krate
+            FnPtrKind::Fun(fun_id) => krate
                 .item_name(fun_id)
                 .mono_args()
                 .unwrap_or(&self.generics),
@@ -420,7 +393,7 @@ impl TryFrom<DeclRef<ItemId>> for FnPtr {
                 deal with the trait method case."
             )
         }
-        let id: FunId = item.id.try_into()?;
+        let id: FunDeclId = item.id.try_into()?;
         Ok(FnPtr::new(id.into(), item.generics))
     }
 }
@@ -460,24 +433,8 @@ wrap_unwrap_enum!(AssocItemId::Type(AssocTypeId));
 wrap_unwrap_enum!(AssocItemId::Method(TraitMethodId));
 wrap_unwrap_enum!(AssocItemId::Const(AssocConstId));
 
-impl TryFrom<ItemId> for FunId {
-    type Error = ();
-    fn try_from(x: ItemId) -> Result<Self, Self::Error> {
-        Ok(FunId::Regular(x.try_into()?))
-    }
-}
-impl From<FunDeclId> for FunId {
-    fn from(id: FunDeclId) -> Self {
-        Self::Regular(id)
-    }
-}
 impl From<FunDeclId> for FnPtrKind {
     fn from(id: FunDeclId) -> Self {
-        Self::Fun(id.into())
-    }
-}
-impl From<FunId> for FnPtrKind {
-    fn from(id: FunId) -> Self {
         Self::Fun(id)
     }
 }

--- a/charon/src/ast/visitor.rs
+++ b/charon/src/ast/visitor.rs
@@ -65,7 +65,7 @@ use derive_generic_visitor::*;
         Assert, AttributeKind, BinderKind, BinOp, BorrowckStatement, BorrowKind, BuiltinAdt, BuiltinAssertKind,
         Call, CastKind, ClosureInfo, ClosureKind, ConstGenericParam, ConstGenericVarId,
         Deprecation, Disambiguator, DynPredicate, Field, FieldId, File, FloatTy, FloatValue,
-        FnOperand, FunId, FnPtrKind, FunSig, InlineAttr, IntegerTy, IntTy, UIntTy, ScalarTy,
+        FnOperand, FnPtrKind, FunSig, InlineAttr, IntegerTy, IntTy, UIntTy, ScalarTy,
         Ident, from_rustc::InlineAttr,
         llbc_ast::ExprBody, llbc_ast::StatementKind,
         Loc, Locals, NullOp, Operand, PathElem, PlaceKind,
@@ -612,9 +612,7 @@ mod wrappers {
         }
         fn visit_fn_ptr(&mut self, x: &FnPtr) -> ControlFlow<Self::Break> {
             match x.kind.as_ref() {
-                FnPtrKind::Fun(FunId::Regular(id)) => {
-                    self.0.visit_item_ref(ItemId::Fun(*id), &x.generics)
-                }
+                FnPtrKind::Fun(id) => self.0.visit_item_ref(ItemId::Fun(*id), &x.generics),
                 FnPtrKind::Trait(..) => self.visit_inner(x),
             }
         }
@@ -645,9 +643,7 @@ mod wrappers {
         }
         fn visit_fn_ptr(&mut self, x: &mut FnPtr) -> ControlFlow<Self::Break> {
             match x.kind.as_ref() {
-                FnPtrKind::Fun(FunId::Regular(id)) => {
-                    self.0.visit_item_ref(ItemId::Fun(*id), &mut x.generics)
-                }
+                FnPtrKind::Fun(id) => self.0.visit_item_ref(ItemId::Fun(*id), &mut x.generics),
                 FnPtrKind::Trait(..) => self.visit_inner(x),
             }
         }

--- a/charon/src/bin/charon-driver/translate/translate_closures.rs
+++ b/charon/src/bin/charon-driver/translate/translate_closures.rs
@@ -302,7 +302,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         )?;
         Ok(Some(bound_ref.map(|dref| {
             let fn_ref: FunDeclRef = dref.try_into().unwrap();
-            FnPtr::new(FnPtrKind::Fun(FunId::Regular(fn_ref.id)), fn_ref.generics)
+            FnPtr::new(FnPtrKind::Fun(fn_ref.id), fn_ref.generics)
         })))
     }
 }

--- a/charon/src/bin/charon-driver/translate/translate_crate.rs
+++ b/charon/src/bin/charon-driver/translate/translate_crate.rs
@@ -996,7 +996,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         let fun_item: DeclRef<FunDeclId> = fun_item.try_convert_id().unwrap();
         let fun_id = match fun_item.trait_ref {
             // Direct function call
-            None => FnPtrKind::Fun(FunId::Regular(fun_item.id)),
+            None => FnPtrKind::Fun(fun_item.id),
             // Trait method
             Some(trait_ref) => {
                 let trait_decl_id = trait_ref.trait_id();

--- a/charon/src/bin/charon-driver/translate/translate_items.rs
+++ b/charon/src/bin/charon-driver/translate/translate_items.rs
@@ -685,7 +685,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             ConstantExpr::new(
                 ConstantExprKind::Call(
                     FnPtr::new(
-                        FnPtrKind::Fun(FunId::Regular(initializer)),
+                        FnPtrKind::Fun(initializer),
                         self.outermost_generics().identity_args(),
                     ),
                     vec![],
@@ -1186,7 +1186,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                                         .collect();
                                     let fn_ptr = bound_fn_ptr.apply(late_bound_regions);
                                     Ok(FunDeclRef {
-                                        id: *fn_ptr.kind.as_fun().unwrap().as_regular().unwrap(),
+                                        id: *fn_ptr.kind.as_fun().unwrap(),
                                         generics: fn_ptr.generics,
                                     })
                                 },

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -791,7 +791,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         let value = ConstantExpr::new(
             ConstantExprKind::Call(
                 FnPtr::new(
-                    FnPtrKind::Fun(FunId::Regular(init)),
+                    FnPtrKind::Fun(init),
                     self.outermost_generics().identity_args(),
                 ),
                 vec![],

--- a/charon/src/bin/generate-asts/generate_ml/templates/GAst.ml
+++ b/charon/src/bin/generate-asts/generate_ml/templates/GAst.ml
@@ -23,7 +23,6 @@ module BranchId = IdGen ()
 (* Imports *)
 type fn_ptr_kind = Types.fn_ptr_kind [@@deriving show, ord]
 type fun_decl_id = Types.fun_decl_id [@@deriving show, ord]
-type fun_id = Types.fun_id [@@deriving show, ord]
 
 (* __REPLACE0__ *)
 

--- a/charon/src/export/multi_target.rs
+++ b/charon/src/export/multi_target.rs
@@ -929,7 +929,7 @@ impl VisitAstMut for IdRefMapperVisitor<'_> {
     }
 
     fn enter_fn_ptr(&mut self, x: &mut FnPtr) {
-        if let FnPtrKind::Fun(FunId::Regular(id)) = x.kind.as_mut() {
+        if let FnPtrKind::Fun(id) = x.kind.as_mut() {
             self.map(id)
         }
     }

--- a/charon/src/pretty/fmt_with_ctx.rs
+++ b/charon/src/pretty/fmt_with_ctx.rs
@@ -575,7 +575,7 @@ impl<C: AstFormatter> FmtWithCtx<C> for FnOperand {
 impl<C: AstFormatter> FmtWithCtx<C> for FnPtr {
     fn fmt_with_ctx(&self, ctx: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind.as_ref() {
-            FnPtrKind::Fun(FunId::Regular(def_id)) => write!(f, "{}", def_id.with_ctx(ctx))?,
+            FnPtrKind::Fun(def_id) => write!(f, "{}", def_id.with_ctx(ctx))?,
             FnPtrKind::Trait(trait_ref, method_id) => {
                 write!(f, "{}::", trait_ref.with_ctx(ctx))?;
                 ctx.format_method_name(f, trait_ref.trait_id(), *method_id)?;

--- a/charon/src/transform/normalize/expand_associated_types.rs
+++ b/charon/src/transform/normalize/expand_associated_types.rs
@@ -1356,7 +1356,7 @@ impl VisitAstMut for UpdateItemBody<'_> {
     }
     fn enter_fn_ptr(&mut self, x: &mut FnPtr) {
         match x.kind.as_ref() {
-            FnPtrKind::Fun(FunId::Regular(id)) => self.update_item_generics(*id, &mut x.generics),
+            FnPtrKind::Fun(id) => self.update_item_generics(*id, &mut x.generics),
             FnPtrKind::Trait(trait_ref, method_name) => {
                 let trait_id = trait_ref.trait_decl_ref.skip_binder.id;
                 self.update_generics(

--- a/charon/src/transform/normalize/partial_monomorphization.rs
+++ b/charon/src/transform/normalize/partial_monomorphization.rs
@@ -498,7 +498,7 @@ impl VisitAstMut for PartialMonomorphizer<'_> {
     fn exit_fn_ptr(&mut self, x: &mut FnPtr) {
         // TODO: methods. any `Trait::method<&mut A>` requires monomorphizing all the instances of
         // that method just in case :>>>
-        if let FnPtrKind::Fun(FunId::Regular(id)) = *x.kind
+        if let FnPtrKind::Fun(id) = *x.kind
             && let Some(new_decl_ref) = self.process_generics(id.into(), &x.generics)
         {
             *x = new_decl_ref.try_into().unwrap()

--- a/charon/src/transform/normalize/skip_trait_refs_when_known.rs
+++ b/charon/src/transform/normalize/skip_trait_refs_when_known.rs
@@ -23,7 +23,7 @@ fn normalize_default_method_call_on_known_impl(
     ctx: &TransformCtx,
     fn_ptr: &FnPtr,
 ) -> Option<FnPtr> {
-    let fun_id = fn_ptr.kind.as_ref().as_fun()?.as_regular()?;
+    let fun_id = fn_ptr.kind.as_ref().as_fun()?;
     let fun_decl = ctx.translated.fun_decls.get(*fun_id)?;
     let FunSource::TraitDefault {
         trait_ref,
@@ -96,10 +96,7 @@ fn normalize_method_call(
     );
     // Substitute the appropriate generics into the function call.
     let fn_ref = fn_ref.apply(&impl_ref.generics).apply(method_generics);
-    Some(FnPtr::new(
-        FnPtrKind::Fun(FunId::Regular(fn_ref.id)),
-        fn_ref.generics,
-    ))
+    Some(FnPtr::new(FnPtrKind::Fun(fn_ref.id), fn_ref.generics))
 }
 
 pub struct Transform;

--- a/charon/src/transform/resugar/reconstruct_intrinsics.rs
+++ b/charon/src/transform/resugar/reconstruct_intrinsics.rs
@@ -12,7 +12,7 @@ impl UllbcPass for Transform {
             let FnOperand::Regular(fn_ptr) = &call.func else {
                 return;
             };
-            let FnPtrKind::Fun(FunId::Regular(fun_id)) = fn_ptr.kind.as_ref() else {
+            let FnPtrKind::Fun(fun_id) = fn_ptr.kind.as_ref() else {
                 return;
             };
             let Some(fun_decl) = ctx.ctx.translated.fun_decls.get(*fun_id) else {

--- a/charon/src/transform/resugar/reconstruct_matches.rs
+++ b/charon/src/transform/resugar/reconstruct_matches.rs
@@ -22,7 +22,7 @@ impl Transform {
     fn replace_mem_discriminant_call(&self, block: &mut BlockData) {
         if let TerminatorKind::Call { call, target, .. } = &block.terminator.kind
             && let FnOperand::Regular(fn_ptr) = &call.func
-            && let FnPtrKind::Fun(FunId::Regular(fun_id)) = fn_ptr.kind.as_ref()
+            && let FnPtrKind::Fun(fun_id) = fn_ptr.kind.as_ref()
             && self.discriminant_intrinsics.contains(fun_id)
             && let [Operand::Move(p)] = call.args.as_slice()
             && let TyKind::Ref(_, sub_ty, _) = p.ty().kind()

--- a/charon/src/transform/resugar/reconstruct_vec_boxes.rs
+++ b/charon/src/transform/resugar/reconstruct_vec_boxes.rs
@@ -77,7 +77,7 @@ struct AssumeInitTail {
 
 fn assume_init_fn_ptr<'a>(ctx: &TransformCtx, call: &'a Call) -> Option<&'a FnPtr> {
     if let FnOperand::Regular(fn_ptr) = &call.func
-        && let FnPtrKind::Fun(FunId::Regular(fid)) = *fn_ptr.kind
+        && let FnPtrKind::Fun(fid) = *fn_ptr.kind
         && ctx.translated.item_name(fid).short_str() == Some("assume_init")
     {
         Some(fn_ptr)
@@ -257,7 +257,7 @@ fn is_new_uninit_call(ctx: &TransformCtx, call: &Call) -> bool {
     let FnOperand::Regular(fn_ptr) = &call.func else {
         return false;
     };
-    let FnPtrKind::Fun(FunId::Regular(fid)) = *fn_ptr.kind else {
+    let FnPtrKind::Fun(fid) = *fn_ptr.kind else {
         return false;
     };
     ctx.translated.item_name(fid).short_str() == Some("new_uninit")
@@ -403,10 +403,7 @@ impl UllbcPass for Transform {
 
             let (fn_ptr, args) = if rw.branched_before_payload {
                 (
-                    FnPtr::new(
-                        FnPtrKind::Fun(FunId::Regular(box_write)),
-                        rw.assume_init_generics,
-                    ),
+                    FnPtr::new(FnPtrKind::Fun(box_write), rw.assume_init_generics),
                     vec![
                         Operand::Move(rw.uninit_box),
                         Operand::Move(array_local.clone()),
@@ -417,7 +414,7 @@ impl UllbcPass for Transform {
                     target: rw.new_uninit_target,
                 };
                 (
-                    FnPtr::new(FnPtrKind::Fun(FunId::Regular(box_new)), rw.box_new_generics),
+                    FnPtr::new(FnPtrKind::Fun(box_new), rw.box_new_generics),
                     vec![Operand::Move(array_local.clone())],
                 )
             };

--- a/charon/src/transform/simplify_output/anon_const_to_call.rs
+++ b/charon/src/transform/simplify_output/anon_const_to_call.rs
@@ -41,7 +41,7 @@ impl UllbcPass for Transform {
                         return_place.as_local().unwrap(),
                         Call {
                             func: FnOperand::Regular(FnPtr::new(
-                                FnPtrKind::Fun(FunId::Regular(*initializer)),
+                                FnPtrKind::Fun(*initializer),
                                 gref.generics.clone(),
                             )),
                             args: vec![],

--- a/charon/src/transform/simplify_output/builtins_to_function_calls.rs
+++ b/charon/src/transform/simplify_output/builtins_to_function_calls.rs
@@ -35,7 +35,7 @@ fn mk_fn_ptr(ctx: &TransformCtx, id: ItemId, mut generics: GenericArgs) -> FnPtr
             .push(TraitRef::new(kind, trait_decl_ref));
     }
     let fun_id = *id.as_fun().unwrap();
-    FnPtr::new(FnPtrKind::Fun(FunId::Regular(fun_id)), generics)
+    FnPtr::new(FnPtrKind::Fun(fun_id), generics)
 }
 
 /// Instantiate the trait impl that provides the given method.

--- a/charon/src/transform/simplify_output/inline_selected_functions.rs
+++ b/charon/src/transform/simplify_output/inline_selected_functions.rs
@@ -78,7 +78,7 @@ impl UllbcPass for Transform {
             let FnOperand::Regular(fn_ptr) = &func else {
                 continue;
             };
-            let FnPtrKind::Fun(FunId::Regular(fun_id)) = fn_ptr.kind.as_ref() else {
+            let FnPtrKind::Fun(fun_id) = fn_ptr.kind.as_ref() else {
                 continue;
             };
             let Some(initializer) = self.to_inline.get(fun_id) else {

--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -524,7 +524,7 @@ impl VisitAst for TypeCheckVisitor<'_> {
     }
     fn enter_fn_ptr(&mut self, x: &FnPtr) {
         match x.kind.as_ref() {
-            FnPtrKind::Fun(FunId::Regular(id)) => self.assert_matches_item(*id, &x.generics),
+            FnPtrKind::Fun(id) => self.assert_matches_item(*id, &x.generics),
             FnPtrKind::Trait(trait_ref, method_id) => {
                 self.assert_matches_method(trait_ref, *method_id, &x.generics);
             }

--- a/charon/src/transform/utils.rs
+++ b/charon/src/transform/utils.rs
@@ -52,17 +52,10 @@ impl TypeDeclId {
         GenericsSource::item(*self)
     }
 }
-impl FunId {
-    pub fn generics_target(&self) -> GenericsSource {
-        match *self {
-            FunId::Regular(fun_id) => GenericsSource::item(fun_id),
-        }
-    }
-}
 impl FnPtrKind {
     pub fn generics_target(&self) -> GenericsSource {
         match self {
-            FnPtrKind::Fun(fun_id) => fun_id.generics_target(),
+            FnPtrKind::Fun(fun_id) => GenericsSource::item(*fun_id),
             FnPtrKind::Trait(trait_ref, name) => {
                 GenericsSource::Method(trait_ref.trait_decl_ref.skip_binder.id, *name)
             }

--- a/charon/tests/crate_data.rs
+++ b/charon/tests/crate_data.rs
@@ -819,7 +819,7 @@ fn known_trait_method_call() -> anyhow::Result<()> {
         panic!()
     };
     // Assert that this call referes to the method directly, without using a trait ref.
-    let FnPtrKind::Fun(FunId::Regular(id)) = fn_ptr.kind.as_ref() else {
+    let FnPtrKind::Fun(id) = fn_ptr.kind.as_ref() else {
         panic!()
     };
     // This is the function that gets called.


### PR DESCRIPTION
Removes `FunId` now that it has a single variant (see https://github.com/AeneasVerif/charon/pull/1382 for the hard work that led to this).

Fixes #1164.

ci: use https://github.com/AeneasVerif/aeneas/pull/1339

ci: use https://github.com/AeneasVerif/eurydice/pull/449