### PR TITLE
Correctly track closure signature lifetimes in their impls

### DIFF
--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -910,8 +910,7 @@ where
                 unreachable!()
             };
             let closure = closure_args.as_closure();
-            // We lose lifetime information here. Eventually would be nice not to.
-            let input_ty = erase_free_regions(tcx, closure.sig().input(0).skip_binder());
+            let input_ty = tcx.liberate_late_bound_regions(def_id, closure.sig().input(0));
             let trait_args = [closure_ty, input_ty];
             let fn_once_trait = tcx.lang_items().fn_once_trait().unwrap();
             let fn_mut_trait = tcx.lang_items().fn_mut_trait().unwrap();

--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -910,7 +910,8 @@ where
                 unreachable!()
             };
             let closure = closure_args.as_closure();
-            let input_ty = tcx.liberate_late_bound_regions(def_id, closure.sig().input(0));
+            let input_ty = tupled_args_ty(s, closure_sig(tcx, closure));
+            let input_ty = tcx.liberate_late_bound_regions(def_id, input_ty);
             let trait_args = [closure_ty, input_ty];
             let fn_once_trait = tcx.lang_items().fn_once_trait().unwrap();
             let fn_mut_trait = tcx.lang_items().fn_mut_trait().unwrap();

--- a/charon/src/bin/charon-driver/hax/types/ty.rs
+++ b/charon/src/bin/charon-driver/hax/types/ty.rs
@@ -1432,6 +1432,68 @@ pub fn tupled_args_ty<'tcx>(
     sig.map_bound(|sig| ty::Ty::new_tup(tcx, sig.inputs()))
 }
 
