### PR TITLE
Don't typecheck under impossible clauses

### DIFF
--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -43,11 +43,12 @@ struct TypeCheckVisitor<'a> {
     body_lt_unifier: Option<UnionFind<RegionId>>,
     /// Whether `body_lt_unifier` merged anything, i.e. whether the body needs rewriting.
     did_unify_lifetimes: bool,
-    /// Copies of default methods may have contradictory premises like `Self::Item = bool` and
+    /// Defaulted methods may have contradictory premises like `Self::Item = bool` and
     /// `Self::Item = u32` which may equate entirely different types. We don't try to reason about
     /// this and instead accept this fact. It's fine because the original methods will be
     /// type-checked.
-    /// Example where this matters: tests/ui/traits/default-method-with-item-bound.6.rs
+    /// Some tests where this matters: default-method-with-item-bound.6.rs,
+    /// issue-1403-default-method-with-item-constraint
     accept_type_errors: bool,
 }
 
@@ -426,6 +427,19 @@ impl VisitAst for TypeCheckVisitor<'_> {
         VisitWithSpan::new(VisitWithBinderStack::new(self)).visit(x)?;
         self.visit_stack.pop();
         Continue(())
+    }
+
+    fn visit_binder<T: AstVisitable>(&mut self, binder: &Binder<T>) -> ControlFlow<Self::Break> {
+        let old_accept_type_errors = self.accept_type_errors;
+        // Default methods with unapplicable type constraints can give rise to type mismatches;
+        // seems to happen mostly when lifting associated types, so we skip typechecking in that
+        // case.
+        self.accept_type_errors |= matches!(&binder.kind, BinderKind::TraitMethod(..))
+            && !self.ctx.options.lift_associated_types.is_empty()
+            && !binder.params.trait_type_constraints.is_empty();
+        let result = self.visit_inner(binder);
+        self.accept_type_errors = old_accept_type_errors;
+        result
     }
 
     // Check that generics are correctly bound.

--- a/charon/tests/ui/traits/issue-1403-default-method-with-item-constraint.out
+++ b/charon/tests/ui/traits/issue-1403-default-method-with-item-constraint.out
@@ -1,0 +1,20 @@
+error: Type error after transformations:
+       Mismatched trait clause:
+       expected: TraitClause0_1: ((): Trait<B>)
+            got: impl_Trait_for_unit: Trait<(), A>
+       Visitor stack:
+         charon_lib::ast::items::item_ids::FunDeclRef
+         charon_lib::ast::type_level::Binder<charon_lib::ast::items::item_ids::FunDeclRef>
+         charon_lib::ids::index_map::IndexMap<charon_lib::ast::items::trait_decl::TraitMethodId, charon_lib::ast::type_level::Binder<charon_lib::ast::items::item_ids::FunDeclRef>>
+         charon_lib::ast::items::trait_impl::TraitImpl
+       Binding stack (depth 2):
+         0: <'_0, Clause0_Assoc, TraitClause0: (@Adt0: @TraitDecl0<missing(@TypeBound(1, 0))>), TypeConstraint0: @TraitImpl0::@AssocType0 = @Adt2>
+         1: 
+  --> tests/ui/traits/issue-1403-unapplicable-method-constraint.rs:18:1
+   |
+18 | / impl Trait for () {
+19 | |     type Assoc = A;
+20 | | }
+   | |_^
+
+ERROR Charon failed to translate this code (1 errors)

--- a/charon/tests/ui/traits/issue-1403-default-method-with-item-constraint.out
+++ b/charon/tests/ui/traits/issue-1403-default-method-with-item-constraint.out
@@ -1,20 +1,59 @@
-error: Type error after transformations:
-       Mismatched trait clause:
-       expected: TraitClause0_1: ((): Trait<B>)
-            got: impl_Trait_for_unit: Trait<(), A>
-       Visitor stack:
-         charon_lib::ast::items::item_ids::FunDeclRef
-         charon_lib::ast::type_level::Binder<charon_lib::ast::items::item_ids::FunDeclRef>
-         charon_lib::ids::index_map::IndexMap<charon_lib::ast::items::trait_decl::TraitMethodId, charon_lib::ast::type_level::Binder<charon_lib::ast::items::item_ids::FunDeclRef>>
-         charon_lib::ast::items::trait_impl::TraitImpl
-       Binding stack (depth 2):
-         0: <'_0, Clause0_Assoc, TraitClause0: (@Adt0: @TraitDecl0<missing(@TypeBound(1, 0))>), TypeConstraint0: @TraitImpl0::@AssocType0 = @Adt2>
-         1: 
-  --> tests/ui/traits/issue-1403-unapplicable-method-constraint.rs:18:1
-   |
-18 | / impl Trait for () {
-19 | |     type Assoc = A;
-20 | | }
-   | |_^
+# Final LLBC before serialization:
 
-ERROR Charon failed to translate this code (1 errors)
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+struct () {}
+
+// Full name: test_crate::A
+pub struct A {}
+
+// Full name: test_crate::B
+pub struct B {}
+
+// Full name: test_crate::Trait
+pub trait Trait<Self, Self_Assoc>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    proof ImpliedClause1: (Self_Assoc: Sized)
+    fn method<'_0_1, Clause0_Assoc, TraitClause0_1: (Self: Trait<Clause0_Assoc>), TypeConstraint0: Self::Assoc = B> = method<'_0_1, Self, Clause0_Assoc>[Self, TraitClause0_1]
+    non-dyn-compatible
+}
+
+// Full name: test_crate::Trait::method
+pub fn method<'_0, Self, Clause1_Assoc>(self: &'_0 Self)
+where
+    TraitClause0: (Self: Trait<B>),
+    TraitClause1: (Self: Trait<Clause1_Assoc>),
+    TypeOutlives0: Self: '_0,
+{
+    let _0: (); // return
+    let self: &'1 Self; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::{impl Trait<A> for ()}
+impl "impl_Trait_for_unit" Trait<A> for () {
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    proof ImpliedClause1: (A: Sized) = {built_in impl Sized for A}
+    fn method<'_0_1, Clause0_Assoc, TraitClause0_1: ((): Trait<Clause0_Assoc>), TypeConstraint0: impl_Trait_for_unit::Assoc = B> = method<'_0_1, (), Clause0_Assoc>[impl_Trait_for_unit, TraitClause0_1]
+    non-dyn-compatible
+}
+
+
+

--- a/charon/tests/ui/traits/issue-1403-default-method-with-item-constraint.rs
+++ b/charon/tests/ui/traits/issue-1403-default-method-with-item-constraint.rs
@@ -1,0 +1,20 @@
+//@ known-failure
+//@ no-default-options
+//@ charon-args=--translate-all-methods
+//@ charon-args=--lift-associated-types=*
+pub struct A;
+pub struct B;
+
+pub trait Trait {
+    type Assoc;
+
+    fn method(&self)
+    where
+        Self: Trait<Assoc = B>,
+    {
+    }
+}
+
+impl Trait for () {
+    type Assoc = A;
+}

--- a/charon/tests/ui/traits/issue-1403-default-method-with-item-constraint.rs
+++ b/charon/tests/ui/traits/issue-1403-default-method-with-item-constraint.rs
@@ -1,4 +1,3 @@
-//@ known-failure
 //@ no-default-options
 //@ charon-args=--translate-all-methods
 //@ charon-args=--lift-associated-types=*


### PR DESCRIPTION
Yet another case of defaulted methods with unapplicable predicates. Can't do better than accept the type errors.

Fixes #1403 