### PR TITLE
Mark Charon as being in beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ the world of code analysis and verification.
 
 ## Limitations
 
-Charon is alpha software. While it works quite well for a large number of crates, it has not reached
-the full set of features we intend, incorrectly translates code in some edge cases, and a number of
+Charon is beta software. It works quite well for a large number of crates, and the correctness of
+its translation is well-tested.
+That said, it is as of now poorly documented, has a number of open bugs, and a number of
 breaking changes in its API are planned. See the [limitations](./docs/limitations.md) for details.
 
 ## Installation & Build

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,21 +1,18 @@
 # Current limitations of Charon
 
-Charon is alpha software. In particular, it is currently poorly documented, doesn't support all the
+Charon is beta software. It works well but it is currently poorly documented, doesn't support all the
 Rust features we'd like, and has several breaking changes planned in the near future.
 
 ## Planned breaking changes
 
 - https://github.com/AeneasVerif/charon/issues/287
-- https://github.com/AeneasVerif/charon/issues/194
-- https://github.com/AeneasVerif/charon/issues/582
-- Some potential rework of how we handle builtins like `SliceIndexMut`
+- https://github.com/AeneasVerif/charon/issues?q=sort%3Aupdated-desc%20is%3Aissue%20state%3Aopen%20label%3AS-representation
 - Name matcher behavior likely to change in subtle ways
   (https://github.com/AeneasVerif/charon/issues/319).
 
 ## Known unsoundnesses
 
 - https://github.com/AeneasVerif/charon/issues/583
-- https://github.com/AeneasVerif/charon/issues/584
 
 ## Unsupported Rust features
 
@@ -23,8 +20,8 @@ Tracked here: https://github.com/AeneasVerif/charon/issues/142
 
 ## Missing information in the translated output
 
-- Bodies of functions in foreign crates often cause errors (https://github.com/AeneasVerif/charon/issues/543);
-- Bodies of std functions (https://github.com/AeneasVerif/charon/issues/545);
-- Drops (https://github.com/AeneasVerif/charon/issues/152);
-- Layout information (https://github.com/AeneasVerif/charon/issues/581);
+- Lifetime information about captured closure variables
+  https://github.com/AeneasVerif/charon/issues/1040;
+- Precise lifetimes for higher-ranked trait predicates
+  https://github.com/AeneasVerif/charon/issues/1143;
 - Lifetime information inside function bodies (not planned).


### PR DESCRIPTION
After a lot of work to make Charon more robust and clean up its AST, I officially declare Charon in beta!

I have got a number of changes planned to get to a 1.0, most notably:
- Finish all the [planned representation changes](https://github.com/AeneasVerif/charon/issues?q=sort%3Aupdated-desc%20is%3Aissue%20state%3Aopen%20label%3AS-representation);
- [Write a manual](https://github.com/AeneasVerif/charon/issues/236) and [document everything](https://github.com/AeneasVerif/charon/issues/1299);
- [Clean up the name matchers](https://github.com/AeneasVerif/charon/issues/319);
- Figuring out convenient distribution, e.g. as [a `cargo` subcommand](https://github.com/AeneasVerif/charon/issues/65) available on [crates.io](https://github.com/AeneasVerif/charon/issues/996).