+/// Retrieve a closure's signature, recovering the regions that rustc erased as fresh bound
+/// regions.
+pub fn closure_sig<'tcx>(
+    tcx: ty::TyCtxt<'tcx>,
+    closure: ty::ClosureArgs<ty::TyCtxt<'tcx>>,
+) -> ty::PolyFnSig<'tcx> {
+    use rustc_type_ir::TypeFoldable;
+    use rustc_type_ir::TypeSuperFoldable;
+
+    struct RegionUnEraserVisitor<'tcx> {
+        tcx: ty::TyCtxt<'tcx>,
+        depth: u32,
+        bound_vars: Vec<ty::BoundVariableKind<'tcx>>,
+    }
+
+    impl<'tcx> ty::TypeFolder<ty::TyCtxt<'tcx>> for RegionUnEraserVisitor<'tcx> {
+        fn cx(&self) -> ty::TyCtxt<'tcx> {
+            self.tcx
+        }
+
+        fn fold_ty(&mut self, ty: ty::Ty<'tcx>) -> ty::Ty<'tcx> {
+            ty.super_fold_with(self)
+        }
+
+        fn fold_binder<T>(&mut self, t: ty::Binder<'tcx, T>) -> ty::Binder<'tcx, T>
+        where
+            T: ty::TypeFoldable<ty::TyCtxt<'tcx>>,
+        {
+            self.depth += 1;
+            let t = t.super_fold_with(self);
+            self.depth -= 1;
+            t
+        }
+
+        fn fold_region(&mut self, r: ty::Region<'tcx>) -> ty::Region<'tcx> {
+            // Replace erased regions with fresh bound regions.
+            if r.is_erased() {
+                let bound_region = ty::BoundRegion {
+                    var: ty::BoundVar::from_usize(self.bound_vars.len()),
+                    kind: ty::BoundRegionKind::Anon,
+                };
+                self.bound_vars
+                    .push(ty::BoundVariableKind::Region(bound_region.kind));
+                ty::Region::new_bound(self.tcx, ty::DebruijnIndex::from(self.depth), bound_region)
+            } else {
+                r
+            }
+        }
+    }
+
+    let sig = closure.sig();
+    let sig = tcx.signature_unclosure(sig, rustc_hir::Safety::Safe);
+    let mut visitor = RegionUnEraserVisitor {
+        tcx,
+        depth: 0,
+        bound_vars: sig.bound_vars().iter().collect(),
+    };
+    let unbound_sig = sig.skip_binder().fold_with(&mut visitor);
+    let bound_vars = tcx.mk_bound_variable_kinds(&visitor.bound_vars);
+    ty::Binder::bind_with_vars(unbound_sig, bound_vars)
+}
+
 /// Reflects [`ty::ClosureArgs`]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 
@@ -1473,71 +1535,10 @@ impl ClosureArgs {
     where
         S: UnderOwnerState<'tcx>,
     {
-        use rustc_middle::ty;
-        use rustc_type_ir::TypeFoldable;
-        use rustc_type_ir::TypeSuperFoldable;
-
-        struct RegionUnEraserVisitor<'tcx> {
-            tcx: ty::TyCtxt<'tcx>,
-            depth: u32,
-            bound_vars: Vec<ty::BoundVariableKind<'tcx>>,
-        }
-
-        impl<'tcx> ty::TypeFolder<ty::TyCtxt<'tcx>> for RegionUnEraserVisitor<'tcx> {
-            fn cx(&self) -> ty::TyCtxt<'tcx> {
-                self.tcx
-            }
-
-            fn fold_ty(&mut self, ty: ty::Ty<'tcx>) -> ty::Ty<'tcx> {
-                ty.super_fold_with(self)
-            }
-
-            fn fold_binder<T>(&mut self, t: ty::Binder<'tcx, T>) -> ty::Binder<'tcx, T>
-            where
-                T: ty::TypeFoldable<ty::TyCtxt<'tcx>>,
-            {
-                self.depth += 1;
-                let t = t.super_fold_with(self);
-                self.depth -= 1;
-                t
-            }
-
-            fn fold_region(&mut self, r: ty::Region<'tcx>) -> ty::Region<'tcx> {
-                // Replace erased regions with fresh bound regions.
-                if r.is_erased() {
-                    let bound_region = ty::BoundRegion {
-                        var: ty::BoundVar::from_usize(self.bound_vars.len()),
-                        kind: ty::BoundRegionKind::Anon,
-                    };
-                    self.bound_vars
-                        .push(ty::BoundVariableKind::Region(bound_region.kind));
-                    ty::Region::new_bound(
-                        self.tcx,
-                        ty::DebruijnIndex::from(self.depth),
-                        bound_region,
-                    )
-                } else {
-                    r
-                }
-            }
-        }
-
         let tcx = s.base().tcx;
         let closure = from.as_closure();
         let item = translate_item_ref(s, def_id, from);
-        let sig = closure.sig();
-        let sig = tcx.signature_unclosure(sig, rustc_hir::Safety::Safe);
-        // Add bound variables for each erased region in the signature.
-        let sig = {
-            let mut visitor = RegionUnEraserVisitor {
-                tcx,
-                depth: 0,
-                bound_vars: sig.bound_vars().iter().collect(),
-            };
-            let unbound_sig = sig.skip_binder().fold_with(&mut visitor);
-            let bound_vars = tcx.mk_bound_variable_kinds(&visitor.bound_vars);
-            ty::Binder::bind_with_vars(unbound_sig, bound_vars)
-        };
+        let sig = closure_sig(tcx, closure);
         ClosureArgs {
             item,
             kind: closure.kind().sinto(s),

--- a/charon/src/bin/charon-driver/translate/translate_generics.rs
+++ b/charon/src/bin/charon-driver/translate/translate_generics.rs
@@ -314,14 +314,34 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         span: Span,
         region: &hax::LateParamRegion,
     ) -> Result<RegionDbVar, Error> {
-        let hax::LateParamRegionKind::Named(def_id, _) = &region.kind else {
-            raise_error!(self, span, "Unexpected late-bound region: {region:?}")
-        };
-        self.lookup_param(
-            span,
-            |bl| bl.region_vars_by_def_id.get(def_id).copied(),
-            || format!("the late-bound region variable {region:?}"),
-        )
+        use hax::LateParamRegionKind::*;
+        match &region.kind {
+            Anon(index) | NamedAnon(index, _) if &region.scope == self.item_src.def_id() => {
+                // These come from liberate_late_bound_regions on a closure signature. They are
+                // bound in the toplevel binder.
+                let Some(region_id) = self
+                    .outermost_binder()
+                    .bound_region_vars
+                    .get(*index as usize)
+                    .copied()
+                else {
+                    raise_error!(
+                        self,
+                        span,
+                        "Unexpected error: could not find the late-bound region variable {region:?}"
+                    )
+                };
+                Ok(DeBruijnVar::bound(self.binding_levels.depth(), region_id))
+            }
+            Named(def_id, _) => self.lookup_param(
+                span,
+                |bl| bl.region_vars_by_def_id.get(def_id).copied(),
+                || format!("the late-bound region variable {region:?}"),
+            ),
+            Anon(_) | NamedAnon(..) | ClosureEnv => {
+                raise_error!(self, span, "Unexpected late-bound region: {region:?}")
+            }
+        }
     }
 
     pub(crate) fn lookup_type_var(

--- a/charon/src/bin/charon-driver/translate/translate_generics.rs
+++ b/charon/src/bin/charon-driver/translate/translate_generics.rs
@@ -24,6 +24,8 @@ use charon_lib::utils::CycleDetector;
 /// this level, and various maps from the rustc-internal indices to our indices.
 #[derive(Debug, Default)]
 pub(crate) struct BindingLevel {
+    /// The definition whose generics this binding level contains, if this is an item binder.
+    pub def_id: Option<hax::DefId>,
     /// The parameters and predicates bound at this level.
     pub params: GenericParams,
     /// Rust makes the distinction between early and late-bound region parameters. We do not make
@@ -79,8 +81,9 @@ fn translate_variance(variance: Option<&hax::Variance>) -> Variance {
 }
 
 impl BindingLevel {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(def_id: Option<hax::DefId>) -> Self {
         Self {
+            def_id,
             ..Default::default()
         }
     }
@@ -316,29 +319,33 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
     ) -> Result<RegionDbVar, Error> {
         use hax::LateParamRegionKind::*;
         match &region.kind {
-            Anon(index) | NamedAnon(index, _) if &region.scope == self.item_src.def_id() => {
-                // These come from liberate_late_bound_regions on a closure signature. They are
-                // bound in the toplevel binder.
-                let Some(region_id) = self
-                    .outermost_binder()
-                    .bound_region_vars
-                    .get(*index as usize)
-                    .copied()
+            Anon(index) | NamedAnon(index, _) => {
+                let Some((dbid, binder)) = self
+                    .binding_levels
+                    .iter_enumerated()
+                    .find(|(_, binder)| binder.def_id.as_ref() == Some(&region.scope))
                 else {
+                    raise_error!(
+                        self,
+                        span,
+                        "Unexpected error: could not find the binder for late-bound region {region:?}"
+                    )
+                };
+                let Some(region_id) = binder.bound_region_vars.get(*index as usize).copied() else {
                     raise_error!(
                         self,
                         span,
                         "Unexpected error: could not find the late-bound region variable {region:?}"
                     )
                 };
-                Ok(DeBruijnVar::bound(self.binding_levels.depth(), region_id))
+                Ok(DeBruijnVar::bound(dbid, region_id))
             }
             Named(def_id, _) => self.lookup_param(
                 span,
                 |bl| bl.region_vars_by_def_id.get(def_id).copied(),
                 || format!("the late-bound region variable {region:?}"),
             ),
-            Anon(_) | NamedAnon(..) | ClosureEnv => {
+            ClosureEnv => {
                 raise_error!(self, span, "Unexpected late-bound region: {region:?}")
             }
         }
@@ -527,7 +534,8 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
         kind: &TransItemSourceKind,
     ) -> Result<(), Error> {
         assert!(self.binding_levels.is_empty());
-        self.binding_levels.push(BindingLevel::new());
+        self.binding_levels
+            .push(BindingLevel::new(Some(def.def_id().clone())));
         self.push_generics_for_def(span, def)?;
         self.push_late_bound_generics_for_def(span, def)?;
 
@@ -582,11 +590,16 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
     }
 
     /// Push a new binding level, run the provided function inside it, then return the bound value.
-    pub(crate) fn inside_binder<F, U>(&mut self, kind: BinderKind, f: F) -> Result<Binder<U>, Error>
+    pub(crate) fn inside_binder<F, U>(
+        &mut self,
+        kind: BinderKind,
+        def_id: Option<hax::DefId>,
+        f: F,
+    ) -> Result<Binder<U>, Error>
     where
         F: FnOnce(&mut Self) -> Result<U, Error>,
     {
-        self.binding_levels.push(BindingLevel::new());
+        self.binding_levels.push(BindingLevel::new(def_id));
 
         // Call the continuation. Important: do not short-circuit on error here.
         let res = f(self);
@@ -616,7 +629,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
     {
         let inner_hax_state = self.t_ctx.hax_state.clone().with_hax_owner(def.def_id());
         let outer_hax_state = mem::replace(&mut self.hax_state, inner_hax_state);
-        let ret = self.inside_binder(kind, |this| {
+        let ret = self.inside_binder(kind, Some(def.def_id().clone()), |this| {
             this.push_generics_for_def_without_parents(span, def)?;
             this.push_late_bound_generics_for_def(span, def)?;
             this.innermost_binder().params.check_consistency();
@@ -641,7 +654,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
     {
         let inner_hax_state = self.t_ctx.hax_state.clone().with_hax_owner(&binder.def_id);
         let outer_hax_state = mem::replace(&mut self.hax_state, inner_hax_state);
-        let ret = self.inside_binder(kind, |this| {
+        let ret = self.inside_binder(kind, Some(binder.def_id.clone()), |this| {
             this.push_param_env_without_parents(&binder.param_env, predicate_origin)?;
             this.innermost_binder_mut()
                 .push_params_from_binder(binder.late_bound.clone())?;
@@ -664,7 +677,7 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
     where
         F: FnOnce(&mut Self, &T) -> Result<U, Error>,
     {
-        let binder = self.inside_binder(BinderKind::Other, |this| {
+        let binder = self.inside_binder(BinderKind::Other, None, |this| {
             this.innermost_binder_mut()
                 .push_params_from_binder(binder.rebind(()))?;
             f(this, binder.hax_skip_binder_ref())

--- a/charon/src/bin/charon-driver/translate/translate_meta.rs
+++ b/charon/src/bin/charon-driver/translate/translate_meta.rs
@@ -469,7 +469,7 @@ impl<'tcx> TranslateCtx<'tcx> {
             let trans_id = self.register_no_enqueue(&None, src).unwrap();
             let span = self.def_span(&item_ref.def_id);
             let mut bt_ctx = ItemTransCtx::new(src.clone(), trans_id, self);
-            let binder = bt_ctx.inside_binder(BinderKind::Other, |bt_ctx| {
+            let binder = bt_ctx.inside_binder(BinderKind::Other, None, |bt_ctx| {
                 // We skip the clauses: the args are enough to uniquely identify an ite.
                 bt_ctx.translate_generic_args(span, &item_ref.generic_args, &[])
             })?;

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -118,7 +118,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         self.check_at_most_one_pred_has_methods(span, &binder.predicates)?;
 
         // Add a binder that contains the existentially quantified type.
-        self.binding_levels.push(BindingLevel::new());
+        self.binding_levels.push(BindingLevel::new(None));
 
         // Add the existentially quantified type.
         let ty_id = self.innermost_binder_mut().push_type_var(
@@ -389,7 +389,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
                     } else {
                         // The method is defined in a context that has an extra `Self: Trait` clause, so
                         // we translate it bound first.
-                        let bound_sig = self.inside_binder(BinderKind::Other, |ctx| {
+                        let bound_sig = self.inside_binder(BinderKind::Other, None, |ctx| {
                             ctx.innermost_binder_mut()
                                 .trait_preds
                                 .insert(hax::GenericPredicateId::TraitSelf, TraitClauseId::ZERO);

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -2196,15 +2196,15 @@ impl Destruct for test_crate::test_map_option3::{closure} {
 
 struct test_crate::test_regions::{closure} {}
 
-// Full name: test_crate::test_regions::{impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call
-fn {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call<'_0, '_1, '_2>(_1: &'_2 test_crate::test_regions::{closure}, tupled_args: (&'_0 &'_1 u32,)) -> u32
+// Full name: test_crate::test_regions::{impl Fn<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}::call
+fn {impl Fn<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}::call<'_0, '_1, '_2>(_1: &'_2 test_crate::test_regions::{closure}, tupled_args: (&'_0 &'_1 u32,)) -> u32
 where
     RegionOutlives0: '_1: '_0,
 {
     let _0: u32; // return
     let _1: &'1 test_crate::test_regions::{closure}; // arg #1
     let tupled_args: (&'_0 &'_1 u32,); // arg #2
-    let x: &'4 &'5 u32; // local
+    let x: &'5 &'6 u32; // local
 
     storage_live(_0)
     storage_live(x)
@@ -2239,7 +2239,7 @@ pub fn test_regions<'a>(x: &'a u32) -> u32
     _6 = &x
     _5 = &(*_6)
     _4 = (move _5,)
-    _0 = {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call<'24, '25, '26>(move _3, move _4)
+    _0 = {impl Fn<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}::call<'24, '25, '26>(move _3, move _4)
     ↳⚡ storage_dead(x)
         unwind_continue
     storage_dead(_5)
@@ -2263,8 +2263,8 @@ unsafe fn {impl Destruct for test_crate::test_regions::{closure}}::drop_glue<'_0
     return
 }
 
-// Full name: test_crate::test_regions::{impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_mut
-fn {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_mut<'_0, '_1, '_2>(state: &'_2 mut test_crate::test_regions::{closure}, args: (&'_0 &'_1 u32,)) -> u32
+// Full name: test_crate::test_regions::{impl FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}::call_mut
+fn {impl FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}::call_mut<'_0, '_1, '_2>(state: &'_2 mut test_crate::test_regions::{closure}, args: (&'_0 &'_1 u32,)) -> u32
 where
     RegionOutlives0: '_1: '_0,
 {
@@ -2276,7 +2276,7 @@ where
     storage_live(_0)
     storage_live(_3)
     _3 = &(*state)
-    _0 = {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call<'_0, '_1, '2>(move _3, move args)
+    _0 = {impl Fn<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}::call<'_0, '_1, '2>(move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -2287,21 +2287,21 @@ where
     return
 }
 
-// Full name: test_crate::test_regions::{impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_once
-fn {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_once<'_0, '_1>(_1: test_crate::test_regions::{closure}, _2: (&'_0 &'_1 u32,)) -> u32
+// Full name: test_crate::test_regions::{impl FnOnce<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}::call_once
+fn {impl FnOnce<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}::call_once<'_0, '_1>(_1: test_crate::test_regions::{closure}, _2: (&'_0 &'_1 u32,)) -> u32
 where
     RegionOutlives0: '_1: '_0,
 {
     let _0: u32; // return
     let _1: test_crate::test_regions::{closure}; // arg #1
-    let _2: (&'4 &'5 u32,); // arg #2
-    let _3: &'7 mut test_crate::test_regions::{closure}; // anonymous local
+    let _2: (&'5 &'6 u32,); // arg #2
+    let _3: &'8 mut test_crate::test_regions::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_mut<'_0, '_1, '17>(move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::test_regions::{closure}}::drop_glue<'18>] _1
+    _0 = {impl FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}::call_mut<'_0, '_1, '18>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::test_regions::{closure}}::drop_glue<'19>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -2310,7 +2310,7 @@ where
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::test_regions::{closure}}::drop_glue<'19>] _1
+    drop[{impl Destruct for test_crate::test_regions::{closure}}::drop_glue<'20>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -2321,34 +2321,43 @@ where
     return
 }
 
-// Full name: test_crate::test_regions::{impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}
-impl<'_0, '_1> FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure} {
+// Full name: test_crate::test_regions::{impl FnOnce<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}
+impl<'_0, '_1> FnOnce<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}
+where
+    RegionOutlives0: '_1: '_0,
+{
     proof ImpliedClause0: (test_crate::test_regions::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::test_regions::{closure}}
-    proof ImpliedClause1: ((&'_0 &'_ u32,): Sized) = {built_in impl Sized for (&'_0 &'_ u32,)}
-    proof ImpliedClause2: ((&'_0 &'_ u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_ u32,)}
+    proof ImpliedClause1: ((&'_0 &'_1 u32,): Sized) = {built_in impl Sized for (&'_0 &'_1 u32,)}
+    proof ImpliedClause2: ((&'_0 &'_1 u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_1 u32,)}
     proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
-    fn call_once = {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_once<'_0, '_1>
-    vtable: {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::{vtable}<'_0, '_1>
+    fn call_once = {impl FnOnce<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}::call_once<'_0, '_1>
+    vtable: {impl FnOnce<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}::{vtable}<'_0, '_1>
 }
 
-// Full name: test_crate::test_regions::{impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}
-impl<'_0, '_1> FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure} {
+// Full name: test_crate::test_regions::{impl FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}
+impl<'_0, '_1> FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}
+where
+    RegionOutlives0: '_1: '_0,
+{
     proof ImpliedClause0: (test_crate::test_regions::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::test_regions::{closure}}
-    proof ImpliedClause1: (test_crate::test_regions::{closure}: FnOnce<(&'_0 &'_ u32,), u32>) = {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}<'_0, '_1>
-    proof ImpliedClause2: ((&'_0 &'_ u32,): Sized) = {built_in impl Sized for (&'_0 &'_ u32,)}
-    proof ImpliedClause3: ((&'_0 &'_ u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_ u32,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_mut<'_0, '_1, '_0_1>
-    vtable: {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::{vtable}<'_0, '_1>
+    proof ImpliedClause1: (test_crate::test_regions::{closure}: FnOnce<(&'_0 &'_1 u32,), u32>) = {impl FnOnce<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}<'_0, '_1>
+    proof ImpliedClause2: ((&'_0 &'_1 u32,): Sized) = {built_in impl Sized for (&'_0 &'_1 u32,)}
+    proof ImpliedClause3: ((&'_0 &'_1 u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_1 u32,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}::call_mut<'_0, '_1, '_0_1>
+    vtable: {impl FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}::{vtable}<'_0, '_1>
 }
 
-// Full name: test_crate::test_regions::{impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}
-impl<'_0, '_1> Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure} {
+// Full name: test_crate::test_regions::{impl Fn<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}
+impl<'_0, '_1> Fn<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}
+where
+    RegionOutlives0: '_1: '_0,
+{
     proof ImpliedClause0: (test_crate::test_regions::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::test_regions::{closure}}
-    proof ImpliedClause1: (test_crate::test_regions::{closure}: FnMut<(&'_0 &'_ u32,), u32>) = {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}<'_0, '_1>
-    proof ImpliedClause2: ((&'_0 &'_ u32,): Sized) = {built_in impl Sized for (&'_0 &'_ u32,)}
-    proof ImpliedClause3: ((&'_0 &'_ u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_ u32,)}
-    fn call<'_0_1> = {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call<'_0, '_1, '_0_1>
-    vtable: {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::{vtable}<'_0, '_1>
+    proof ImpliedClause1: (test_crate::test_regions::{closure}: FnMut<(&'_0 &'_1 u32,), u32>) = {impl FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}<'_0, '_1>
+    proof ImpliedClause2: ((&'_0 &'_1 u32,): Sized) = {built_in impl Sized for (&'_0 &'_1 u32,)}
+    proof ImpliedClause3: ((&'_0 &'_1 u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_1 u32,)}
+    fn call<'_0_1> = {impl Fn<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}::call<'_0, '_1, '_0_1>
+    vtable: {impl Fn<(&'_0 &'_1 u32,), u32> for test_crate::test_regions::{closure}}::{vtable}<'_0, '_1>
 }
 
 // Full name: test_crate::test_regions::{closure}::{impl Destruct for test_crate::test_regions::{closure}}
@@ -2371,15 +2380,15 @@ unsafe fn {impl Destruct for test_crate::test_regions_casted::{closure}}::drop_g
     return
 }
 
-// Full name: test_crate::test_regions_casted::{impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call
-fn {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call<'_0, '_1, '_2>(_1: &'_2 test_crate::test_regions_casted::{closure}, tupled_args: (&'_0 &'_1 u32,)) -> u32
+// Full name: test_crate::test_regions_casted::{impl Fn<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}::call
+fn {impl Fn<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}::call<'_0, '_1, '_2>(_1: &'_2 test_crate::test_regions_casted::{closure}, tupled_args: (&'_0 &'_1 u32,)) -> u32
 where
     RegionOutlives0: '_1: '_0,
 {
     let _0: u32; // return
     let _1: &'1 test_crate::test_regions_casted::{closure}; // arg #1
     let tupled_args: (&'_0 &'_1 u32,); // arg #2
-    let x: &'4 &'5 u32; // local
+    let x: &'5 &'6 u32; // local
 
     storage_live(_0)
     storage_live(x)
@@ -2391,8 +2400,8 @@ where
     return
 }
 
-// Full name: test_crate::test_regions_casted::{impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut
-fn {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut<'_0, '_1, '_2>(state: &'_2 mut test_crate::test_regions_casted::{closure}, args: (&'_0 &'_1 u32,)) -> u32
+// Full name: test_crate::test_regions_casted::{impl FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut
+fn {impl FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut<'_0, '_1, '_2>(state: &'_2 mut test_crate::test_regions_casted::{closure}, args: (&'_0 &'_1 u32,)) -> u32
 where
     RegionOutlives0: '_1: '_0,
 {
@@ -2404,7 +2413,7 @@ where
     storage_live(_0)
     storage_live(_3)
     _3 = &(*state)
-    _0 = {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call<'_0, '_1, '2>(move _3, move args)
+    _0 = {impl Fn<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}::call<'_0, '_1, '2>(move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -2415,21 +2424,21 @@ where
     return
 }
 
-// Full name: test_crate::test_regions_casted::{impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once
-fn {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once<'_0, '_1>(_1: test_crate::test_regions_casted::{closure}, _2: (&'_0 &'_1 u32,)) -> u32
+// Full name: test_crate::test_regions_casted::{impl FnOnce<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once
+fn {impl FnOnce<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once<'_0, '_1>(_1: test_crate::test_regions_casted::{closure}, _2: (&'_0 &'_1 u32,)) -> u32
 where
     RegionOutlives0: '_1: '_0,
 {
     let _0: u32; // return
     let _1: test_crate::test_regions_casted::{closure}; // arg #1
-    let _2: (&'4 &'5 u32,); // arg #2
-    let _3: &'7 mut test_crate::test_regions_casted::{closure}; // anonymous local
+    let _2: (&'5 &'6 u32,); // arg #2
+    let _3: &'8 mut test_crate::test_regions_casted::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut<'_0, '_1, '17>(move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::test_regions_casted::{closure}}::drop_glue<'18>] _1
+    _0 = {impl FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut<'_0, '_1, '18>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::test_regions_casted::{closure}}::drop_glue<'19>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -2438,7 +2447,7 @@ where
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::test_regions_casted::{closure}}::drop_glue<'19>] _1
+    drop[{impl Destruct for test_crate::test_regions_casted::{closure}}::drop_glue<'20>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -2463,7 +2472,7 @@ where
     storage_live(state)
     args = (move arg1,)
     state = test_crate::test_regions_casted::{closure} {  }
-    _0 = {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once<'_0, '_1>(move state, move args)
+    _0 = {impl FnOnce<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once<'_0, '_1>(move state, move args)
     ↳⚡ storage_dead(state)
         storage_dead(args)
         storage_dead(arg1)
@@ -2510,34 +2519,43 @@ pub fn test_regions_casted<'a>(x: &'a u32) -> u32
     return
 }
 
-// Full name: test_crate::test_regions_casted::{impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}
-impl<'_0, '_1> FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure} {
+// Full name: test_crate::test_regions_casted::{impl FnOnce<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}
+impl<'_0, '_1> FnOnce<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}
+where
+    RegionOutlives0: '_1: '_0,
+{
     proof ImpliedClause0: (test_crate::test_regions_casted::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::test_regions_casted::{closure}}
-    proof ImpliedClause1: ((&'_0 &'_ u32,): Sized) = {built_in impl Sized for (&'_0 &'_ u32,)}
-    proof ImpliedClause2: ((&'_0 &'_ u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_ u32,)}
+    proof ImpliedClause1: ((&'_0 &'_1 u32,): Sized) = {built_in impl Sized for (&'_0 &'_1 u32,)}
+    proof ImpliedClause2: ((&'_0 &'_1 u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_1 u32,)}
     proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
-    fn call_once = {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once<'_0, '_1>
-    vtable: {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::{vtable}<'_0, '_1>
+    fn call_once = {impl FnOnce<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once<'_0, '_1>
+    vtable: {impl FnOnce<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}::{vtable}<'_0, '_1>
 }
 
-// Full name: test_crate::test_regions_casted::{impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}
-impl<'_0, '_1> FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure} {
+// Full name: test_crate::test_regions_casted::{impl FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}
+impl<'_0, '_1> FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}
+where
+    RegionOutlives0: '_1: '_0,
+{
     proof ImpliedClause0: (test_crate::test_regions_casted::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::test_regions_casted::{closure}}
-    proof ImpliedClause1: (test_crate::test_regions_casted::{closure}: FnOnce<(&'_0 &'_ u32,), u32>) = {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}<'_0, '_1>
-    proof ImpliedClause2: ((&'_0 &'_ u32,): Sized) = {built_in impl Sized for (&'_0 &'_ u32,)}
-    proof ImpliedClause3: ((&'_0 &'_ u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_ u32,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut<'_0, '_1, '_0_1>
-    vtable: {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::{vtable}<'_0, '_1>
+    proof ImpliedClause1: (test_crate::test_regions_casted::{closure}: FnOnce<(&'_0 &'_1 u32,), u32>) = {impl FnOnce<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}<'_0, '_1>
+    proof ImpliedClause2: ((&'_0 &'_1 u32,): Sized) = {built_in impl Sized for (&'_0 &'_1 u32,)}
+    proof ImpliedClause3: ((&'_0 &'_1 u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_1 u32,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut<'_0, '_1, '_0_1>
+    vtable: {impl FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}::{vtable}<'_0, '_1>
 }
 
-// Full name: test_crate::test_regions_casted::{impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}
-impl<'_0, '_1> Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure} {
+// Full name: test_crate::test_regions_casted::{impl Fn<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}
+impl<'_0, '_1> Fn<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}
+where
+    RegionOutlives0: '_1: '_0,
+{
     proof ImpliedClause0: (test_crate::test_regions_casted::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::test_regions_casted::{closure}}
-    proof ImpliedClause1: (test_crate::test_regions_casted::{closure}: FnMut<(&'_0 &'_ u32,), u32>) = {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}<'_0, '_1>
-    proof ImpliedClause2: ((&'_0 &'_ u32,): Sized) = {built_in impl Sized for (&'_0 &'_ u32,)}
-    proof ImpliedClause3: ((&'_0 &'_ u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_ u32,)}
-    fn call<'_0_1> = {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call<'_0, '_1, '_0_1>
-    vtable: {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::{vtable}<'_0, '_1>
+    proof ImpliedClause1: (test_crate::test_regions_casted::{closure}: FnMut<(&'_0 &'_1 u32,), u32>) = {impl FnMut<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}<'_0, '_1>
+    proof ImpliedClause2: ((&'_0 &'_1 u32,): Sized) = {built_in impl Sized for (&'_0 &'_1 u32,)}
+    proof ImpliedClause3: ((&'_0 &'_1 u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_1 u32,)}
+    fn call<'_0_1> = {impl Fn<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}::call<'_0, '_1, '_0_1>
+    vtable: {impl Fn<(&'_0 &'_1 u32,), u32> for test_crate::test_regions_casted::{closure}}::{vtable}<'_0, '_1>
 }
 
 // Full name: test_crate::test_regions_casted::{closure}::{impl Destruct for test_crate::test_regions_casted::{closure}}

--- a/charon/tests/ui/closures.out
+++ b/charon/tests/ui/closures.out
@@ -849,13 +849,13 @@ unsafe fn {impl Destruct for test_crate::test_closure_ref_u32::{closure}}::drop_
     return
 }
 
-// Full name: test_crate::test_closure_ref_u32::{impl Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}::call
-fn {impl Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}::call<'_0, '_1>(_1: &'_1 test_crate::test_closure_ref_u32::{closure}, tupled_args: (&'_0 u32,)) -> &'_0 u32
+// Full name: test_crate::test_closure_ref_u32::{impl Fn<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}::call
+fn {impl Fn<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}::call<'_0, '_1>(_1: &'_1 test_crate::test_closure_ref_u32::{closure}, tupled_args: (&'_0 u32,)) -> &'_0 u32
 {
-    let _0: &'0 u32; // return
-    let _1: &'2 test_crate::test_closure_ref_u32::{closure}; // arg #1
+    let _0: &'1 u32; // return
+    let _1: &'3 test_crate::test_closure_ref_u32::{closure}; // arg #1
     let tupled_args: (&'_0 u32,); // arg #2
-    let y: &'3 u32; // local
+    let y: &'4 u32; // local
 
     storage_live(_0)
     storage_live(y)
@@ -867,8 +867,8 @@ fn {impl Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}
     return
 }
 
-// Full name: test_crate::test_closure_ref_u32::{impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}::call_mut
-fn {impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}::call_mut<'_0, '_1>(state: &'_1 mut test_crate::test_closure_ref_u32::{closure}, args: (&'_0 u32,)) -> &'_0 u32
+// Full name: test_crate::test_closure_ref_u32::{impl FnMut<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}::call_mut
+fn {impl FnMut<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}::call_mut<'_0, '_1>(state: &'_1 mut test_crate::test_closure_ref_u32::{closure}, args: (&'_0 u32,)) -> &'_0 u32
 {
     let _0: &'_0 u32; // return
     let state: &'_1 mut test_crate::test_closure_ref_u32::{closure}; // arg #1
@@ -878,7 +878,7 @@ fn {impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closu
     storage_live(_0)
     storage_live(_3)
     _3 = &(*state)
-    _0 = {impl Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}::call<'_0, '2>(move _3, move args)
+    _0 = {impl Fn<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}::call<'_0, '2>(move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -889,19 +889,19 @@ fn {impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closu
     return
 }
 
-// Full name: test_crate::test_closure_ref_u32::{impl FnOnce<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}::call_once
-fn {impl FnOnce<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}::call_once<'_0>(_1: test_crate::test_closure_ref_u32::{closure}, _2: (&'_0 u32,)) -> &'_0 u32
+// Full name: test_crate::test_closure_ref_u32::{impl FnOnce<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}::call_once
+fn {impl FnOnce<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}::call_once<'_0>(_1: test_crate::test_closure_ref_u32::{closure}, _2: (&'_0 u32,)) -> &'_0 u32
 {
-    let _0: &'0 u32; // return
+    let _0: &'1 u32; // return
     let _1: test_crate::test_closure_ref_u32::{closure}; // arg #1
-    let _2: (&'1 u32,); // arg #2
-    let _3: &'3 mut test_crate::test_closure_ref_u32::{closure}; // anonymous local
+    let _2: (&'3 u32,); // arg #2
+    let _3: &'5 mut test_crate::test_closure_ref_u32::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}::call_mut<'_0, '8>(move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::test_closure_ref_u32::{closure}}::drop_glue<'9>] _1
+    _0 = {impl FnMut<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}::call_mut<'_0, '10>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::test_closure_ref_u32::{closure}}::drop_glue<'11>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -910,7 +910,7 @@ fn {impl FnOnce<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{clos
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::test_closure_ref_u32::{closure}}::drop_glue<'10>] _1
+    drop[{impl Destruct for test_crate::test_closure_ref_u32::{closure}}::drop_glue<'12>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -933,7 +933,7 @@ fn test_crate::test_closure_ref_u32::{closure}::{as_fn}<'_0>(arg1: &'_0 u32) -> 
     storage_live(state)
     args = (move arg1,)
     state = test_crate::test_closure_ref_u32::{closure} {  }
-    _0 = {impl FnOnce<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}::call_once<'_0>(move state, move args)
+    _0 = {impl FnOnce<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}::call_once<'_0>(move state, move args)
     ↳⚡ storage_dead(state)
         storage_dead(args)
         storage_dead(arg1)
@@ -981,34 +981,34 @@ pub fn test_closure_ref_u32<'a>(x: &'a u32) -> &'a u32
     return
 }
 
-// Full name: test_crate::test_closure_ref_u32::{impl FnOnce<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}
-impl<'_0> FnOnce<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure} {
+// Full name: test_crate::test_closure_ref_u32::{impl FnOnce<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}
+impl<'_0> FnOnce<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure} {
     proof ImpliedClause0: (test_crate::test_closure_ref_u32::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_u32::{closure}}
-    proof ImpliedClause1: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
-    proof ImpliedClause2: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
-    proof ImpliedClause3: (&'_ u32: Sized) = {built_in impl Sized for &'_ u32}
-    fn call_once = {impl FnOnce<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}::call_once<'_0>
-    vtable: {impl FnOnce<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}::{vtable}<'_0>
+    proof ImpliedClause1: ((&'_0 u32,): Sized) = {built_in impl Sized for (&'_0 u32,)}
+    proof ImpliedClause2: ((&'_0 u32,): Tuple) = {built_in impl Tuple for (&'_0 u32,)}
+    proof ImpliedClause3: (&'_0 u32: Sized) = {built_in impl Sized for &'_0 u32}
+    fn call_once = {impl FnOnce<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}::call_once<'_0>
+    vtable: {impl FnOnce<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}::{vtable}<'_0>
 }
 
-// Full name: test_crate::test_closure_ref_u32::{impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}
-impl<'_0> FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure} {
+// Full name: test_crate::test_closure_ref_u32::{impl FnMut<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}
+impl<'_0> FnMut<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure} {
     proof ImpliedClause0: (test_crate::test_closure_ref_u32::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_u32::{closure}}
-    proof ImpliedClause1: (test_crate::test_closure_ref_u32::{closure}: FnOnce<(&'_ u32,), &'_ u32>) = {impl FnOnce<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}<'_0>
-    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
-    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}::call_mut<'_0, '_0_1>
-    vtable: {impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}::{vtable}<'_0>
+    proof ImpliedClause1: (test_crate::test_closure_ref_u32::{closure}: FnOnce<(&'_0 u32,), &'_0 u32>) = {impl FnOnce<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}<'_0>
+    proof ImpliedClause2: ((&'_0 u32,): Sized) = {built_in impl Sized for (&'_0 u32,)}
+    proof ImpliedClause3: ((&'_0 u32,): Tuple) = {built_in impl Tuple for (&'_0 u32,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}::call_mut<'_0, '_0_1>
+    vtable: {impl FnMut<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}::{vtable}<'_0>
 }
 
-// Full name: test_crate::test_closure_ref_u32::{impl Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}
-impl<'_0> Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure} {
+// Full name: test_crate::test_closure_ref_u32::{impl Fn<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}
+impl<'_0> Fn<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure} {
     proof ImpliedClause0: (test_crate::test_closure_ref_u32::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_u32::{closure}}
-    proof ImpliedClause1: (test_crate::test_closure_ref_u32::{closure}: FnMut<(&'_ u32,), &'_ u32>) = {impl FnMut<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}<'_0>
-    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
-    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
-    fn call<'_0_1> = {impl Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}::call<'_0, '_0_1>
-    vtable: {impl Fn<(&'_ u32,), &'_ u32> for test_crate::test_closure_ref_u32::{closure}}::{vtable}<'_0>
+    proof ImpliedClause1: (test_crate::test_closure_ref_u32::{closure}: FnMut<(&'_0 u32,), &'_0 u32>) = {impl FnMut<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}<'_0>
+    proof ImpliedClause2: ((&'_0 u32,): Sized) = {built_in impl Sized for (&'_0 u32,)}
+    proof ImpliedClause3: ((&'_0 u32,): Tuple) = {built_in impl Tuple for (&'_0 u32,)}
+    fn call<'_0_1> = {impl Fn<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}::call<'_0, '_0_1>
+    vtable: {impl Fn<(&'_0 u32,), &'_0 u32> for test_crate::test_closure_ref_u32::{closure}}::{vtable}<'_0>
 }
 
 // Full name: test_crate::test_closure_ref_u32::{closure}::{impl Destruct for test_crate::test_closure_ref_u32::{closure}}
@@ -1037,17 +1037,17 @@ where
     return
 }
 
-// Full name: test_crate::test_closure_ref_param::{impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call
-fn {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call<'_0, '_1, T>(_1: &'_1 test_crate::test_closure_ref_param::{closure}<T>[TraitClause0], tupled_args: (&'_0 T,)) -> &'_0 T
+// Full name: test_crate::test_closure_ref_param::{impl Fn<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call
+fn {impl Fn<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call<'_0, '_1, T>(_1: &'_1 test_crate::test_closure_ref_param::{closure}<T>[TraitClause0], tupled_args: (&'_0 T,)) -> &'_0 T
 where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_1,
     TypeOutlives1: T: '_0,
 {
-    let _0: &'0 T; // return
-    let _1: &'2 test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]; // arg #1
+    let _0: &'1 T; // return
+    let _1: &'3 test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]; // arg #1
     let tupled_args: (&'_0 T,); // arg #2
-    let x: &'3 T; // local
+    let x: &'4 T; // local
 
     storage_live(_0)
     storage_live(x)
@@ -1059,8 +1059,8 @@ where
     return
 }
 
-// Full name: test_crate::test_closure_ref_param::{impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_mut
-fn {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_mut<'_0, '_1, T>(state: &'_1 mut test_crate::test_closure_ref_param::{closure}<T>[TraitClause0], args: (&'_0 T,)) -> &'_0 T
+// Full name: test_crate::test_closure_ref_param::{impl FnMut<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_mut
+fn {impl FnMut<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_mut<'_0, '_1, T>(state: &'_1 mut test_crate::test_closure_ref_param::{closure}<T>[TraitClause0], args: (&'_0 T,)) -> &'_0 T
 where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_1,
@@ -1074,7 +1074,7 @@ where
     storage_live(_0)
     storage_live(_3)
     _3 = &(*state)
-    _0 = {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call<'_0, '2, T>[TraitClause0](move _3, move args)
+    _0 = {impl Fn<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call<'_0, '2, T>[TraitClause0](move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -1085,22 +1085,22 @@ where
     return
 }
 
-// Full name: test_crate::test_closure_ref_param::{impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_once
-fn {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_once<'_0, T>(_1: test_crate::test_closure_ref_param::{closure}<T>[TraitClause0], _2: (&'_0 T,)) -> &'_0 T
+// Full name: test_crate::test_closure_ref_param::{impl FnOnce<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_once
+fn {impl FnOnce<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_once<'_0, T>(_1: test_crate::test_closure_ref_param::{closure}<T>[TraitClause0], _2: (&'_0 T,)) -> &'_0 T
 where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_0,
 {
-    let _0: &'0 T; // return
+    let _0: &'1 T; // return
     let _1: test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]; // arg #1
-    let _2: (&'1 T,); // arg #2
-    let _3: &'3 mut test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]; // anonymous local
+    let _2: (&'3 T,); // arg #2
+    let _3: &'5 mut test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_mut<'_0, '8, T>[TraitClause0](move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::drop_glue<'9, T>[TraitClause0]] _1
+    _0 = {impl FnMut<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_mut<'_0, '10, T>[TraitClause0](move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::drop_glue<'11, T>[TraitClause0]] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -1109,7 +1109,7 @@ where
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::drop_glue<'10, T>[TraitClause0]] _1
+    drop[{impl Destruct for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::drop_glue<'12, T>[TraitClause0]] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -1135,7 +1135,7 @@ where
     storage_live(state)
     args = (move arg1,)
     state = test_crate::test_closure_ref_param::{closure} {  }
-    _0 = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_once<'_0, T>[TraitClause0](move state, move args)
+    _0 = {impl FnOnce<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_once<'_0, T>[TraitClause0](move state, move args)
     ↳⚡ storage_dead(state)
         storage_dead(args)
         storage_dead(arg1)
@@ -1185,43 +1185,46 @@ where
     return
 }
 
-// Full name: test_crate::test_closure_ref_param::{impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}
-impl<'_0, T> FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]
+// Full name: test_crate::test_closure_ref_param::{impl FnOnce<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}
+impl<'_0, T> FnOnce<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]
 where
     TraitClause0: (T: Sized),
+    TypeOutlives0: T: '_0,
 {
     proof ImpliedClause0: (test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}
-    proof ImpliedClause1: ((&'_ T,): Sized) = {built_in impl Sized for (&'_ T,)}
-    proof ImpliedClause2: ((&'_ T,): Tuple) = {built_in impl Tuple for (&'_ T,)}
-    proof ImpliedClause3: (&'_ T: Sized) = {built_in impl Sized for &'_ T}
-    fn call_once = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_once<'_0, T>[TraitClause0]
-    vtable: {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::{vtable}<'_0, T>[TraitClause0]
+    proof ImpliedClause1: ((&'_0 T,): Sized) = {built_in impl Sized for (&'_0 T,)}
+    proof ImpliedClause2: ((&'_0 T,): Tuple) = {built_in impl Tuple for (&'_0 T,)}
+    proof ImpliedClause3: (&'_0 T: Sized) = {built_in impl Sized for &'_0 T}
+    fn call_once = {impl FnOnce<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_once<'_0, T>[TraitClause0]
+    vtable: {impl FnOnce<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::{vtable}<'_0, T>[TraitClause0]
 }
 
-// Full name: test_crate::test_closure_ref_param::{impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}
-impl<'_0, T> FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]
+// Full name: test_crate::test_closure_ref_param::{impl FnMut<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}
+impl<'_0, T> FnMut<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]
 where
     TraitClause0: (T: Sized),
+    TypeOutlives0: T: '_0,
 {
     proof ImpliedClause0: (test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}
-    proof ImpliedClause1: (test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]: FnOnce<(&'_ T,), &'_ T>) = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}<'_0, T>[TraitClause0]
-    proof ImpliedClause2: ((&'_ T,): Sized) = {built_in impl Sized for (&'_ T,)}
-    proof ImpliedClause3: ((&'_ T,): Tuple) = {built_in impl Tuple for (&'_ T,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_mut<'_0, '_0_1, T>[TraitClause0]
-    vtable: {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::{vtable}<'_0, T>[TraitClause0]
+    proof ImpliedClause1: (test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]: FnOnce<(&'_0 T,), &'_0 T>) = {impl FnOnce<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}<'_0, T>[TraitClause0]
+    proof ImpliedClause2: ((&'_0 T,): Sized) = {built_in impl Sized for (&'_0 T,)}
+    proof ImpliedClause3: ((&'_0 T,): Tuple) = {built_in impl Tuple for (&'_0 T,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call_mut<'_0, '_0_1, T>[TraitClause0]
+    vtable: {impl FnMut<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::{vtable}<'_0, T>[TraitClause0]
 }
 
-// Full name: test_crate::test_closure_ref_param::{impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}
-impl<'_0, T> Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]
+// Full name: test_crate::test_closure_ref_param::{impl Fn<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}
+impl<'_0, T> Fn<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]
 where
     TraitClause0: (T: Sized),
+    TypeOutlives0: T: '_0,
 {
     proof ImpliedClause0: (test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}
-    proof ImpliedClause1: (test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]: FnMut<(&'_ T,), &'_ T>) = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}<'_0, T>[TraitClause0]
-    proof ImpliedClause2: ((&'_ T,): Sized) = {built_in impl Sized for (&'_ T,)}
-    proof ImpliedClause3: ((&'_ T,): Tuple) = {built_in impl Tuple for (&'_ T,)}
-    fn call<'_0_1> = {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call<'_0, '_0_1, T>[TraitClause0]
-    vtable: {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::{vtable}<'_0, T>[TraitClause0]
+    proof ImpliedClause1: (test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]: FnMut<(&'_0 T,), &'_0 T>) = {impl FnMut<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}<'_0, T>[TraitClause0]
+    proof ImpliedClause2: ((&'_0 T,): Sized) = {built_in impl Sized for (&'_0 T,)}
+    proof ImpliedClause3: ((&'_0 T,): Tuple) = {built_in impl Tuple for (&'_0 T,)}
+    fn call<'_0_1> = {impl Fn<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::call<'_0, '_0_1, T>[TraitClause0]
+    vtable: {impl Fn<(&'_0 T,), &'_0 T> for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}::{vtable}<'_0, T>[TraitClause0]
 }
 
 // Full name: test_crate::test_closure_ref_param::{closure}::{impl Destruct for test_crate::test_closure_ref_param::{closure}<T>[TraitClause0]}
@@ -1263,8 +1266,8 @@ where
     return
 }
 
-// Full name: test_crate::test_closure_ref_early_bound::{impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call
-fn {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, T>(_1: &'_2 test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1], tupled_args: (&'_1 T,)) -> &'_1 T
+// Full name: test_crate::test_closure_ref_early_bound::{impl Fn<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call
+fn {impl Fn<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, T>(_1: &'_2 test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1], tupled_args: (&'_1 T,)) -> &'_1 T
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Trait<'a>),
@@ -1272,10 +1275,10 @@ where
     TypeOutlives1: T: '_1,
     RegionOutlives0: 'a: '_2,
 {
-    let _0: &'0 T; // return
-    let _1: &'3 test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]; // arg #1
+    let _0: &'1 T; // return
+    let _1: &'4 test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args: (&'_1 T,); // arg #2
-    let y: &'5 T; // local
+    let y: &'6 T; // local
 
     storage_live(_0)
     storage_live(y)
@@ -1287,8 +1290,8 @@ where
     return
 }
 
-// Full name: test_crate::test_closure_ref_early_bound::{impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_mut
-fn {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, T>(state: &'_2 mut test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1], args: (&'_1 T,)) -> &'_1 T
+// Full name: test_crate::test_closure_ref_early_bound::{impl FnMut<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_mut
+fn {impl FnMut<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, T>(state: &'_2 mut test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1], args: (&'_1 T,)) -> &'_1 T
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Trait<'a>),
@@ -1304,7 +1307,7 @@ where
     storage_live(_0)
     storage_live(_3)
     _3 = &(*state)
-    _0 = {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '7, T>[TraitClause0, TraitClause1](move _3, move args)
+    _0 = {impl Fn<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '7, T>[TraitClause0, TraitClause1](move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -1315,23 +1318,23 @@ where
     return
 }
 
-// Full name: test_crate::test_closure_ref_early_bound::{impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_once
-fn {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, T>(_1: test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1], _2: (&'_1 T,)) -> &'_1 T
+// Full name: test_crate::test_closure_ref_early_bound::{impl FnOnce<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, T>(_1: test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1], _2: (&'_1 T,)) -> &'_1 T
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Trait<'a>),
     TypeOutlives0: T: '_1,
 {
-    let _0: &'0 T; // return
+    let _0: &'1 T; // return
     let _1: test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]; // arg #1
-    let _2: (&'2 T,); // arg #2
-    let _3: &'5 mut test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]; // anonymous local
+    let _2: (&'4 T,); // arg #2
+    let _3: &'7 mut test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '16, T>[TraitClause0, TraitClause1](move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::drop_glue<'a, '22, T>[TraitClause0, TraitClause1]] _1
+    _0 = {impl FnMut<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '18, T>[TraitClause0, TraitClause1](move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::drop_glue<'a, '24, T>[TraitClause0, TraitClause1]] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -1340,7 +1343,7 @@ where
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::drop_glue<'a, '28, T>[TraitClause0, TraitClause1]] _1
+    drop[{impl Destruct for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::drop_glue<'a, '30, T>[TraitClause0, TraitClause1]] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -1367,7 +1370,7 @@ where
     storage_live(state)
     args = (move arg1,)
     state = test_crate::test_closure_ref_early_bound::{closure} {  }
-    _0 = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, T>[TraitClause0, TraitClause1](move state, move args)
+    _0 = {impl FnOnce<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, T>[TraitClause0, TraitClause1](move state, move args)
     ↳⚡ storage_dead(state)
         storage_dead(args)
         storage_dead(arg1)
@@ -1418,46 +1421,49 @@ where
     return
 }
 
-// Full name: test_crate::test_closure_ref_early_bound::{impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}
-impl<'a, '_1, T> FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]
+// Full name: test_crate::test_closure_ref_early_bound::{impl FnOnce<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, T> FnOnce<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Trait<'a>),
+    TypeOutlives0: T: '_1,
 {
     proof ImpliedClause0: (test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}
-    proof ImpliedClause1: ((&'_ T,): Sized) = {built_in impl Sized for (&'_ T,)}
-    proof ImpliedClause2: ((&'_ T,): Tuple) = {built_in impl Tuple for (&'_ T,)}
-    proof ImpliedClause3: (&'_ T: Sized) = {built_in impl Sized for &'_ T}
-    fn call_once = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, T>[TraitClause0, TraitClause1]
-    vtable: {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause1: ((&'_1 T,): Sized) = {built_in impl Sized for (&'_1 T,)}
+    proof ImpliedClause2: ((&'_1 T,): Tuple) = {built_in impl Tuple for (&'_1 T,)}
+    proof ImpliedClause3: (&'_1 T: Sized) = {built_in impl Sized for &'_1 T}
+    fn call_once = {impl FnOnce<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, T>[TraitClause0, TraitClause1]
+    vtable: {impl FnOnce<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, T>[TraitClause0, TraitClause1]
 }
 
-// Full name: test_crate::test_closure_ref_early_bound::{impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}
-impl<'a, '_1, T> FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]
+// Full name: test_crate::test_closure_ref_early_bound::{impl FnMut<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, T> FnMut<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Trait<'a>),
+    TypeOutlives0: T: '_1,
 {
     proof ImpliedClause0: (test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}
-    proof ImpliedClause1: (test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]: FnOnce<(&'_ T,), &'_ T>) = {impl FnOnce<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}<'a, '_1, T>[TraitClause0, TraitClause1]
-    proof ImpliedClause2: ((&'_ T,): Sized) = {built_in impl Sized for (&'_ T,)}
-    proof ImpliedClause3: ((&'_ T,): Tuple) = {built_in impl Tuple for (&'_ T,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_0_1, T>[TraitClause0, TraitClause1]
-    vtable: {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause1: (test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]: FnOnce<(&'_1 T,), &'_1 T>) = {impl FnOnce<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}<'a, '_1, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((&'_1 T,): Sized) = {built_in impl Sized for (&'_1 T,)}
+    proof ImpliedClause3: ((&'_1 T,): Tuple) = {built_in impl Tuple for (&'_1 T,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_0_1, T>[TraitClause0, TraitClause1]
+    vtable: {impl FnMut<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, T>[TraitClause0, TraitClause1]
 }
 
-// Full name: test_crate::test_closure_ref_early_bound::{impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}
-impl<'a, '_1, T> Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]
+// Full name: test_crate::test_closure_ref_early_bound::{impl Fn<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, T> Fn<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Trait<'a>),
+    TypeOutlives0: T: '_1,
 {
     proof ImpliedClause0: (test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}
-    proof ImpliedClause1: (test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]: FnMut<(&'_ T,), &'_ T>) = {impl FnMut<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}<'a, '_1, T>[TraitClause0, TraitClause1]
-    proof ImpliedClause2: ((&'_ T,): Sized) = {built_in impl Sized for (&'_ T,)}
-    proof ImpliedClause3: ((&'_ T,): Tuple) = {built_in impl Tuple for (&'_ T,)}
-    fn call<'_0_1> = {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_0_1, T>[TraitClause0, TraitClause1]
-    vtable: {impl Fn<(&'_ T,), &'_ T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause1: (test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]: FnMut<(&'_1 T,), &'_1 T>) = {impl FnMut<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}<'a, '_1, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((&'_1 T,): Sized) = {built_in impl Sized for (&'_1 T,)}
+    proof ImpliedClause3: ((&'_1 T,): Tuple) = {built_in impl Tuple for (&'_1 T,)}
+    fn call<'_0_1> = {impl Fn<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_0_1, T>[TraitClause0, TraitClause1]
+    vtable: {impl Fn<(&'_1 T,), &'_1 T> for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, T>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::test_closure_ref_early_bound::{closure}::{impl Destruct for test_crate::test_closure_ref_early_bound::{closure}<'a, T>[TraitClause0, TraitClause1]}
@@ -2190,15 +2196,15 @@ impl Destruct for test_crate::test_map_option3::{closure} {
 
 struct test_crate::test_regions::{closure} {}
 
-// Full name: test_crate::test_regions::{impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}::call
-fn {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}::call<'_0, '_1, '_2>(_1: &'_2 test_crate::test_regions::{closure}, tupled_args: (&'_0 &'_1 u32,)) -> u32
+// Full name: test_crate::test_regions::{impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call
+fn {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call<'_0, '_1, '_2>(_1: &'_2 test_crate::test_regions::{closure}, tupled_args: (&'_0 &'_1 u32,)) -> u32
 where
     RegionOutlives0: '_1: '_0,
 {
     let _0: u32; // return
     let _1: &'1 test_crate::test_regions::{closure}; // arg #1
     let tupled_args: (&'_0 &'_1 u32,); // arg #2
-    let x: &'2 &'3 u32; // local
+    let x: &'4 &'5 u32; // local
 
     storage_live(_0)
     storage_live(x)
@@ -2233,7 +2239,7 @@ pub fn test_regions<'a>(x: &'a u32) -> u32
     _6 = &x
     _5 = &(*_6)
     _4 = (move _5,)
-    _0 = {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}::call<'24, '25, '26>(move _3, move _4)
+    _0 = {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call<'24, '25, '26>(move _3, move _4)
     ↳⚡ storage_dead(x)
         unwind_continue
     storage_dead(_5)
@@ -2257,8 +2263,8 @@ unsafe fn {impl Destruct for test_crate::test_regions::{closure}}::drop_glue<'_0
     return
 }
 
-// Full name: test_crate::test_regions::{impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_mut
-fn {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_mut<'_0, '_1, '_2>(state: &'_2 mut test_crate::test_regions::{closure}, args: (&'_0 &'_1 u32,)) -> u32
+// Full name: test_crate::test_regions::{impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_mut
+fn {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_mut<'_0, '_1, '_2>(state: &'_2 mut test_crate::test_regions::{closure}, args: (&'_0 &'_1 u32,)) -> u32
 where
     RegionOutlives0: '_1: '_0,
 {
@@ -2270,7 +2276,7 @@ where
     storage_live(_0)
     storage_live(_3)
     _3 = &(*state)
-    _0 = {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}::call<'_0, '_1, '2>(move _3, move args)
+    _0 = {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call<'_0, '_1, '2>(move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -2281,21 +2287,21 @@ where
     return
 }
 
-// Full name: test_crate::test_regions::{impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_once
-fn {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_once<'_0, '_1>(_1: test_crate::test_regions::{closure}, _2: (&'_0 &'_1 u32,)) -> u32
+// Full name: test_crate::test_regions::{impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_once
+fn {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_once<'_0, '_1>(_1: test_crate::test_regions::{closure}, _2: (&'_0 &'_1 u32,)) -> u32
 where
     RegionOutlives0: '_1: '_0,
 {
     let _0: u32; // return
     let _1: test_crate::test_regions::{closure}; // arg #1
-    let _2: (&'0 &'1 u32,); // arg #2
-    let _3: &'3 mut test_crate::test_regions::{closure}; // anonymous local
+    let _2: (&'4 &'5 u32,); // arg #2
+    let _3: &'7 mut test_crate::test_regions::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_mut<'_0, '_1, '13>(move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::test_regions::{closure}}::drop_glue<'14>] _1
+    _0 = {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_mut<'_0, '_1, '17>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::test_regions::{closure}}::drop_glue<'18>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -2304,7 +2310,7 @@ where
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::test_regions::{closure}}::drop_glue<'15>] _1
+    drop[{impl Destruct for test_crate::test_regions::{closure}}::drop_glue<'19>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -2315,34 +2321,34 @@ where
     return
 }
 
-// Full name: test_crate::test_regions::{impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}
-impl<'_0, '_1> FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure} {
+// Full name: test_crate::test_regions::{impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}
+impl<'_0, '_1> FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure} {
     proof ImpliedClause0: (test_crate::test_regions::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::test_regions::{closure}}
-    proof ImpliedClause1: ((&'_ &'_ u32,): Sized) = {built_in impl Sized for (&'_ &'_ u32,)}
-    proof ImpliedClause2: ((&'_ &'_ u32,): Tuple) = {built_in impl Tuple for (&'_ &'_ u32,)}
+    proof ImpliedClause1: ((&'_0 &'_ u32,): Sized) = {built_in impl Sized for (&'_0 &'_ u32,)}
+    proof ImpliedClause2: ((&'_0 &'_ u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_ u32,)}
     proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
-    fn call_once = {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_once<'_0, '_1>
-    vtable: {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}::{vtable}<'_0, '_1>
+    fn call_once = {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_once<'_0, '_1>
+    vtable: {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::{vtable}<'_0, '_1>
 }
 
-// Full name: test_crate::test_regions::{impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}
-impl<'_0, '_1> FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure} {
+// Full name: test_crate::test_regions::{impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}
+impl<'_0, '_1> FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure} {
     proof ImpliedClause0: (test_crate::test_regions::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::test_regions::{closure}}
-    proof ImpliedClause1: (test_crate::test_regions::{closure}: FnOnce<(&'_ &'_ u32,), u32>) = {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}<'_0, '_1>
-    proof ImpliedClause2: ((&'_ &'_ u32,): Sized) = {built_in impl Sized for (&'_ &'_ u32,)}
-    proof ImpliedClause3: ((&'_ &'_ u32,): Tuple) = {built_in impl Tuple for (&'_ &'_ u32,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_mut<'_0, '_1, '_0_1>
-    vtable: {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}::{vtable}<'_0, '_1>
+    proof ImpliedClause1: (test_crate::test_regions::{closure}: FnOnce<(&'_0 &'_ u32,), u32>) = {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}<'_0, '_1>
+    proof ImpliedClause2: ((&'_0 &'_ u32,): Sized) = {built_in impl Sized for (&'_0 &'_ u32,)}
+    proof ImpliedClause3: ((&'_0 &'_ u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_ u32,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call_mut<'_0, '_1, '_0_1>
+    vtable: {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::{vtable}<'_0, '_1>
 }
 
-// Full name: test_crate::test_regions::{impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}
-impl<'_0, '_1> Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure} {
+// Full name: test_crate::test_regions::{impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}
+impl<'_0, '_1> Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure} {
     proof ImpliedClause0: (test_crate::test_regions::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::test_regions::{closure}}
-    proof ImpliedClause1: (test_crate::test_regions::{closure}: FnMut<(&'_ &'_ u32,), u32>) = {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}<'_0, '_1>
-    proof ImpliedClause2: ((&'_ &'_ u32,): Sized) = {built_in impl Sized for (&'_ &'_ u32,)}
-    proof ImpliedClause3: ((&'_ &'_ u32,): Tuple) = {built_in impl Tuple for (&'_ &'_ u32,)}
-    fn call<'_0_1> = {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}::call<'_0, '_1, '_0_1>
-    vtable: {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions::{closure}}::{vtable}<'_0, '_1>
+    proof ImpliedClause1: (test_crate::test_regions::{closure}: FnMut<(&'_0 &'_ u32,), u32>) = {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}<'_0, '_1>
+    proof ImpliedClause2: ((&'_0 &'_ u32,): Sized) = {built_in impl Sized for (&'_0 &'_ u32,)}
+    proof ImpliedClause3: ((&'_0 &'_ u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_ u32,)}
+    fn call<'_0_1> = {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::call<'_0, '_1, '_0_1>
+    vtable: {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions::{closure}}::{vtable}<'_0, '_1>
 }
 
 // Full name: test_crate::test_regions::{closure}::{impl Destruct for test_crate::test_regions::{closure}}
@@ -2365,15 +2371,15 @@ unsafe fn {impl Destruct for test_crate::test_regions_casted::{closure}}::drop_g
     return
 }
 
-// Full name: test_crate::test_regions_casted::{impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call
-fn {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call<'_0, '_1, '_2>(_1: &'_2 test_crate::test_regions_casted::{closure}, tupled_args: (&'_0 &'_1 u32,)) -> u32
+// Full name: test_crate::test_regions_casted::{impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call
+fn {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call<'_0, '_1, '_2>(_1: &'_2 test_crate::test_regions_casted::{closure}, tupled_args: (&'_0 &'_1 u32,)) -> u32
 where
     RegionOutlives0: '_1: '_0,
 {
     let _0: u32; // return
     let _1: &'1 test_crate::test_regions_casted::{closure}; // arg #1
     let tupled_args: (&'_0 &'_1 u32,); // arg #2
-    let x: &'2 &'3 u32; // local
+    let x: &'4 &'5 u32; // local
 
     storage_live(_0)
     storage_live(x)
@@ -2385,8 +2391,8 @@ where
     return
 }
 
-// Full name: test_crate::test_regions_casted::{impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut
-fn {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut<'_0, '_1, '_2>(state: &'_2 mut test_crate::test_regions_casted::{closure}, args: (&'_0 &'_1 u32,)) -> u32
+// Full name: test_crate::test_regions_casted::{impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut
+fn {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut<'_0, '_1, '_2>(state: &'_2 mut test_crate::test_regions_casted::{closure}, args: (&'_0 &'_1 u32,)) -> u32
 where
     RegionOutlives0: '_1: '_0,
 {
@@ -2398,7 +2404,7 @@ where
     storage_live(_0)
     storage_live(_3)
     _3 = &(*state)
-    _0 = {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call<'_0, '_1, '2>(move _3, move args)
+    _0 = {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call<'_0, '_1, '2>(move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -2409,21 +2415,21 @@ where
     return
 }
 
-// Full name: test_crate::test_regions_casted::{impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once
-fn {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once<'_0, '_1>(_1: test_crate::test_regions_casted::{closure}, _2: (&'_0 &'_1 u32,)) -> u32
+// Full name: test_crate::test_regions_casted::{impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once
+fn {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once<'_0, '_1>(_1: test_crate::test_regions_casted::{closure}, _2: (&'_0 &'_1 u32,)) -> u32
 where
     RegionOutlives0: '_1: '_0,
 {
     let _0: u32; // return
     let _1: test_crate::test_regions_casted::{closure}; // arg #1
-    let _2: (&'0 &'1 u32,); // arg #2
-    let _3: &'3 mut test_crate::test_regions_casted::{closure}; // anonymous local
+    let _2: (&'4 &'5 u32,); // arg #2
+    let _3: &'7 mut test_crate::test_regions_casted::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut<'_0, '_1, '13>(move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::test_regions_casted::{closure}}::drop_glue<'14>] _1
+    _0 = {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut<'_0, '_1, '17>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::test_regions_casted::{closure}}::drop_glue<'18>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -2432,7 +2438,7 @@ where
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::test_regions_casted::{closure}}::drop_glue<'15>] _1
+    drop[{impl Destruct for test_crate::test_regions_casted::{closure}}::drop_glue<'19>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -2457,7 +2463,7 @@ where
     storage_live(state)
     args = (move arg1,)
     state = test_crate::test_regions_casted::{closure} {  }
-    _0 = {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once<'_0, '_1>(move state, move args)
+    _0 = {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once<'_0, '_1>(move state, move args)
     ↳⚡ storage_dead(state)
         storage_dead(args)
         storage_dead(arg1)
@@ -2504,34 +2510,34 @@ pub fn test_regions_casted<'a>(x: &'a u32) -> u32
     return
 }
 
-// Full name: test_crate::test_regions_casted::{impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}
-impl<'_0, '_1> FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure} {
+// Full name: test_crate::test_regions_casted::{impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}
+impl<'_0, '_1> FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure} {
     proof ImpliedClause0: (test_crate::test_regions_casted::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::test_regions_casted::{closure}}
-    proof ImpliedClause1: ((&'_ &'_ u32,): Sized) = {built_in impl Sized for (&'_ &'_ u32,)}
-    proof ImpliedClause2: ((&'_ &'_ u32,): Tuple) = {built_in impl Tuple for (&'_ &'_ u32,)}
+    proof ImpliedClause1: ((&'_0 &'_ u32,): Sized) = {built_in impl Sized for (&'_0 &'_ u32,)}
+    proof ImpliedClause2: ((&'_0 &'_ u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_ u32,)}
     proof ImpliedClause3: (u32: Sized) = {built_in impl Sized for u32}
-    fn call_once = {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once<'_0, '_1>
-    vtable: {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::{vtable}<'_0, '_1>
+    fn call_once = {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_once<'_0, '_1>
+    vtable: {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::{vtable}<'_0, '_1>
 }
 
-// Full name: test_crate::test_regions_casted::{impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}
-impl<'_0, '_1> FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure} {
+// Full name: test_crate::test_regions_casted::{impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}
+impl<'_0, '_1> FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure} {
     proof ImpliedClause0: (test_crate::test_regions_casted::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::test_regions_casted::{closure}}
-    proof ImpliedClause1: (test_crate::test_regions_casted::{closure}: FnOnce<(&'_ &'_ u32,), u32>) = {impl FnOnce<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}<'_0, '_1>
-    proof ImpliedClause2: ((&'_ &'_ u32,): Sized) = {built_in impl Sized for (&'_ &'_ u32,)}
-    proof ImpliedClause3: ((&'_ &'_ u32,): Tuple) = {built_in impl Tuple for (&'_ &'_ u32,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut<'_0, '_1, '_0_1>
-    vtable: {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::{vtable}<'_0, '_1>
+    proof ImpliedClause1: (test_crate::test_regions_casted::{closure}: FnOnce<(&'_0 &'_ u32,), u32>) = {impl FnOnce<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}<'_0, '_1>
+    proof ImpliedClause2: ((&'_0 &'_ u32,): Sized) = {built_in impl Sized for (&'_0 &'_ u32,)}
+    proof ImpliedClause3: ((&'_0 &'_ u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_ u32,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call_mut<'_0, '_1, '_0_1>
+    vtable: {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::{vtable}<'_0, '_1>
 }
 
-// Full name: test_crate::test_regions_casted::{impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}
-impl<'_0, '_1> Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure} {
+// Full name: test_crate::test_regions_casted::{impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}
+impl<'_0, '_1> Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure} {
     proof ImpliedClause0: (test_crate::test_regions_casted::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::test_regions_casted::{closure}}
-    proof ImpliedClause1: (test_crate::test_regions_casted::{closure}: FnMut<(&'_ &'_ u32,), u32>) = {impl FnMut<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}<'_0, '_1>
-    proof ImpliedClause2: ((&'_ &'_ u32,): Sized) = {built_in impl Sized for (&'_ &'_ u32,)}
-    proof ImpliedClause3: ((&'_ &'_ u32,): Tuple) = {built_in impl Tuple for (&'_ &'_ u32,)}
-    fn call<'_0_1> = {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call<'_0, '_1, '_0_1>
-    vtable: {impl Fn<(&'_ &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::{vtable}<'_0, '_1>
+    proof ImpliedClause1: (test_crate::test_regions_casted::{closure}: FnMut<(&'_0 &'_ u32,), u32>) = {impl FnMut<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}<'_0, '_1>
+    proof ImpliedClause2: ((&'_0 &'_ u32,): Sized) = {built_in impl Sized for (&'_0 &'_ u32,)}
+    proof ImpliedClause3: ((&'_0 &'_ u32,): Tuple) = {built_in impl Tuple for (&'_0 &'_ u32,)}
+    fn call<'_0_1> = {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::call<'_0, '_1, '_0_1>
+    vtable: {impl Fn<(&'_0 &'_ u32,), u32> for test_crate::test_regions_casted::{closure}}::{vtable}<'_0, '_1>
 }
 
 // Full name: test_crate::test_regions_casted::{closure}::{impl Destruct for test_crate::test_regions_casted::{closure}}
@@ -3087,15 +3093,15 @@ struct test_crate::test_fnmut_with_ref::{closure}<'_0> {
   _0: &'_0 mut usize,
 }
 
-// Full name: test_crate::test_fnmut_with_ref::{impl FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_mut
-fn {impl FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_mut<'_0, '_1, '_2>(_1: &'_2 mut test_crate::test_fnmut_with_ref::{closure}<'_0>, tupled_args: (&'_1 usize,))
+// Full name: test_crate::test_fnmut_with_ref::{impl FnMut<(&'_1 usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_mut
+fn {impl FnMut<(&'_1 usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_mut<'_0, '_1, '_2>(_1: &'_2 mut test_crate::test_fnmut_with_ref::{closure}<'_0>, tupled_args: (&'_1 usize,))
 where
     RegionOutlives0: '_0: '_2,
 {
     let _0: (); // return
     let _1: &'1 mut test_crate::test_fnmut_with_ref::{closure}<'_0>; // arg #1
     let tupled_args: (&'_1 usize,); // arg #2
-    let x: &'2 usize; // local
+    let x: &'3 usize; // local
     let _4: usize; // anonymous local
     let _5: usize; // anonymous local
 
@@ -3162,7 +3168,7 @@ fn test_fnmut_with_ref()
     _8 = &(*_9)
     _7 = &(*_8)
     _6 = (move _7,)
-    _4 = {impl FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_mut<'22, '23, '24>(move _5, move _6)
+    _4 = {impl FnMut<(&'_1 usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_mut<'22, '23, '24>(move _5, move _6)
     ↳⚡ storage_dead(_9)
         unwind_continue
     storage_dead(_7)
@@ -3194,20 +3200,20 @@ where
     return
 }
 
-// Full name: test_crate::test_fnmut_with_ref::{impl FnOnce<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_once
-fn {impl FnOnce<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_once<'_0, '_1>(_1: test_crate::test_fnmut_with_ref::{closure}<'_0>, _2: (&'_1 usize,))
+// Full name: test_crate::test_fnmut_with_ref::{impl FnOnce<(&'_1 usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_once
+fn {impl FnOnce<(&'_1 usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_once<'_0, '_1>(_1: test_crate::test_fnmut_with_ref::{closure}<'_0>, _2: (&'_1 usize,))
 {
     let _0: (); // return
     let _1: test_crate::test_fnmut_with_ref::{closure}<'_0>; // arg #1
-    let _2: (&'0 usize,); // arg #2
-    let _3: &'2 mut test_crate::test_fnmut_with_ref::{closure}<'_0>; // anonymous local
+    let _2: (&'2 usize,); // arg #2
+    let _3: &'4 mut test_crate::test_fnmut_with_ref::{closure}<'_0>; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _0 = ()
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_mut<'_0, '_1, '9>(move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::test_fnmut_with_ref::{closure}<'_0>}::drop_glue<'_0, '12>] _1
+    _0 = {impl FnMut<(&'_1 usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_mut<'_0, '_1, '11>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::test_fnmut_with_ref::{closure}<'_0>}::drop_glue<'_0, '14>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -3216,7 +3222,7 @@ fn {impl FnOnce<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::test_fnmut_with_ref::{closure}<'_0>}::drop_glue<'_0, '15>] _1
+    drop[{impl Destruct for test_crate::test_fnmut_with_ref::{closure}<'_0>}::drop_glue<'_0, '17>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -3227,24 +3233,24 @@ fn {impl FnOnce<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}
     return
 }
 
-// Full name: test_crate::test_fnmut_with_ref::{impl FnOnce<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}
-impl<'_0, '_1> FnOnce<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0> {
+// Full name: test_crate::test_fnmut_with_ref::{impl FnOnce<(&'_1 usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}
+impl<'_0, '_1> FnOnce<(&'_1 usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0> {
     proof ImpliedClause0: (test_crate::test_fnmut_with_ref::{closure}<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::test_fnmut_with_ref::{closure}<'_0>}
-    proof ImpliedClause1: ((&'_ usize,): Sized) = {built_in impl Sized for (&'_ usize,)}
-    proof ImpliedClause2: ((&'_ usize,): Tuple) = {built_in impl Tuple for (&'_ usize,)}
+    proof ImpliedClause1: ((&'_1 usize,): Sized) = {built_in impl Sized for (&'_1 usize,)}
+    proof ImpliedClause2: ((&'_1 usize,): Tuple) = {built_in impl Tuple for (&'_1 usize,)}
     proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
-    fn call_once = {impl FnOnce<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_once<'_0, '_1>
-    vtable: {impl FnOnce<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::{vtable}<'_0, '_1>
+    fn call_once = {impl FnOnce<(&'_1 usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_once<'_0, '_1>
+    vtable: {impl FnOnce<(&'_1 usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::{vtable}<'_0, '_1>
 }
 
-// Full name: test_crate::test_fnmut_with_ref::{impl FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}
-impl<'_0, '_1> FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0> {
+// Full name: test_crate::test_fnmut_with_ref::{impl FnMut<(&'_1 usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}
+impl<'_0, '_1> FnMut<(&'_1 usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0> {
     proof ImpliedClause0: (test_crate::test_fnmut_with_ref::{closure}<'_0>: MetaSized) = {built_in impl MetaSized for test_crate::test_fnmut_with_ref::{closure}<'_0>}
-    proof ImpliedClause1: (test_crate::test_fnmut_with_ref::{closure}<'_0>: FnOnce<(&'_ usize,), ()>) = {impl FnOnce<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}<'_0, '_1>
-    proof ImpliedClause2: ((&'_ usize,): Sized) = {built_in impl Sized for (&'_ usize,)}
-    proof ImpliedClause3: ((&'_ usize,): Tuple) = {built_in impl Tuple for (&'_ usize,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_mut<'_0, '_1, '_0_1>
-    vtable: {impl FnMut<(&'_ usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::{vtable}<'_0, '_1>
+    proof ImpliedClause1: (test_crate::test_fnmut_with_ref::{closure}<'_0>: FnOnce<(&'_1 usize,), ()>) = {impl FnOnce<(&'_1 usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}<'_0, '_1>
+    proof ImpliedClause2: ((&'_1 usize,): Sized) = {built_in impl Sized for (&'_1 usize,)}
+    proof ImpliedClause3: ((&'_1 usize,): Tuple) = {built_in impl Tuple for (&'_1 usize,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_1 usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::call_mut<'_0, '_1, '_0_1>
+    vtable: {impl FnMut<(&'_1 usize,), ()> for test_crate::test_fnmut_with_ref::{closure}<'_0>}::{vtable}<'_0, '_1>
 }
 
 // Full name: test_crate::test_fnmut_with_ref::{closure}::{impl Destruct for test_crate::test_fnmut_with_ref::{closure}<'_0>}

--- a/charon/tests/ui/dyn/dyn-fn.out
+++ b/charon/tests/ui/dyn/dyn-fn.out
@@ -153,13 +153,13 @@ fn takes_fn<'_0>(f: &'_0 (dyn for<'a> Fn<(&'a mut u32,), ImpliedClause1::Implied
 // Full name: test_crate::gives_fn::{closure}
 struct {closure} {}
 
-// Full name: test_crate::gives_fn::{impl Fn<(&'_ mut u32,)> for {closure}}::call
+// Full name: test_crate::gives_fn::{impl Fn<(&'_0 mut u32,)> for {closure}}::call
 fn call<'_0, '_1>(_1: &'_1 {closure}, tupled_args: (&'_0 mut u32,)) -> bool
 {
     let _0: bool; // return
     let _1: &'1 {closure}; // arg #1
     let tupled_args: (&'_0 mut u32,); // arg #2
-    let counter: &'2 mut u32; // local
+    let counter: &'3 mut u32; // local
     let _4: u32; // anonymous local
 
     storage_live(_0)
@@ -176,7 +176,7 @@ fn call<'_0, '_1>(_1: &'_1 {closure}, tupled_args: (&'_0 mut u32,)) -> bool
     return
 }
 
-// Full name: test_crate::gives_fn::{impl FnMut<(&'_ mut u32,)> for {closure}}::call_mut
+// Full name: test_crate::gives_fn::{impl FnMut<(&'_0 mut u32,)> for {closure}}::call_mut
 fn call_mut<'_0, '_1>(state: &'_1 mut {closure}, args: (&'_0 mut u32,)) -> bool
 {
     let _0: bool; // return
@@ -210,19 +210,19 @@ unsafe fn drop_glue<'_0>(_1: &'_0 mut {closure})
     return
 }
 
-// Full name: test_crate::gives_fn::{impl FnOnce<(&'_ mut u32,)> for {closure}}::call_once
+// Full name: test_crate::gives_fn::{impl FnOnce<(&'_0 mut u32,)> for {closure}}::call_once
 fn call_once<'_0>(_1: {closure}, _2: (&'_0 mut u32,)) -> bool
 {
     let _0: bool; // return
     let _1: {closure}; // arg #1
-    let _2: (&'0 mut u32,); // arg #2
-    let _3: &'2 mut {closure}; // anonymous local
+    let _2: (&'2 mut u32,); // arg #2
+    let _3: &'4 mut {closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = call_mut<'_0, '7>(move _3, move _2)
-    ↳⚡ drop[drop_glue<'8>] _1
+    _0 = call_mut<'_0, '9>(move _3, move _2)
+    ↳⚡ drop[drop_glue<'10>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -231,7 +231,7 @@ fn call_once<'_0>(_1: {closure}, _2: (&'_0 mut u32,)) -> bool
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[drop_glue<'9>] _1
+    drop[drop_glue<'11>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -242,33 +242,33 @@ fn call_once<'_0>(_1: {closure}, _2: (&'_0 mut u32,)) -> bool
     return
 }
 
-// Full name: test_crate::gives_fn::{impl FnOnce<(&'_ mut u32,)> for {closure}}
-impl<'_0> "impl_FnOnce_tuple_for_closure" FnOnce<(&'_ mut u32,)> for {closure} {
+// Full name: test_crate::gives_fn::{impl FnOnce<(&'_0 mut u32,)> for {closure}}
+impl<'_0> "impl_FnOnce_tuple_for_closure" FnOnce<(&'_0 mut u32,)> for {closure} {
     proof ImpliedClause0: ({closure}: MetaSized) = {built_in impl MetaSized for {closure}}
-    proof ImpliedClause1: ((&'_ mut u32,): Sized) = {built_in impl Sized for (&'_ mut u32,)}
-    proof ImpliedClause2: ((&'_ mut u32,): Tuple) = {built_in impl Tuple for (&'_ mut u32,)}
+    proof ImpliedClause1: ((&'_0 mut u32,): Sized) = {built_in impl Sized for (&'_0 mut u32,)}
+    proof ImpliedClause2: ((&'_0 mut u32,): Tuple) = {built_in impl Tuple for (&'_0 mut u32,)}
     proof ImpliedClause3: (bool: Sized) = {built_in impl Sized for bool}
     type Output = bool
     fn call_once = call_once<'_0>
     vtable: impl_FnOnce_tuple_for_closure::{vtable}<'_0>
 }
 
-// Full name: test_crate::gives_fn::{impl FnMut<(&'_ mut u32,)> for {closure}}
-impl<'_0> "impl_FnMut_tuple_for_closure" FnMut<(&'_ mut u32,)> for {closure} {
+// Full name: test_crate::gives_fn::{impl FnMut<(&'_0 mut u32,)> for {closure}}
+impl<'_0> "impl_FnMut_tuple_for_closure" FnMut<(&'_0 mut u32,)> for {closure} {
     proof ImpliedClause0: ({closure}: MetaSized) = {built_in impl MetaSized for {closure}}
-    proof ImpliedClause1: ({closure}: FnOnce<(&'_ mut u32,)>) = impl_FnOnce_tuple_for_closure<'_0>
-    proof ImpliedClause2: ((&'_ mut u32,): Sized) = {built_in impl Sized for (&'_ mut u32,)}
-    proof ImpliedClause3: ((&'_ mut u32,): Tuple) = {built_in impl Tuple for (&'_ mut u32,)}
+    proof ImpliedClause1: ({closure}: FnOnce<(&'_0 mut u32,)>) = impl_FnOnce_tuple_for_closure<'_0>
+    proof ImpliedClause2: ((&'_0 mut u32,): Sized) = {built_in impl Sized for (&'_0 mut u32,)}
+    proof ImpliedClause3: ((&'_0 mut u32,): Tuple) = {built_in impl Tuple for (&'_0 mut u32,)}
     fn call_mut<'_0_1> = call_mut<'_0, '_0_1>
     vtable: impl_FnMut_tuple_for_closure::{vtable}<'_0>
 }
 
-// Full name: test_crate::gives_fn::{impl Fn<(&'_ mut u32,)> for {closure}}
-impl<'_0> "impl_Fn_tuple_for_closure" Fn<(&'_ mut u32,)> for {closure} {
+// Full name: test_crate::gives_fn::{impl Fn<(&'_0 mut u32,)> for {closure}}
+impl<'_0> "impl_Fn_tuple_for_closure" Fn<(&'_0 mut u32,)> for {closure} {
     proof ImpliedClause0: ({closure}: MetaSized) = {built_in impl MetaSized for {closure}}
-    proof ImpliedClause1: ({closure}: FnMut<(&'_ mut u32,)>) = impl_FnMut_tuple_for_closure<'_0>
-    proof ImpliedClause2: ((&'_ mut u32,): Sized) = {built_in impl Sized for (&'_ mut u32,)}
-    proof ImpliedClause3: ((&'_ mut u32,): Tuple) = {built_in impl Tuple for (&'_ mut u32,)}
+    proof ImpliedClause1: ({closure}: FnMut<(&'_0 mut u32,)>) = impl_FnMut_tuple_for_closure<'_0>
+    proof ImpliedClause2: ((&'_0 mut u32,): Sized) = {built_in impl Sized for (&'_0 mut u32,)}
+    proof ImpliedClause3: ((&'_0 mut u32,): Tuple) = {built_in impl Tuple for (&'_0 mut u32,)}
     fn call<'_0_1> = call<'_0, '_0_1>
     vtable: impl_Fn_tuple_for_closure::{vtable}<'_0>
 }

--- a/charon/tests/ui/impl-trait.out
+++ b/charon/tests/ui/impl-trait.out
@@ -308,7 +308,7 @@ where
     return
 }
 
-// Full name: test_crate::wrap::{impl FnOnce<(&'_ U,)> for {closure}<U>[TraitClause0]}::call_once
+// Full name: test_crate::wrap::{impl FnOnce<(&'_0 U,)> for {closure}<U>[TraitClause0]}::call_once
 fn call_once<'_0, U>(_1: {closure}<U>[TraitClause0], tupled_args: (&'_0 U,)) -> WrapClone<&'_0 U>[{built_in impl Sized for &'_0 U}, {impl Clone for &'_0 T}<'_, U>]
 where
     TraitClause0: (U: Sized),
@@ -333,16 +333,17 @@ where
     return
 }
 
-// Full name: test_crate::wrap::{impl FnOnce<(&'_ U,)> for {closure}<U>[TraitClause0]}
-impl<'_0, U> "impl_FnOnce_tuple_for_closure" FnOnce<(&'_ U,)> for {closure}<U>[TraitClause0]
+// Full name: test_crate::wrap::{impl FnOnce<(&'_0 U,)> for {closure}<U>[TraitClause0]}
+impl<'_0, U> "impl_FnOnce_tuple_for_closure" FnOnce<(&'_0 U,)> for {closure}<U>[TraitClause0]
 where
     TraitClause0: (U: Sized),
+    TypeOutlives0: U: '_0,
 {
     proof ImpliedClause0: ({closure}<U>[TraitClause0]: MetaSized) = {built_in impl MetaSized for {closure}<U>[TraitClause0]}
-    proof ImpliedClause1: ((&'_ U,): Sized) = {built_in impl Sized for (&'_ U,)}
-    proof ImpliedClause2: ((&'_ U,): Tuple) = {built_in impl Tuple for (&'_ U,)}
-    proof ImpliedClause3: (WrapClone<&'_ U>[{built_in impl Sized for &'_ U}, {impl Clone for &'_0 T}<'_, U>]: Sized) = {built_in impl Sized for WrapClone<&'_ U>[{built_in impl Sized for &'_ U}, {impl Clone for &'_0 T}<'_, U>]}
-    type Output = WrapClone<&'_ U>[{built_in impl Sized for &'_ U}, {impl Clone for &'_0 T}<'_, U>]
+    proof ImpliedClause1: ((&'_0 U,): Sized) = {built_in impl Sized for (&'_0 U,)}
+    proof ImpliedClause2: ((&'_0 U,): Tuple) = {built_in impl Tuple for (&'_0 U,)}
+    proof ImpliedClause3: (WrapClone<&'_0 U>[{built_in impl Sized for &'_0 U}, {impl Clone for &'_0 T}<'_, U>]: Sized) = {built_in impl Sized for WrapClone<&'_0 U>[{built_in impl Sized for &'_0 U}, {impl Clone for &'_0 T}<'_, U>]}
+    type Output = WrapClone<&'_0 U>[{built_in impl Sized for &'_0 U}, {impl Clone for &'_0 T}<'_, U>]
     fn call_once = call_once<'_0, U>[TraitClause0]
     vtable: impl_FnOnce_tuple_for_closure::{vtable}<'_0, U>[TraitClause0]
 }

--- a/charon/tests/ui/regressions/invalid-reconstruct-assert.out
+++ b/charon/tests/ui/regressions/invalid-reconstruct-assert.out
@@ -607,19 +607,19 @@ impl "impl_Destruct_for_closure" Destruct for {closure} {
     non-dyn-compatible
 }
 
-// Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for {closure}}::call_mut
+// Full name: test_crate::main::{impl FnMut<(&'_0 u32,)> for {closure}}::call_mut
 fn call_mut<'_0, '_1>(_1: &'_1 mut {closure}, tupled_args: (&'_0 u32,)) -> Ordering
 {
     let _0: Ordering; // return
     let _1: &'1 mut {closure}; // arg #1
     let tupled_args: (&'_0 u32,); // arg #2
-    let x: &'2 u32; // local
-    let _4: &'3 u32; // anonymous local
-    let _5: &'4 u32; // anonymous local
-    let _6: &'5 u32; // anonymous local
-    let _7: &'6 u32; // anonymous local
-    let _8: &'7 u32; // anonymous local
-    let _9: &'12 u32; // anonymous local
+    let x: &'3 u32; // local
+    let _4: &'4 u32; // anonymous local
+    let _5: &'5 u32; // anonymous local
+    let _6: &'6 u32; // anonymous local
+    let _7: &'7 u32; // anonymous local
+    let _8: &'8 u32; // anonymous local
+    let _9: &'13 u32; // anonymous local
     let _10: u32; // anonymous local
 
     bb0: {
@@ -640,7 +640,7 @@ fn call_mut<'_0, '_1>(_1: &'_1 mut {closure}, tupled_args: (&'_0 u32,)) -> Order
         _7 = move _8;
         _6 = &(*_7);
         _5 = &(*_6);
-        _0 = cmp<'10, '11>(move _4, move _5) -> bb2 (unwind: bb1);
+        _0 = cmp<'11, '12>(move _4, move _5) -> bb2 (unwind: bb1);
     }
 
     bb1: {
@@ -669,27 +669,27 @@ fn call_mut<'_0, '_1>(_1: &'_1 mut {closure}, tupled_args: (&'_0 u32,)) -> Order
     }
 }
 
-// Full name: test_crate::main::{impl FnOnce<(&'_ u32,)> for {closure}}::call_once
+// Full name: test_crate::main::{impl FnOnce<(&'_0 u32,)> for {closure}}::call_once
 fn call_once<'_0>(_1: {closure}, _2: (&'_0 u32,)) -> Ordering
 {
     let _0: Ordering; // return
     let _1: {closure}; // arg #1
-    let _2: (&'0 u32,); // arg #2
-    let _3: &'2 mut {closure}; // anonymous local
+    let _2: (&'2 u32,); // arg #2
+    let _3: &'4 mut {closure}; // anonymous local
 
     bb0: {
         storage_live(_0);
         storage_live(_3);
         _3 = &mut _1;
-        _0 = call_mut<'_0, '7>(move _3, move _2) -> bb2 (unwind: bb1);
+        _0 = call_mut<'_0, '9>(move _3, move _2) -> bb2 (unwind: bb1);
     }
 
     bb1: {
-        drop[drop_glue<'8>] _1 -> bb3 (unwind: bb4);
+        drop[drop_glue<'10>] _1 -> bb3 (unwind: bb4);
     }
 
     bb2: {
-        drop[drop_glue<'9>] _1 -> bb6 (unwind: bb5);
+        drop[drop_glue<'11>] _1 -> bb6 (unwind: bb5);
     }
 
     bb3: {
@@ -721,23 +721,23 @@ fn call_once<'_0>(_1: {closure}, _2: (&'_0 u32,)) -> Ordering
     }
 }
 
-// Full name: test_crate::main::{impl FnOnce<(&'_ u32,)> for {closure}}
-impl<'_0> "impl_FnOnce_tuple_for_closure" FnOnce<(&'_ u32,)> for {closure} {
+// Full name: test_crate::main::{impl FnOnce<(&'_0 u32,)> for {closure}}
+impl<'_0> "impl_FnOnce_tuple_for_closure" FnOnce<(&'_0 u32,)> for {closure} {
     proof ImpliedClause0: ({closure}: MetaSized) = {built_in impl MetaSized for {closure}}
-    proof ImpliedClause1: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
-    proof ImpliedClause2: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    proof ImpliedClause1: ((&'_0 u32,): Sized) = {built_in impl Sized for (&'_0 u32,)}
+    proof ImpliedClause2: ((&'_0 u32,): Tuple) = {built_in impl Tuple for (&'_0 u32,)}
     proof ImpliedClause3: (Ordering: Sized) = {built_in impl Sized for Ordering}
     type Output = Ordering
     fn call_once = call_once<'_0>
     vtable: impl_FnOnce_tuple_for_closure::{vtable}<'_0>
 }
 
-// Full name: test_crate::main::{impl FnMut<(&'_ u32,)> for {closure}}
-impl<'_0> "impl_FnMut_tuple_for_closure" FnMut<(&'_ u32,)> for {closure} {
+// Full name: test_crate::main::{impl FnMut<(&'_0 u32,)> for {closure}}
+impl<'_0> "impl_FnMut_tuple_for_closure" FnMut<(&'_0 u32,)> for {closure} {
     proof ImpliedClause0: ({closure}: MetaSized) = {built_in impl MetaSized for {closure}}
-    proof ImpliedClause1: ({closure}: FnOnce<(&'_ u32,)>) = impl_FnOnce_tuple_for_closure<'_0>
-    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
-    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    proof ImpliedClause1: ({closure}: FnOnce<(&'_0 u32,)>) = impl_FnOnce_tuple_for_closure<'_0>
+    proof ImpliedClause2: ((&'_0 u32,): Sized) = {built_in impl Sized for (&'_0 u32,)}
+    proof ImpliedClause3: ((&'_0 u32,): Tuple) = {built_in impl Tuple for (&'_0 u32,)}
     fn call_mut<'_0_1> = call_mut<'_0, '_0_1>
     vtable: impl_FnMut_tuple_for_closure::{vtable}<'_0>
 }
@@ -780,7 +780,7 @@ fn main()
         storage_dead(_7);
         storage_live(_8);
         _8 = {closure} {  };
-        res = binary_search_by<'10, u32, {closure}>[{built_in impl Sized for u32}, {built_in impl Sized for {closure}}, impl_FnMut_tuple_for_closure<'14>, impl_Destruct_for_closure](move _6, move _8) -> bb2 (unwind: bb1);
+        res = binary_search_by<'10, u32, {closure}>[{built_in impl Sized for u32}, {built_in impl Sized for {closure}}, impl_FnMut_tuple_for_closure<'10>, impl_Destruct_for_closure](move _6, move _8) -> bb2 (unwind: bb1);
     }
 
     bb1: {

--- a/charon/tests/ui/regressions/issue-1010-missing-lifetime.out
+++ b/charon/tests/ui/regressions/issue-1010-missing-lifetime.out
@@ -107,13 +107,13 @@ unsafe fn {impl Destruct for test_crate::main::{closure#1}}::drop_glue<'_0>(_1: 
     return
 }
 
-// Full name: test_crate::main::{impl Fn<(&'_ u16,)> for test_crate::main::{closure#1}}::call
-fn {impl Fn<(&'_ u16,)> for test_crate::main::{closure#1}}::call<'_0, '_1>(_1: &'_1 test_crate::main::{closure#1}, tupled_args: (&'_0 u16,))
+// Full name: test_crate::main::{impl Fn<(&'_0 u16,)> for test_crate::main::{closure#1}}::call
+fn {impl Fn<(&'_0 u16,)> for test_crate::main::{closure#1}}::call<'_0, '_1>(_1: &'_1 test_crate::main::{closure#1}, tupled_args: (&'_0 u16,))
 {
     let _0: (); // return
     let _1: &'1 test_crate::main::{closure#1}; // arg #1
     let tupled_args: (&'_0 u16,); // arg #2
-    let _3: &'2 u16; // anonymous local
+    let _3: &'3 u16; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
@@ -126,8 +126,8 @@ fn {impl Fn<(&'_ u16,)> for test_crate::main::{closure#1}}::call<'_0, '_1>(_1: &
     return
 }
 
-// Full name: test_crate::main::{impl FnMut<(&'_ u16,)> for test_crate::main::{closure#1}}::call_mut
-fn {impl FnMut<(&'_ u16,)> for test_crate::main::{closure#1}}::call_mut<'_0, '_1>(state: &'_1 mut test_crate::main::{closure#1}, args: (&'_0 u16,))
+// Full name: test_crate::main::{impl FnMut<(&'_0 u16,)> for test_crate::main::{closure#1}}::call_mut
+fn {impl FnMut<(&'_0 u16,)> for test_crate::main::{closure#1}}::call_mut<'_0, '_1>(state: &'_1 mut test_crate::main::{closure#1}, args: (&'_0 u16,))
 {
     let _0: (); // return
     let state: &'_1 mut test_crate::main::{closure#1}; // arg #1
@@ -138,7 +138,7 @@ fn {impl FnMut<(&'_ u16,)> for test_crate::main::{closure#1}}::call_mut<'_0, '_1
     _0 = ()
     storage_live(_3)
     _3 = &(*state)
-    _0 = {impl Fn<(&'_ u16,)> for test_crate::main::{closure#1}}::call<'_0, '2>(move _3, move args)
+    _0 = {impl Fn<(&'_0 u16,)> for test_crate::main::{closure#1}}::call<'_0, '2>(move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -149,20 +149,20 @@ fn {impl FnMut<(&'_ u16,)> for test_crate::main::{closure#1}}::call_mut<'_0, '_1
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(&'_ u16,)> for test_crate::main::{closure#1}}::call_once
-fn {impl FnOnce<(&'_ u16,)> for test_crate::main::{closure#1}}::call_once<'_0>(_1: test_crate::main::{closure#1}, _2: (&'_0 u16,))
+// Full name: test_crate::main::{impl FnOnce<(&'_0 u16,)> for test_crate::main::{closure#1}}::call_once
+fn {impl FnOnce<(&'_0 u16,)> for test_crate::main::{closure#1}}::call_once<'_0>(_1: test_crate::main::{closure#1}, _2: (&'_0 u16,))
 {
     let _0: (); // return
     let _1: test_crate::main::{closure#1}; // arg #1
-    let _2: (&'0 u16,); // arg #2
-    let _3: &'2 mut test_crate::main::{closure#1}; // anonymous local
+    let _2: (&'2 u16,); // arg #2
+    let _3: &'4 mut test_crate::main::{closure#1}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _0 = ()
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_ u16,)> for test_crate::main::{closure#1}}::call_mut<'_0, '7>(move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::main::{closure#1}}::drop_glue<'8>] _1
+    _0 = {impl FnMut<(&'_0 u16,)> for test_crate::main::{closure#1}}::call_mut<'_0, '9>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::main::{closure#1}}::drop_glue<'10>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -171,7 +171,7 @@ fn {impl FnOnce<(&'_ u16,)> for test_crate::main::{closure#1}}::call_once<'_0>(_
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::main::{closure#1}}::drop_glue<'9>] _1
+    drop[{impl Destruct for test_crate::main::{closure#1}}::drop_glue<'11>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -196,7 +196,7 @@ fn {as_fn}<'_0>(arg1: &'_0 u16)
     storage_live(state)
     args = (move arg1,)
     state = test_crate::main::{closure#1} {  }
-    _0 = {impl FnOnce<(&'_ u16,)> for test_crate::main::{closure#1}}::call_once<'_0>(move state, move args)
+    _0 = {impl FnOnce<(&'_0 u16,)> for test_crate::main::{closure#1}}::call_once<'_0>(move state, move args)
     ↳⚡ storage_dead(state)
         storage_dead(args)
         storage_dead(arg1)
@@ -361,35 +361,35 @@ impl Destruct for test_crate::main::{closure} {
     non-dyn-compatible
 }
 
-// Full name: test_crate::main::{impl FnOnce<(&'_ u16,)> for test_crate::main::{closure#1}}
-impl<'_0> FnOnce<(&'_ u16,)> for test_crate::main::{closure#1} {
+// Full name: test_crate::main::{impl FnOnce<(&'_0 u16,)> for test_crate::main::{closure#1}}
+impl<'_0> FnOnce<(&'_0 u16,)> for test_crate::main::{closure#1} {
     proof ImpliedClause0: (test_crate::main::{closure#1}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#1}}
-    proof ImpliedClause1: ((&'_ u16,): Sized) = {built_in impl Sized for (&'_ u16,)}
-    proof ImpliedClause2: ((&'_ u16,): Tuple) = {built_in impl Tuple for (&'_ u16,)}
+    proof ImpliedClause1: ((&'_0 u16,): Sized) = {built_in impl Sized for (&'_0 u16,)}
+    proof ImpliedClause2: ((&'_0 u16,): Tuple) = {built_in impl Tuple for (&'_0 u16,)}
     proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     type Output = ()
-    fn call_once = {impl FnOnce<(&'_ u16,)> for test_crate::main::{closure#1}}::call_once<'_0>
-    vtable: {impl FnOnce<(&'_ u16,)> for test_crate::main::{closure#1}}::{vtable}<'_0>
+    fn call_once = {impl FnOnce<(&'_0 u16,)> for test_crate::main::{closure#1}}::call_once<'_0>
+    vtable: {impl FnOnce<(&'_0 u16,)> for test_crate::main::{closure#1}}::{vtable}<'_0>
 }
 
-// Full name: test_crate::main::{impl FnMut<(&'_ u16,)> for test_crate::main::{closure#1}}
-impl<'_0> FnMut<(&'_ u16,)> for test_crate::main::{closure#1} {
+// Full name: test_crate::main::{impl FnMut<(&'_0 u16,)> for test_crate::main::{closure#1}}
+impl<'_0> FnMut<(&'_0 u16,)> for test_crate::main::{closure#1} {
     proof ImpliedClause0: (test_crate::main::{closure#1}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#1}}
-    proof ImpliedClause1: (test_crate::main::{closure#1}: FnOnce<(&'_ u16,)>) = {impl FnOnce<(&'_ u16,)> for test_crate::main::{closure#1}}<'_0>
-    proof ImpliedClause2: ((&'_ u16,): Sized) = {built_in impl Sized for (&'_ u16,)}
-    proof ImpliedClause3: ((&'_ u16,): Tuple) = {built_in impl Tuple for (&'_ u16,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_ u16,)> for test_crate::main::{closure#1}}::call_mut<'_0, '_0_1>
-    vtable: {impl FnMut<(&'_ u16,)> for test_crate::main::{closure#1}}::{vtable}<'_0>
+    proof ImpliedClause1: (test_crate::main::{closure#1}: FnOnce<(&'_0 u16,)>) = {impl FnOnce<(&'_0 u16,)> for test_crate::main::{closure#1}}<'_0>
+    proof ImpliedClause2: ((&'_0 u16,): Sized) = {built_in impl Sized for (&'_0 u16,)}
+    proof ImpliedClause3: ((&'_0 u16,): Tuple) = {built_in impl Tuple for (&'_0 u16,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_0 u16,)> for test_crate::main::{closure#1}}::call_mut<'_0, '_0_1>
+    vtable: {impl FnMut<(&'_0 u16,)> for test_crate::main::{closure#1}}::{vtable}<'_0>
 }
 
-// Full name: test_crate::main::{impl Fn<(&'_ u16,)> for test_crate::main::{closure#1}}
-impl<'_0> Fn<(&'_ u16,)> for test_crate::main::{closure#1} {
+// Full name: test_crate::main::{impl Fn<(&'_0 u16,)> for test_crate::main::{closure#1}}
+impl<'_0> Fn<(&'_0 u16,)> for test_crate::main::{closure#1} {
     proof ImpliedClause0: (test_crate::main::{closure#1}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure#1}}
-    proof ImpliedClause1: (test_crate::main::{closure#1}: FnMut<(&'_ u16,)>) = {impl FnMut<(&'_ u16,)> for test_crate::main::{closure#1}}<'_0>
-    proof ImpliedClause2: ((&'_ u16,): Sized) = {built_in impl Sized for (&'_ u16,)}
-    proof ImpliedClause3: ((&'_ u16,): Tuple) = {built_in impl Tuple for (&'_ u16,)}
-    fn call<'_0_1> = {impl Fn<(&'_ u16,)> for test_crate::main::{closure#1}}::call<'_0, '_0_1>
-    vtable: {impl Fn<(&'_ u16,)> for test_crate::main::{closure#1}}::{vtable}<'_0>
+    proof ImpliedClause1: (test_crate::main::{closure#1}: FnMut<(&'_0 u16,)>) = {impl FnMut<(&'_0 u16,)> for test_crate::main::{closure#1}}<'_0>
+    proof ImpliedClause2: ((&'_0 u16,): Sized) = {built_in impl Sized for (&'_0 u16,)}
+    proof ImpliedClause3: ((&'_0 u16,): Tuple) = {built_in impl Tuple for (&'_0 u16,)}
+    fn call<'_0_1> = {impl Fn<(&'_0 u16,)> for test_crate::main::{closure#1}}::call<'_0, '_0_1>
+    vtable: {impl Fn<(&'_0 u16,)> for test_crate::main::{closure#1}}::{vtable}<'_0>
 }
 
 // Full name: test_crate::main::{closure#1}::{impl Destruct for test_crate::main::{closure#1}}

--- a/charon/tests/ui/regressions/issue-1010-missing-lifetime.out
+++ b/charon/tests/ui/regressions/issue-1010-missing-lifetime.out
@@ -249,13 +249,13 @@ unsafe fn {impl Destruct for test_crate::main::{closure}}::drop_glue<'_0>(_1: &'
     return
 }
 
-// Full name: test_crate::main::{impl Fn<(&'_ u8,)> for test_crate::main::{closure}}::call
-fn {impl Fn<(&'_ u8,)> for test_crate::main::{closure}}::call<'_0, '_1>(_1: &'_1 test_crate::main::{closure}, tupled_args: (&'_0 u8,))
+// Full name: test_crate::main::{impl Fn<(&'_0 u8,)> for test_crate::main::{closure}}::call
+fn {impl Fn<(&'_0 u8,)> for test_crate::main::{closure}}::call<'_0, '_1>(_1: &'_1 test_crate::main::{closure}, tupled_args: (&'_0 u8,))
 {
     let _0: (); // return
     let _1: &'1 test_crate::main::{closure}; // arg #1
     let tupled_args: (&'_0 u8,); // arg #2
-    let _3: &'2 u8; // anonymous local
+    let _3: &'3 u8; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
@@ -268,8 +268,8 @@ fn {impl Fn<(&'_ u8,)> for test_crate::main::{closure}}::call<'_0, '_1>(_1: &'_1
     return
 }
 
-// Full name: test_crate::main::{impl FnMut<(&'_ u8,)> for test_crate::main::{closure}}::call_mut
-fn {impl FnMut<(&'_ u8,)> for test_crate::main::{closure}}::call_mut<'_0, '_1>(state: &'_1 mut test_crate::main::{closure}, args: (&'_0 u8,))
+// Full name: test_crate::main::{impl FnMut<(&'_0 u8,)> for test_crate::main::{closure}}::call_mut
+fn {impl FnMut<(&'_0 u8,)> for test_crate::main::{closure}}::call_mut<'_0, '_1>(state: &'_1 mut test_crate::main::{closure}, args: (&'_0 u8,))
 {
     let _0: (); // return
     let state: &'_1 mut test_crate::main::{closure}; // arg #1
@@ -280,7 +280,7 @@ fn {impl FnMut<(&'_ u8,)> for test_crate::main::{closure}}::call_mut<'_0, '_1>(s
     _0 = ()
     storage_live(_3)
     _3 = &(*state)
-    _0 = {impl Fn<(&'_ u8,)> for test_crate::main::{closure}}::call<'_0, '2>(move _3, move args)
+    _0 = {impl Fn<(&'_0 u8,)> for test_crate::main::{closure}}::call<'_0, '2>(move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -291,20 +291,20 @@ fn {impl FnMut<(&'_ u8,)> for test_crate::main::{closure}}::call_mut<'_0, '_1>(s
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(&'_ u8,)> for test_crate::main::{closure}}::call_once
-fn {impl FnOnce<(&'_ u8,)> for test_crate::main::{closure}}::call_once<'_0>(_1: test_crate::main::{closure}, _2: (&'_0 u8,))
+// Full name: test_crate::main::{impl FnOnce<(&'_0 u8,)> for test_crate::main::{closure}}::call_once
+fn {impl FnOnce<(&'_0 u8,)> for test_crate::main::{closure}}::call_once<'_0>(_1: test_crate::main::{closure}, _2: (&'_0 u8,))
 {
     let _0: (); // return
     let _1: test_crate::main::{closure}; // arg #1
-    let _2: (&'0 u8,); // arg #2
-    let _3: &'2 mut test_crate::main::{closure}; // anonymous local
+    let _2: (&'2 u8,); // arg #2
+    let _3: &'4 mut test_crate::main::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _0 = ()
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_ u8,)> for test_crate::main::{closure}}::call_mut<'_0, '7>(move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::main::{closure}}::drop_glue<'8>] _1
+    _0 = {impl FnMut<(&'_0 u8,)> for test_crate::main::{closure}}::call_mut<'_0, '9>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::main::{closure}}::drop_glue<'10>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -313,7 +313,7 @@ fn {impl FnOnce<(&'_ u8,)> for test_crate::main::{closure}}::call_once<'_0>(_1: 
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::main::{closure}}::drop_glue<'9>] _1
+    drop[{impl Destruct for test_crate::main::{closure}}::drop_glue<'11>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -324,35 +324,35 @@ fn {impl FnOnce<(&'_ u8,)> for test_crate::main::{closure}}::call_once<'_0>(_1: 
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(&'_ u8,)> for test_crate::main::{closure}}
-impl<'_0> FnOnce<(&'_ u8,)> for test_crate::main::{closure} {
+// Full name: test_crate::main::{impl FnOnce<(&'_0 u8,)> for test_crate::main::{closure}}
+impl<'_0> FnOnce<(&'_0 u8,)> for test_crate::main::{closure} {
     proof ImpliedClause0: (test_crate::main::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure}}
-    proof ImpliedClause1: ((&'_ u8,): Sized) = {built_in impl Sized for (&'_ u8,)}
-    proof ImpliedClause2: ((&'_ u8,): Tuple) = {built_in impl Tuple for (&'_ u8,)}
+    proof ImpliedClause1: ((&'_0 u8,): Sized) = {built_in impl Sized for (&'_0 u8,)}
+    proof ImpliedClause2: ((&'_0 u8,): Tuple) = {built_in impl Tuple for (&'_0 u8,)}
     proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     type Output = ()
-    fn call_once = {impl FnOnce<(&'_ u8,)> for test_crate::main::{closure}}::call_once<'_0>
-    vtable: {impl FnOnce<(&'_ u8,)> for test_crate::main::{closure}}::{vtable}<'_0>
+    fn call_once = {impl FnOnce<(&'_0 u8,)> for test_crate::main::{closure}}::call_once<'_0>
+    vtable: {impl FnOnce<(&'_0 u8,)> for test_crate::main::{closure}}::{vtable}<'_0>
 }
 
-// Full name: test_crate::main::{impl FnMut<(&'_ u8,)> for test_crate::main::{closure}}
-impl<'_0> FnMut<(&'_ u8,)> for test_crate::main::{closure} {
+// Full name: test_crate::main::{impl FnMut<(&'_0 u8,)> for test_crate::main::{closure}}
+impl<'_0> FnMut<(&'_0 u8,)> for test_crate::main::{closure} {
     proof ImpliedClause0: (test_crate::main::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure}}
-    proof ImpliedClause1: (test_crate::main::{closure}: FnOnce<(&'_ u8,)>) = {impl FnOnce<(&'_ u8,)> for test_crate::main::{closure}}<'_0>
-    proof ImpliedClause2: ((&'_ u8,): Sized) = {built_in impl Sized for (&'_ u8,)}
-    proof ImpliedClause3: ((&'_ u8,): Tuple) = {built_in impl Tuple for (&'_ u8,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_ u8,)> for test_crate::main::{closure}}::call_mut<'_0, '_0_1>
-    vtable: {impl FnMut<(&'_ u8,)> for test_crate::main::{closure}}::{vtable}<'_0>
+    proof ImpliedClause1: (test_crate::main::{closure}: FnOnce<(&'_0 u8,)>) = {impl FnOnce<(&'_0 u8,)> for test_crate::main::{closure}}<'_0>
+    proof ImpliedClause2: ((&'_0 u8,): Sized) = {built_in impl Sized for (&'_0 u8,)}
+    proof ImpliedClause3: ((&'_0 u8,): Tuple) = {built_in impl Tuple for (&'_0 u8,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_0 u8,)> for test_crate::main::{closure}}::call_mut<'_0, '_0_1>
+    vtable: {impl FnMut<(&'_0 u8,)> for test_crate::main::{closure}}::{vtable}<'_0>
 }
 
-// Full name: test_crate::main::{impl Fn<(&'_ u8,)> for test_crate::main::{closure}}
-impl<'_0> Fn<(&'_ u8,)> for test_crate::main::{closure} {
+// Full name: test_crate::main::{impl Fn<(&'_0 u8,)> for test_crate::main::{closure}}
+impl<'_0> Fn<(&'_0 u8,)> for test_crate::main::{closure} {
     proof ImpliedClause0: (test_crate::main::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::main::{closure}}
-    proof ImpliedClause1: (test_crate::main::{closure}: FnMut<(&'_ u8,)>) = {impl FnMut<(&'_ u8,)> for test_crate::main::{closure}}<'_0>
-    proof ImpliedClause2: ((&'_ u8,): Sized) = {built_in impl Sized for (&'_ u8,)}
-    proof ImpliedClause3: ((&'_ u8,): Tuple) = {built_in impl Tuple for (&'_ u8,)}
-    fn call<'_0_1> = {impl Fn<(&'_ u8,)> for test_crate::main::{closure}}::call<'_0, '_0_1>
-    vtable: {impl Fn<(&'_ u8,)> for test_crate::main::{closure}}::{vtable}<'_0>
+    proof ImpliedClause1: (test_crate::main::{closure}: FnMut<(&'_0 u8,)>) = {impl FnMut<(&'_0 u8,)> for test_crate::main::{closure}}<'_0>
+    proof ImpliedClause2: ((&'_0 u8,): Sized) = {built_in impl Sized for (&'_0 u8,)}
+    proof ImpliedClause3: ((&'_0 u8,): Tuple) = {built_in impl Tuple for (&'_0 u8,)}
+    fn call<'_0_1> = {impl Fn<(&'_0 u8,)> for test_crate::main::{closure}}::call<'_0, '_0_1>
+    vtable: {impl Fn<(&'_0 u8,)> for test_crate::main::{closure}}::{vtable}<'_0>
 }
 
 // Full name: test_crate::main::{closure}::{impl Destruct for test_crate::main::{closure}}

--- a/charon/tests/ui/simple/lending-iterator-gat.out
+++ b/charon/tests/ui/simple/lending-iterator-gat.out
@@ -394,7 +394,7 @@ struct {closure}<'_0> {
   _0: &'_0 mut i32,
 }
 
-// Full name: test_crate::main::{impl FnMut<(&'_ i32,)> for {closure}<'_0>}::call_mut
+// Full name: test_crate::main::{impl FnMut<(&'_1 i32,)> for {closure}<'_0>}::call_mut
 fn call_mut<'_0, '_1, '_2>(_1: &'_2 mut {closure}<'_0>, tupled_args: (&'_1 i32,))
 where
     RegionOutlives0: '_0: '_2,
@@ -402,7 +402,7 @@ where
     let _0: (); // return
     let _1: &'1 mut {closure}<'_0>; // arg #1
     let tupled_args: (&'_1 i32,); // arg #2
-    let item: &'2 i32; // local
+    let item: &'3 i32; // local
     let _4: i32; // anonymous local
     let _5: i32; // anonymous local
 
@@ -438,20 +438,20 @@ where
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(&'_ i32,)> for {closure}<'_0>}::call_once
+// Full name: test_crate::main::{impl FnOnce<(&'_1 i32,)> for {closure}<'_0>}::call_once
 fn call_once<'_0, '_1>(_1: {closure}<'_0>, _2: (&'_1 i32,))
 {
     let _0: (); // return
     let _1: {closure}<'_0>; // arg #1
-    let _2: (&'0 i32,); // arg #2
-    let _3: &'2 mut {closure}<'_0>; // anonymous local
+    let _2: (&'2 i32,); // arg #2
+    let _3: &'4 mut {closure}<'_0>; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _0 = ()
     _3 = &mut _1
-    _0 = call_mut<'_0, '_1, '9>(move _3, move _2)
-    ↳⚡ drop[impl_Destruct_for_closure::drop_glue<'_0, '12>] _1
+    _0 = call_mut<'_0, '_1, '11>(move _3, move _2)
+    ↳⚡ drop[impl_Destruct_for_closure::drop_glue<'_0, '14>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -460,7 +460,7 @@ fn call_once<'_0, '_1>(_1: {closure}<'_0>, _2: (&'_1 i32,))
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[impl_Destruct_for_closure::drop_glue<'_0, '15>] _1
+    drop[impl_Destruct_for_closure::drop_glue<'_0, '17>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -471,23 +471,23 @@ fn call_once<'_0, '_1>(_1: {closure}<'_0>, _2: (&'_1 i32,))
     return
 }
 
-// Full name: test_crate::main::{impl FnOnce<(&'_ i32,)> for {closure}<'_0>}
-impl<'_0, '_1> "impl_FnOnce_tuple_for_closure" FnOnce<(&'_ i32,)> for {closure}<'_0> {
+// Full name: test_crate::main::{impl FnOnce<(&'_1 i32,)> for {closure}<'_0>}
+impl<'_0, '_1> "impl_FnOnce_tuple_for_closure" FnOnce<(&'_1 i32,)> for {closure}<'_0> {
     proof ImpliedClause0: ({closure}<'_0>: MetaSized) = {built_in impl MetaSized for {closure}<'_0>}
-    proof ImpliedClause1: ((&'_ i32,): Sized) = {built_in impl Sized for (&'_ i32,)}
-    proof ImpliedClause2: ((&'_ i32,): Tuple) = {built_in impl Tuple for (&'_ i32,)}
+    proof ImpliedClause1: ((&'_1 i32,): Sized) = {built_in impl Sized for (&'_1 i32,)}
+    proof ImpliedClause2: ((&'_1 i32,): Tuple) = {built_in impl Tuple for (&'_1 i32,)}
     proof ImpliedClause3: ((): Sized) = {built_in impl Sized for ()}
     type Output = ()
     fn call_once = call_once<'_0, '_1>
     vtable: impl_FnOnce_tuple_for_closure::{vtable}<'_0, '_1>
 }
 
-// Full name: test_crate::main::{impl FnMut<(&'_ i32,)> for {closure}<'_0>}
-impl<'_0, '_1> "impl_FnMut_tuple_for_closure" FnMut<(&'_ i32,)> for {closure}<'_0> {
+// Full name: test_crate::main::{impl FnMut<(&'_1 i32,)> for {closure}<'_0>}
+impl<'_0, '_1> "impl_FnMut_tuple_for_closure" FnMut<(&'_1 i32,)> for {closure}<'_0> {
     proof ImpliedClause0: ({closure}<'_0>: MetaSized) = {built_in impl MetaSized for {closure}<'_0>}
-    proof ImpliedClause1: ({closure}<'_0>: FnOnce<(&'_ i32,)>) = impl_FnOnce_tuple_for_closure<'_0, '_1>
-    proof ImpliedClause2: ((&'_ i32,): Sized) = {built_in impl Sized for (&'_ i32,)}
-    proof ImpliedClause3: ((&'_ i32,): Tuple) = {built_in impl Tuple for (&'_ i32,)}
+    proof ImpliedClause1: ({closure}<'_0>: FnOnce<(&'_1 i32,)>) = impl_FnOnce_tuple_for_closure<'_0, '_1>
+    proof ImpliedClause2: ((&'_1 i32,): Sized) = {built_in impl Sized for (&'_1 i32,)}
+    proof ImpliedClause3: ((&'_1 i32,): Tuple) = {built_in impl Tuple for (&'_1 i32,)}
     fn call_mut<'_0_1> = call_mut<'_0, '_1, '_0_1>
     vtable: impl_FnMut_tuple_for_closure::{vtable}<'_0, '_1>
 }

--- a/charon/tests/ui/simple/nested-closure.out
+++ b/charon/tests/ui/simple/nested-closure.out
@@ -105,8 +105,8 @@ where
   _0: &'_1 T,
 }
 
-// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call
-fn {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_3, T>(_1: &'_3 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1], tupled_args: (&'_2 u32,)) -> T
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{impl Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call
+fn {impl Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_3, T>(_1: &'_3 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1], tupled_args: (&'_2 u32,)) -> T
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
@@ -118,15 +118,15 @@ where
     let _0: T; // return
     let _1: &'1 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args: (&'_2 u32,); // arg #2
-    let _z: &'2 u32; // local
-    let _4: &'3 T; // anonymous local
+    let _z: &'3 u32; // local
+    let _4: &'4 T; // anonymous local
 
     storage_live(_0)
     storage_live(_z)
     _z = move tupled_args._0
     storage_live(_4)
     _4 = &(*(*_1)._0)
-    _0 = TraitClause1::clone<'5>(move _4)
+    _0 = TraitClause1::clone<'6>(move _4)
     ↳⚡ storage_dead(_z)
         storage_dead(tupled_args)
         storage_dead(_1)
@@ -147,8 +147,8 @@ where
   _0: &'_1 T,
 }
 
-// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call
-fn {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_5, T>(_1: &'_5 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1], tupled_args: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'_3, '_, T>[TraitClause0, TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{impl Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call
+fn {impl Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_5, T>(_1: &'_5 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1], tupled_args: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'_3, '_, T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
@@ -160,8 +160,8 @@ where
     let _0: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'2, '3, T>[TraitClause0, TraitClause1]; // return
     let _1: &'5 test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]; // arg #1
     let tupled_args: (&'_2 u32,); // arg #2
-    let _y: &'6 u32; // local
-    let _4: &'7 T; // anonymous local
+    let _y: &'7 u32; // local
+    let _4: &'8 T; // anonymous local
 
     storage_live(_0)
     storage_live(_y)
@@ -281,7 +281,7 @@ where
     _12 = &(*_17)
     _11 = &(*_12)
     _10 = (move _11,)
-    _5 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'70, '71, '72, '73, '74, '75, T>[TraitClause0, TraitClause1](move _6, move _10)
+    _5 = {impl Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'70, '71, '72, '73, '74, '75, T>[TraitClause0, TraitClause1](move _6, move _10)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(x)
@@ -303,7 +303,7 @@ where
     _15 = &(*_16)
     _14 = &(*_15)
     _13 = (move _14,)
-    _0 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'86, '87, '88, '89, T>[TraitClause0, TraitClause1](move _4, move _13)
+    _0 = {impl Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'86, '87, '88, '89, T>[TraitClause0, TraitClause1](move _4, move _13)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(x)
@@ -488,8 +488,8 @@ where
     return
 }
 
-// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut
-fn {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_5, T>(state: &'_5 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1], args: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'_3, '_, T>[TraitClause0, TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{impl FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut
+fn {impl FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_5, T>(state: &'_5 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1], args: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'_3, '_, T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
@@ -506,7 +506,7 @@ where
     storage_live(_0)
     storage_live(_3)
     _3 = &(*state)
-    _0 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '3, T>[TraitClause0, TraitClause1](move _3, move args)
+    _0 = {impl Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '3, T>[TraitClause0, TraitClause1](move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -517,8 +517,8 @@ where
     return
 }
 
-// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once
-fn {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, '_2, '_3, '_4, T>(_1: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1], _2: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'_3, '_, T>[TraitClause0, TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{impl FnOnce<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, '_2, '_3, '_4, T>(_1: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1], _2: (&'_2 u32,)) -> test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'_3, '_, T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
@@ -526,14 +526,14 @@ where
 {
     let _0: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'2, '3, T>[TraitClause0, TraitClause1]; // return
     let _1: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]; // arg #1
-    let _2: (&'4 u32,); // arg #2
-    let _3: &'6 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]; // anonymous local
+    let _2: (&'6 u32,); // arg #2
+    let _3: &'8 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '17, T>[TraitClause0, TraitClause1](move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_glue<'a, '_1, '22, T>[TraitClause0, TraitClause1]] _1
+    _0 = {impl FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '19, T>[TraitClause0, TraitClause1](move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_glue<'a, '_1, '24, T>[TraitClause0, TraitClause1]] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -542,7 +542,7 @@ where
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_glue<'a, '_1, '27, T>[TraitClause0, TraitClause1]] _1
+    drop[{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_glue<'a, '_1, '29, T>[TraitClause0, TraitClause1]] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -553,50 +553,50 @@ where
     return
 }
 
-// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
-impl<'a, '_1, '_2, '_3, '_4, T> FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{impl FnOnce<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, '_2, '_3, '_4, T> FnOnce<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
     TypeOutlives0: T: '_1,
 {
     proof ImpliedClause0: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
-    proof ImpliedClause1: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
-    proof ImpliedClause2: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    proof ImpliedClause1: ((&'_2 u32,): Sized) = {built_in impl Sized for (&'_2 u32,)}
+    proof ImpliedClause2: ((&'_2 u32,): Tuple) = {built_in impl Tuple for (&'_2 u32,)}
     proof ImpliedClause3: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'_, '_, T>[TraitClause0, TraitClause1]: Sized) = {built_in impl Sized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'_, '_, T>[TraitClause0, TraitClause1]}
     type Output = test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'_, '_, T>[TraitClause0, TraitClause1]
-    fn call_once = {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, '_2, '_3, '_4, T>[TraitClause0, TraitClause1]
-    vtable: {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, '_2, '_3, '_4, T>[TraitClause0, TraitClause1]
+    fn call_once = {impl FnOnce<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, '_2, '_3, '_4, T>[TraitClause0, TraitClause1]
+    vtable: {impl FnOnce<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, '_2, '_3, '_4, T>[TraitClause0, TraitClause1]
 }
 
-// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
-impl<'a, '_1, '_2, '_3, '_4, T> FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{impl FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, '_2, '_3, '_4, T> FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
     TypeOutlives0: T: '_1,
 {
     proof ImpliedClause0: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
-    proof ImpliedClause1: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]: FnOnce<(&'_ u32,)>) = {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}<'a, '_1, '_2, '_3, '_4, T>[TraitClause0, TraitClause1]
-    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
-    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_0_1, T>[TraitClause0, TraitClause1]
-    vtable: {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, '_2, '_3, '_4, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause1: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]: FnOnce<(&'_2 u32,)>) = {impl FnOnce<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}<'a, '_1, '_2, '_3, '_4, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((&'_2 u32,): Sized) = {built_in impl Sized for (&'_2 u32,)}
+    proof ImpliedClause3: ((&'_2 u32,): Tuple) = {built_in impl Tuple for (&'_2 u32,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_3, '_4, '_0_1, T>[TraitClause0, TraitClause1]
+    vtable: {impl FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, '_2, '_3, '_4, T>[TraitClause0, TraitClause1]
 }
 
-// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
-impl<'a, '_1, '_2, '_3, '_4, T> Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{impl Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, '_2, '_3, '_4, T> Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
     TypeOutlives0: T: '_1,
 {
     proof ImpliedClause0: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
-    proof ImpliedClause1: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]: FnMut<(&'_ u32,)>) = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}<'a, '_1, '_2, '_3, '_4, T>[TraitClause0, TraitClause1]
-    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
-    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
-    fn call<'_0_1> = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_0_1, T>[TraitClause0, TraitClause1]
-    vtable: {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, '_2, '_3, '_4, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause1: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]: FnMut<(&'_2 u32,)>) = {impl FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}<'a, '_1, '_2, '_3, '_4, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((&'_2 u32,): Sized) = {built_in impl Sized for (&'_2 u32,)}
+    proof ImpliedClause3: ((&'_2 u32,): Tuple) = {built_in impl Tuple for (&'_2 u32,)}
+    fn call<'_0_1> = {impl Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_3, '_4, '_0_1, T>[TraitClause0, TraitClause1]
+    vtable: {impl Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, '_2, '_3, '_4, T>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
@@ -629,8 +629,8 @@ where
     return
 }
 
-// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut
-fn {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_3, T>(state: &'_3 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1], args: (&'_2 u32,)) -> T
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{impl FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut
+fn {impl FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_3, T>(state: &'_3 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1], args: (&'_2 u32,)) -> T
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
@@ -647,7 +647,7 @@ where
     storage_live(_0)
     storage_live(_3)
     _3 = &(*state)
-    _0 = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '2, T>[TraitClause0, TraitClause1](move _3, move args)
+    _0 = {impl Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '2, T>[TraitClause0, TraitClause1](move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -658,8 +658,8 @@ where
     return
 }
 
-// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once
-fn {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, '_2, T>(_1: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1], _2: (&'_2 u32,)) -> T
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{impl FnOnce<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once
+fn {impl FnOnce<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, '_2, T>(_1: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1], _2: (&'_2 u32,)) -> T
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
@@ -667,14 +667,14 @@ where
 {
     let _0: T; // return
     let _1: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]; // arg #1
-    let _2: (&'0 u32,); // arg #2
-    let _3: &'2 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]; // anonymous local
+    let _2: (&'2 u32,); // arg #2
+    let _3: &'4 mut test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '11, T>[TraitClause0, TraitClause1](move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_glue<'a, '_1, '16, T>[TraitClause0, TraitClause1]] _1
+    _0 = {impl FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '13, T>[TraitClause0, TraitClause1](move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_glue<'a, '_1, '18, T>[TraitClause0, TraitClause1]] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -683,7 +683,7 @@ where
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_glue<'a, '_1, '21, T>[TraitClause0, TraitClause1]] _1
+    drop[{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::drop_glue<'a, '_1, '23, T>[TraitClause0, TraitClause1]] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -694,50 +694,50 @@ where
     return
 }
 
-// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
-impl<'a, '_1, '_2, T> FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{impl FnOnce<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, '_2, T> FnOnce<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
     TypeOutlives0: T: '_1,
 {
     proof ImpliedClause0: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
-    proof ImpliedClause1: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
-    proof ImpliedClause2: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
+    proof ImpliedClause1: ((&'_2 u32,): Sized) = {built_in impl Sized for (&'_2 u32,)}
+    proof ImpliedClause2: ((&'_2 u32,): Tuple) = {built_in impl Tuple for (&'_2 u32,)}
     proof ImpliedClause3: (T: Sized) = TraitClause0
     type Output = T
-    fn call_once = {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, '_2, T>[TraitClause0, TraitClause1]
-    vtable: {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, '_2, T>[TraitClause0, TraitClause1]
+    fn call_once = {impl FnOnce<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_once<'a, '_1, '_2, T>[TraitClause0, TraitClause1]
+    vtable: {impl FnOnce<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, '_2, T>[TraitClause0, TraitClause1]
 }
 
-// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
-impl<'a, '_1, '_2, T> FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{impl FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, '_2, T> FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
     TypeOutlives0: T: '_1,
 {
     proof ImpliedClause0: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
-    proof ImpliedClause1: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]: FnOnce<(&'_ u32,)>) = {impl FnOnce<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}<'a, '_1, '_2, T>[TraitClause0, TraitClause1]
-    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
-    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
-    fn call_mut<'_0_1> = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_0_1, T>[TraitClause0, TraitClause1]
-    vtable: {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, '_2, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause1: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]: FnOnce<(&'_2 u32,)>) = {impl FnOnce<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}<'a, '_1, '_2, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((&'_2 u32,): Sized) = {built_in impl Sized for (&'_2 u32,)}
+    proof ImpliedClause3: ((&'_2 u32,): Tuple) = {built_in impl Tuple for (&'_2 u32,)}
+    fn call_mut<'_0_1> = {impl FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call_mut<'a, '_1, '_2, '_0_1, T>[TraitClause0, TraitClause1]
+    vtable: {impl FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, '_2, T>[TraitClause0, TraitClause1]
 }
 
-// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
-impl<'a, '_1, '_2, T> Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]
+// Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{impl Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
+impl<'a, '_1, '_2, T> Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]
 where
     TraitClause0: (T: Sized),
     TraitClause1: (T: Clone),
     TypeOutlives0: T: '_1,
 {
     proof ImpliedClause0: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]: MetaSized) = {built_in impl MetaSized for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}
-    proof ImpliedClause1: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]: FnMut<(&'_ u32,)>) = {impl FnMut<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}<'a, '_1, '_2, T>[TraitClause0, TraitClause1]
-    proof ImpliedClause2: ((&'_ u32,): Sized) = {built_in impl Sized for (&'_ u32,)}
-    proof ImpliedClause3: ((&'_ u32,): Tuple) = {built_in impl Tuple for (&'_ u32,)}
-    fn call<'_0_1> = {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_0_1, T>[TraitClause0, TraitClause1]
-    vtable: {impl Fn<(&'_ u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, '_2, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause1: (test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]: FnMut<(&'_2 u32,)>) = {impl FnMut<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}<'a, '_1, '_2, T>[TraitClause0, TraitClause1]
+    proof ImpliedClause2: ((&'_2 u32,): Sized) = {built_in impl Sized for (&'_2 u32,)}
+    proof ImpliedClause3: ((&'_2 u32,): Tuple) = {built_in impl Tuple for (&'_2 u32,)}
+    fn call<'_0_1> = {impl Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::call<'a, '_1, '_2, '_0_1, T>[TraitClause0, TraitClause1]
+    vtable: {impl Fn<(&'_2 u32,)> for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}::{vtable}<'a, '_1, '_2, T>[TraitClause0, TraitClause1]
 }
 
 // Full name: test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}::{impl Destruct for test_crate::{Foo<'a, T>[TraitClause0]}::test_nested_closures::{closure}::{closure}::{closure}<'a, '_1, T>[TraitClause0, TraitClause1]}

--- a/charon/tests/ui/simple/thread-local.out
+++ b/charon/tests/ui/simple/thread-local.out
@@ -278,16 +278,16 @@ fn test_crate::FOO::{const}::{closure}::__RUST_STD_INTERNAL_VAL() -> Storage<u32
 
 thread_local test_crate::FOO::{const}::{closure}::__RUST_STD_INTERNAL_VAL: Storage<u32, ()>[{built_in impl Sized for u32}, {built_in impl Sized for ()}] = test_crate::FOO::{const}::{closure}::__RUST_STD_INTERNAL_VAL()
 
-// Full name: test_crate::FOO::{const}::{impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call
-fn {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call<'_0, '_1>(_1: &'_1 test_crate::FOO::{const}::{closure}, tupled_args: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)) -> *const u32
+// Full name: test_crate::FOO::{const}::{impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call
+fn {impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call<'_0, '_1>(_1: &'_1 test_crate::FOO::{const}::{closure}, tupled_args: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)) -> *const u32
 {
     let _0: *const u32; // return
     let _1: &'1 test_crate::FOO::{const}::{closure}; // arg #1
     let tupled_args: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],); // arg #2
-    let __rust_std_internal_init: Option<&'2 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'2 mut Option<u32>[{built_in impl Sized for u32}]}]; // local
-    let _4: &'7 Storage<u32, ()>[{built_in impl Sized for u32}, {built_in impl Sized for ()}]; // anonymous local
-    let _5: &'8 Storage<u32, ()>[{built_in impl Sized for u32}, {built_in impl Sized for ()}]; // anonymous local
-    let _6: Option<&'9 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'9 mut Option<u32>[{built_in impl Sized for u32}]}]; // anonymous local
+    let __rust_std_internal_init: Option<&'8 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'8 mut Option<u32>[{built_in impl Sized for u32}]}]; // local
+    let _4: &'13 Storage<u32, ()>[{built_in impl Sized for u32}, {built_in impl Sized for ()}]; // anonymous local
+    let _5: &'14 Storage<u32, ()>[{built_in impl Sized for u32}, {built_in impl Sized for ()}]; // anonymous local
+    let _6: Option<&'15 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'15 mut Option<u32>[{built_in impl Sized for u32}]}]; // anonymous local
 
     storage_live(_0)
     storage_live(__rust_std_internal_init)
@@ -298,7 +298,7 @@ fn {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_i
     _4 = &(*_5)
     storage_live(_6)
     _6 = move __rust_std_internal_init
-    _0 = get_or_init<'15, '16, u32, (), __rust_std_internal_init_fn>[{built_in impl Sized for u32}, {built_in impl Sized for ()}, impl_DestroyedState_for_unit, {built_in impl Sized for __rust_std_internal_init_fn}, {impl FnOnce<()> for __rust_std_internal_init_fn}](move _4, move _6, const __rust_std_internal_init_fn)
+    _0 = get_or_init<'21, '22, u32, (), __rust_std_internal_init_fn>[{built_in impl Sized for u32}, {built_in impl Sized for ()}, impl_DestroyedState_for_unit, {built_in impl Sized for __rust_std_internal_init_fn}, {impl FnOnce<()> for __rust_std_internal_init_fn}](move _4, move _6, const __rust_std_internal_init_fn)
     ↳⚡ storage_dead(__rust_std_internal_init)
         storage_dead(tupled_args)
         storage_dead(_1)
@@ -312,8 +312,8 @@ fn {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_i
     return
 }
 
-// Full name: test_crate::FOO::{const}::{impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_mut
-fn {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_mut<'_0, '_1>(state: &'_1 mut test_crate::FOO::{const}::{closure}, args: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)) -> *const u32
+// Full name: test_crate::FOO::{const}::{impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_mut
+fn {impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_mut<'_0, '_1>(state: &'_1 mut test_crate::FOO::{const}::{closure}, args: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)) -> *const u32
 {
     let _0: *const u32; // return
     let state: &'_1 mut test_crate::FOO::{const}::{closure}; // arg #1
@@ -323,7 +323,7 @@ fn {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{buil
     storage_live(_0)
     storage_live(_3)
     _3 = &(*state)
-    _0 = {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call<'_0, '4>(move _3, move args)
+    _0 = {impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call<'_0, '4>(move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -334,19 +334,19 @@ fn {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{buil
     return
 }
 
-// Full name: test_crate::FOO::{const}::{impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_once
-fn {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_once<'_0>(_1: test_crate::FOO::{const}::{closure}, _2: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)) -> *const u32
+// Full name: test_crate::FOO::{const}::{impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_once
+fn {impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_once<'_0>(_1: test_crate::FOO::{const}::{closure}, _2: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)) -> *const u32
 {
     let _0: *const u32; // return
     let _1: test_crate::FOO::{const}::{closure}; // arg #1
-    let _2: (Option<&'0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'0 mut Option<u32>[{built_in impl Sized for u32}]}],); // arg #2
-    let _3: &'5 mut test_crate::FOO::{const}::{closure}; // anonymous local
+    let _2: (Option<&'10 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'10 mut Option<u32>[{built_in impl Sized for u32}]}],); // arg #2
+    let _3: &'15 mut test_crate::FOO::{const}::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_mut<'_0, '22>(move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::FOO::{const}::{closure}}::drop_glue<'23>] _1
+    _0 = {impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_mut<'_0, '32>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::FOO::{const}::{closure}}::drop_glue<'33>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -355,7 +355,7 @@ fn {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{bui
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::FOO::{const}::{closure}}::drop_glue<'24>] _1
+    drop[{impl Destruct for test_crate::FOO::{const}::{closure}}::drop_glue<'34>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -366,35 +366,35 @@ fn {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{bui
     return
 }
 
-// Full name: test_crate::FOO::{const}::{impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}
-impl<'_0> FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure} {
+// Full name: test_crate::FOO::{const}::{impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}
+impl<'_0> FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure} {
     proof ImpliedClause0: (test_crate::FOO::{const}::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::FOO::{const}::{closure}}
-    proof ImpliedClause1: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    proof ImpliedClause2: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause1: ((Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause2: ((Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)}
     proof ImpliedClause3: (*const u32: Sized) = {built_in impl Sized for *const u32}
     type Output = *const u32
-    fn call_once = {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_once<'_0>
-    vtable: {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::{vtable}<'_0>
+    fn call_once = {impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_once<'_0>
+    vtable: {impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::{vtable}<'_0>
 }
 
-// Full name: test_crate::FOO::{const}::{impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}
-impl<'_0> FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure} {
+// Full name: test_crate::FOO::{const}::{impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}
+impl<'_0> FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure} {
     proof ImpliedClause0: (test_crate::FOO::{const}::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::FOO::{const}::{closure}}
-    proof ImpliedClause1: (test_crate::FOO::{const}::{closure}: FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)>) = {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}<'_0>
-    proof ImpliedClause2: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    proof ImpliedClause3: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    fn call_mut<'_0_1> = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_mut<'_0, '_0_1>
-    vtable: {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::{vtable}<'_0>
+    proof ImpliedClause1: (test_crate::FOO::{const}::{closure}: FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)>) = {impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}<'_0>
+    proof ImpliedClause2: ((Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause3: ((Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    fn call_mut<'_0_1> = {impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_mut<'_0, '_0_1>
+    vtable: {impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::{vtable}<'_0>
 }
 
-// Full name: test_crate::FOO::{const}::{impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}
-impl<'_0> Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure} {
+// Full name: test_crate::FOO::{const}::{impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}
+impl<'_0> Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure} {
     proof ImpliedClause0: (test_crate::FOO::{const}::{closure}: MetaSized) = {built_in impl MetaSized for test_crate::FOO::{const}::{closure}}
-    proof ImpliedClause1: (test_crate::FOO::{const}::{closure}: FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)>) = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}<'_0>
-    proof ImpliedClause2: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    proof ImpliedClause3: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    fn call<'_0_1> = {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call<'_0, '_0_1>
-    vtable: {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::{vtable}<'_0>
+    proof ImpliedClause1: (test_crate::FOO::{const}::{closure}: FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)>) = {impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}<'_0>
+    proof ImpliedClause2: ((Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause3: ((Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    fn call<'_0_1> = {impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call<'_0, '_0_1>
+    vtable: {impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::{vtable}<'_0>
 }
 
 // Full name: test_crate::FOO::{const}::{closure}::{impl Destruct for test_crate::FOO::{const}::{closure}}
@@ -415,7 +415,7 @@ fn test_crate::FOO::{const}::{closure}::{as_fn}<'_0>(arg1: Option<&'_0 mut Optio
     storage_live(state)
     args = (move arg1,)
     state = test_crate::FOO::{const}::{closure} {  }
-    _0 = {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_once<'_0>(move state, move args)
+    _0 = {impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_once<'_0>(move state, move args)
     ↳⚡ storage_dead(state)
         storage_dead(args)
         storage_dead(arg1)
@@ -452,16 +452,16 @@ fn test_crate::FOO::{const}::{closure#1}::__RUST_STD_INTERNAL_VAL() -> Storage<u
 
 thread_local test_crate::FOO::{const}::{closure#1}::__RUST_STD_INTERNAL_VAL: Storage<u32, !>[{built_in impl Sized for u32}, {built_in impl Sized for !}] = test_crate::FOO::{const}::{closure#1}::__RUST_STD_INTERNAL_VAL()
 
-// Full name: test_crate::FOO::{const}::{impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call
-fn {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call<'_0, '_1>(_1: &'_1 test_crate::FOO::{const}::{closure#1}, tupled_args: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)) -> *const u32
+// Full name: test_crate::FOO::{const}::{impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call
+fn {impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call<'_0, '_1>(_1: &'_1 test_crate::FOO::{const}::{closure#1}, tupled_args: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)) -> *const u32
 {
     let _0: *const u32; // return
     let _1: &'1 test_crate::FOO::{const}::{closure#1}; // arg #1
     let tupled_args: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],); // arg #2
-    let __rust_std_internal_init: Option<&'2 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'2 mut Option<u32>[{built_in impl Sized for u32}]}]; // local
-    let _4: &'7 Storage<u32, !>[{built_in impl Sized for u32}, {built_in impl Sized for !}]; // anonymous local
-    let _5: &'8 Storage<u32, !>[{built_in impl Sized for u32}, {built_in impl Sized for !}]; // anonymous local
-    let _6: Option<&'9 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'9 mut Option<u32>[{built_in impl Sized for u32}]}]; // anonymous local
+    let __rust_std_internal_init: Option<&'8 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'8 mut Option<u32>[{built_in impl Sized for u32}]}]; // local
+    let _4: &'13 Storage<u32, !>[{built_in impl Sized for u32}, {built_in impl Sized for !}]; // anonymous local
+    let _5: &'14 Storage<u32, !>[{built_in impl Sized for u32}, {built_in impl Sized for !}]; // anonymous local
+    let _6: Option<&'15 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'15 mut Option<u32>[{built_in impl Sized for u32}]}]; // anonymous local
 
     storage_live(_0)
     storage_live(__rust_std_internal_init)
@@ -472,7 +472,7 @@ fn {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_i
     _4 = &(*_5)
     storage_live(_6)
     _6 = move __rust_std_internal_init
-    _0 = get_or_init<'15, '16, u32, !, __rust_std_internal_init_fn>[{built_in impl Sized for u32}, {built_in impl Sized for !}, {impl DestroyedState for !}, {built_in impl Sized for __rust_std_internal_init_fn}, {impl FnOnce<()> for __rust_std_internal_init_fn}](move _4, move _6, const __rust_std_internal_init_fn)
+    _0 = get_or_init<'21, '22, u32, !, __rust_std_internal_init_fn>[{built_in impl Sized for u32}, {built_in impl Sized for !}, {impl DestroyedState for !}, {built_in impl Sized for __rust_std_internal_init_fn}, {impl FnOnce<()> for __rust_std_internal_init_fn}](move _4, move _6, const __rust_std_internal_init_fn)
     ↳⚡ storage_dead(__rust_std_internal_init)
         storage_dead(tupled_args)
         storage_dead(_1)
@@ -486,8 +486,8 @@ fn {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_i
     return
 }
 
-// Full name: test_crate::FOO::{const}::{impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_mut
-fn {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_mut<'_0, '_1>(state: &'_1 mut test_crate::FOO::{const}::{closure#1}, args: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)) -> *const u32
+// Full name: test_crate::FOO::{const}::{impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_mut
+fn {impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_mut<'_0, '_1>(state: &'_1 mut test_crate::FOO::{const}::{closure#1}, args: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)) -> *const u32
 {
     let _0: *const u32; // return
     let state: &'_1 mut test_crate::FOO::{const}::{closure#1}; // arg #1
@@ -497,7 +497,7 @@ fn {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{buil
     storage_live(_0)
     storage_live(_3)
     _3 = &(*state)
-    _0 = {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call<'_0, '4>(move _3, move args)
+    _0 = {impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call<'_0, '4>(move _3, move args)
     ↳⚡ storage_dead(_3)
         storage_dead(args)
         storage_dead(state)
@@ -508,19 +508,19 @@ fn {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{buil
     return
 }
 
-// Full name: test_crate::FOO::{const}::{impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_once
-fn {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_once<'_0>(_1: test_crate::FOO::{const}::{closure#1}, _2: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)) -> *const u32
+// Full name: test_crate::FOO::{const}::{impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_once
+fn {impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_once<'_0>(_1: test_crate::FOO::{const}::{closure#1}, _2: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)) -> *const u32
 {
     let _0: *const u32; // return
     let _1: test_crate::FOO::{const}::{closure#1}; // arg #1
-    let _2: (Option<&'0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'0 mut Option<u32>[{built_in impl Sized for u32}]}],); // arg #2
-    let _3: &'5 mut test_crate::FOO::{const}::{closure#1}; // anonymous local
+    let _2: (Option<&'10 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'10 mut Option<u32>[{built_in impl Sized for u32}]}],); // arg #2
+    let _3: &'15 mut test_crate::FOO::{const}::{closure#1}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_mut<'_0, '22>(move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::FOO::{const}::{closure#1}}::drop_glue<'23>] _1
+    _0 = {impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_mut<'_0, '32>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::FOO::{const}::{closure#1}}::drop_glue<'33>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -529,7 +529,7 @@ fn {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{bui
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::FOO::{const}::{closure#1}}::drop_glue<'24>] _1
+    drop[{impl Destruct for test_crate::FOO::{const}::{closure#1}}::drop_glue<'34>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -540,35 +540,35 @@ fn {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{bui
     return
 }
 
-// Full name: test_crate::FOO::{const}::{impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}
-impl<'_0> FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1} {
+// Full name: test_crate::FOO::{const}::{impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}
+impl<'_0> FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1} {
     proof ImpliedClause0: (test_crate::FOO::{const}::{closure#1}: MetaSized) = {built_in impl MetaSized for test_crate::FOO::{const}::{closure#1}}
-    proof ImpliedClause1: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    proof ImpliedClause2: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause1: ((Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause2: ((Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)}
     proof ImpliedClause3: (*const u32: Sized) = {built_in impl Sized for *const u32}
     type Output = *const u32
-    fn call_once = {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_once<'_0>
-    vtable: {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::{vtable}<'_0>
+    fn call_once = {impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_once<'_0>
+    vtable: {impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::{vtable}<'_0>
 }
 
-// Full name: test_crate::FOO::{const}::{impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}
-impl<'_0> FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1} {
+// Full name: test_crate::FOO::{const}::{impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}
+impl<'_0> FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1} {
     proof ImpliedClause0: (test_crate::FOO::{const}::{closure#1}: MetaSized) = {built_in impl MetaSized for test_crate::FOO::{const}::{closure#1}}
-    proof ImpliedClause1: (test_crate::FOO::{const}::{closure#1}: FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)>) = {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}<'_0>
-    proof ImpliedClause2: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    proof ImpliedClause3: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    fn call_mut<'_0_1> = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_mut<'_0, '_0_1>
-    vtable: {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::{vtable}<'_0>
+    proof ImpliedClause1: (test_crate::FOO::{const}::{closure#1}: FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)>) = {impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}<'_0>
+    proof ImpliedClause2: ((Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause3: ((Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    fn call_mut<'_0_1> = {impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_mut<'_0, '_0_1>
+    vtable: {impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::{vtable}<'_0>
 }
 
-// Full name: test_crate::FOO::{const}::{impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}
-impl<'_0> Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1} {
+// Full name: test_crate::FOO::{const}::{impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}
+impl<'_0> Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1} {
     proof ImpliedClause0: (test_crate::FOO::{const}::{closure#1}: MetaSized) = {built_in impl MetaSized for test_crate::FOO::{const}::{closure#1}}
-    proof ImpliedClause1: (test_crate::FOO::{const}::{closure#1}: FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)>) = {impl FnMut<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}<'_0>
-    proof ImpliedClause2: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    proof ImpliedClause3: ((Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)}
-    fn call<'_0_1> = {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call<'_0, '_0_1>
-    vtable: {impl Fn<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::{vtable}<'_0>
+    proof ImpliedClause1: (test_crate::FOO::{const}::{closure#1}: FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)>) = {impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}<'_0>
+    proof ImpliedClause2: ((Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],): Sized) = {built_in impl Sized for (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    proof ImpliedClause3: ((Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],): Tuple) = {built_in impl Tuple for (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)}
+    fn call<'_0_1> = {impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call<'_0, '_0_1>
+    vtable: {impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::{vtable}<'_0>
 }
 
 // Full name: test_crate::FOO::{const}::{closure#1}::{impl Destruct for test_crate::FOO::{const}::{closure#1}}
@@ -589,7 +589,7 @@ fn test_crate::FOO::{const}::{closure#1}::{as_fn}<'_0>(arg1: Option<&'_0 mut Opt
     storage_live(state)
     args = (move arg1,)
     state = test_crate::FOO::{const}::{closure#1} {  }
-    _0 = {impl FnOnce<(Option<&'_ mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_ mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_once<'_0>(move state, move args)
+    _0 = {impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_once<'_0>(move state, move args)
     ↳⚡ storage_dead(state)
         storage_dead(args)
         storage_dead(arg1)


### PR DESCRIPTION
Fixes #807

The last commit is debatably sound: freshening erased regions underconstrains them. For accurate region relations we need borrow-checker input however, see https://github.com/AeneasVerif/charon/issues/1040.