### PR TITLE
Fix escaping bound var for HRTB

### DIFF
--- a/charon/src/bin/charon-driver/translate/translate_predicates.rs
+++ b/charon/src/bin/charon-driver/translate/translate_predicates.rs
@@ -407,12 +407,15 @@ impl<'tcx, 'ctx> ItemTransCtx<'tcx, 'ctx> {
                             }
                             type_map
                         };
-                        let vtable = self.translate_vtable_instance_ref_no_enqueue(
-                            span,
-                            tref.hax_skip_binder_ref(),
-                            tref.hax_skip_binder_ref(),
-                            TransImplSource::Marker,
-                        )?;
+                        let vtable = self.translate_region_binder(span, tref, |ctx, tref| {
+                            ctx.translate_vtable_instance_ref_no_enqueue(
+                                span,
+                                tref,
+                                tref,
+                                TransImplSource::Marker,
+                            )
+                        })?;
+                        let vtable = self.erase_region_binder(vtable);
                         TraitRefKind::BuiltinOrAuto {
                             builtin_data,
                             parent_trait_refs,

--- a/charon/tests/cargo/dependencies.out
+++ b/charon/tests/cargo/dependencies.out
@@ -154,24 +154,24 @@ fn main()
     let _2: (); // anonymous local
     let _3: &'1 mut u32; // anonymous local
     let _4: &'2 mut u32; // anonymous local
-    let _5: (&'11 u32, &'12 u32); // anonymous local
-    let _6: &'16 u32; // anonymous local
-    let _7: &'17 u32; // anonymous local
-    let left_val: &'18 u32; // local
-    let right_val: &'19 u32; // local
+    let _5: (&'12 u32, &'13 u32); // anonymous local
+    let _6: &'17 u32; // anonymous local
+    let _7: &'18 u32; // anonymous local
+    let left_val: &'19 u32; // local
+    let right_val: &'20 u32; // local
     let _10: bool; // anonymous local
     let _11: u32; // anonymous local
     let _12: u32; // anonymous local
     let kind: AssertKind; // local
     let _14: AssertKind; // anonymous local
-    let _15: &'20 u32; // anonymous local
-    let _16: &'21 u32; // anonymous local
-    let _17: &'22 u32; // anonymous local
-    let _18: &'23 u32; // anonymous local
-    let _19: Option<Arguments<'31>>[{built_in impl Sized for Arguments<'31>}]; // anonymous local
-    let _20: &'35 u32; // anonymous local
-    let _21: &'38 u32; // anonymous local
-    let _22: &'52 u32; // anonymous local
+    let _15: &'21 u32; // anonymous local
+    let _16: &'22 u32; // anonymous local
+    let _17: &'23 u32; // anonymous local
+    let _18: &'24 u32; // anonymous local
+    let _19: Option<Arguments<'33>>[{built_in impl Sized for Arguments<'33>}]; // anonymous local
+    let _20: &'37 u32; // anonymous local
+    let _21: &'40 u32; // anonymous local
+    let _22: &'55 u32; // anonymous local
     let _23: u32; // anonymous local
 
     storage_live(_0)
@@ -185,7 +185,7 @@ fn main()
     storage_live(_4)
     _4 = &mut x
     _3 = &two-phase-mut (*_4)
-    _2 = silly_incr<'37>(move _3)
+    _2 = silly_incr<'39>(move _3)
     ↳⚡ unwind_continue
     storage_live(_21)
     storage_live(_22)

--- a/charon/tests/cargo/issue-396-lib-bin.out
+++ b/charon/tests/cargo/issue-396-lib-bin.out
@@ -117,15 +117,15 @@ fn main()
     let args_3: (&'4 u32,); // local
     let _4: &'5 u32; // anonymous local
     let _5: u32; // anonymous local
-    let args_6: [Argument<'13>; 1usize]; // local
-    let _7: Argument<'17>; // anonymous local
-    let _8: &'18 u32; // anonymous local
-    let _9: &'20 [u8; 4usize]; // anonymous local
-    let _10: &'21 [u8; 4usize]; // anonymous local
-    let _11: &'27 [Argument<'28>; 1usize]; // anonymous local
-    let _12: &'32 [Argument<'33>; 1usize]; // anonymous local
+    let args_6: [Argument<'14>; 1usize]; // local
+    let _7: Argument<'18>; // anonymous local
+    let _8: &'19 u32; // anonymous local
+    let _9: &'21 [u8; 4usize]; // anonymous local
+    let _10: &'22 [u8; 4usize]; // anonymous local
+    let _11: &'28 [Argument<'29>; 1usize]; // anonymous local
+    let _12: &'33 [Argument<'34>; 1usize]; // anonymous local
     let _13: [u8; 4usize]; // anonymous local
-    let _14: &'43 [u8; 4usize]; // anonymous local
+    let _14: &'44 [u8; 4usize]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -144,7 +144,7 @@ fn main()
     storage_live(_7)
     storage_live(_8)
     _8 = &(*args_3._0)
-    _7 = new_display<'39, '41, u32>[{built_in impl Sized for u32}, impl_Display_for_u32](move _8)
+    _7 = new_display<'40, '42, u32>[{built_in impl Sized for u32}, impl_Display_for_u32](move _8)
     ↳⚡ unwind_continue
     storage_dead(_8)
     args_6 = [move _7]
@@ -162,13 +162,13 @@ fn main()
     storage_live(_12)
     _12 = &args_6
     _11 = &(*_12)
-    _2 = new<'48, 4usize, 1usize>(move _9, move _11)
+    _2 = new<'49, 4usize, 1usize>(move _9, move _11)
     ↳⚡ unwind_continue
     storage_dead(_12)
     storage_dead(_11)
     storage_dead(_10)
     storage_dead(_9)
-    _1 = _print<'50>(move _2)
+    _1 = _print<'51>(move _2)
     ↳⚡ unwind_continue
     storage_dead(_2)
     storage_dead(args_6)

--- a/charon/tests/cargo/issue-412-dup-deps.out
+++ b/charon/tests/cargo/issue-412-dup-deps.out
@@ -70,28 +70,28 @@ fn main()
     let _0: (); // return
     let a: u32; // local
     let b: u32; // local
-    let _3: (&'8 u32, &'9 u32); // anonymous local
-    let _4: &'13 u32; // anonymous local
+    let _3: (&'9 u32, &'10 u32); // anonymous local
+    let _4: &'14 u32; // anonymous local
     let _5: u32; // anonymous local
     let _6: u32; // anonymous local
     let _7: u32; // anonymous local
     let _8: (u32, bool); // anonymous local
-    let _9: &'14 u32; // anonymous local
-    let left_val: &'15 u32; // local
-    let right_val: &'16 u32; // local
+    let _9: &'15 u32; // anonymous local
+    let left_val: &'16 u32; // local
+    let right_val: &'17 u32; // local
     let _12: bool; // anonymous local
     let _13: u32; // anonymous local
     let _14: u32; // anonymous local
     let kind: AssertKind; // local
     let _16: AssertKind; // anonymous local
-    let _17: &'17 u32; // anonymous local
-    let _18: &'18 u32; // anonymous local
-    let _19: &'19 u32; // anonymous local
-    let _20: &'20 u32; // anonymous local
-    let _21: Option<Arguments<'28>>[{built_in impl Sized for Arguments<'28>}]; // anonymous local
-    let _22: &'32 u32; // anonymous local
-    let _23: &'33 u32; // anonymous local
-    let _24: &'47 u32; // anonymous local
+    let _17: &'18 u32; // anonymous local
+    let _18: &'19 u32; // anonymous local
+    let _19: &'20 u32; // anonymous local
+    let _20: &'21 u32; // anonymous local
+    let _21: Option<Arguments<'30>>[{built_in impl Sized for Arguments<'30>}]; // anonymous local
+    let _22: &'34 u32; // anonymous local
+    let _23: &'35 u32; // anonymous local
+    let _24: &'50 u32; // anonymous local
     let _25: u32; // anonymous local
 
     storage_live(_0)

--- a/charon/tests/cargo/test-attributes.out
+++ b/charon/tests/cargo/test-attributes.out
@@ -457,7 +457,7 @@ pub fn test_attributes::tests::test_ignore() -> TestDescAndFn
     let _0: TestDescAndFn; // return
     let _1: TestDesc; // anonymous local
     let _2: TestName; // anonymous local
-    let _3: Option<&'7 str>[{built_in impl Sized for &'7 str}]; // anonymous local
+    let _3: Option<&'8 str>[{built_in impl Sized for &'8 str}]; // anonymous local
     let _4: ShouldPanic; // anonymous local
     let _5: TestType; // anonymous local
     let _6: TestFn; // anonymous local
@@ -478,8 +478,8 @@ pub fn test_attributes::tests::test_ignore() -> TestDescAndFn
     storage_dead(_5)
     storage_dead(_4)
     storage_dead(_3)
-    conditional_drop[impl_Destruct_for_TestName::drop_glue<'19>] _2
-    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'21>] _1
+    conditional_drop[impl_Destruct_for_TestName::drop_glue<'21>] _2
+    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'23>] _1
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_2)
@@ -492,12 +492,12 @@ pub fn test_attributes::tests::test_ignore() -> TestDescAndFn
     _6 = TestFn::StaticTestFn { _0: move _7 }
     storage_dead(_7)
     _0 = TestDescAndFn { desc: move _1, testfn: move _6 }
-    conditional_drop[impl_Destruct_for_TestFn::drop_glue<'20>] _6
-    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'21>] _1
+    conditional_drop[impl_Destruct_for_TestFn::drop_glue<'22>] _6
+    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'23>] _1
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_6)
-    conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'22>] _1
+    conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'24>] _1
     ↳⚡ unwind_continue
     storage_dead(_1)
     return
@@ -608,7 +608,7 @@ pub fn test_attributes::tests::test_should_panic() -> TestDescAndFn
     let _0: TestDescAndFn; // return
     let _1: TestDesc; // anonymous local
     let _2: TestName; // anonymous local
-    let _3: Option<&'7 str>[{built_in impl Sized for &'7 str}]; // anonymous local
+    let _3: Option<&'8 str>[{built_in impl Sized for &'8 str}]; // anonymous local
     let _4: ShouldPanic; // anonymous local
     let _5: TestType; // anonymous local
     let _6: TestFn; // anonymous local
@@ -629,8 +629,8 @@ pub fn test_attributes::tests::test_should_panic() -> TestDescAndFn
     storage_dead(_5)
     storage_dead(_4)
     storage_dead(_3)
-    conditional_drop[impl_Destruct_for_TestName::drop_glue<'19>] _2
-    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'21>] _1
+    conditional_drop[impl_Destruct_for_TestName::drop_glue<'21>] _2
+    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'23>] _1
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_2)
@@ -643,12 +643,12 @@ pub fn test_attributes::tests::test_should_panic() -> TestDescAndFn
     _6 = TestFn::StaticTestFn { _0: move _7 }
     storage_dead(_7)
     _0 = TestDescAndFn { desc: move _1, testfn: move _6 }
-    conditional_drop[impl_Destruct_for_TestFn::drop_glue<'20>] _6
-    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'21>] _1
+    conditional_drop[impl_Destruct_for_TestFn::drop_glue<'22>] _6
+    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'23>] _1
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_6)
-    conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'22>] _1
+    conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'24>] _1
     ↳⚡ unwind_continue
     storage_dead(_1)
     return
@@ -760,7 +760,7 @@ pub fn test_attributes::tests::test_foo() -> TestDescAndFn
     let _0: TestDescAndFn; // return
     let _1: TestDesc; // anonymous local
     let _2: TestName; // anonymous local
-    let _3: Option<&'7 str>[{built_in impl Sized for &'7 str}]; // anonymous local
+    let _3: Option<&'8 str>[{built_in impl Sized for &'8 str}]; // anonymous local
     let _4: ShouldPanic; // anonymous local
     let _5: TestType; // anonymous local
     let _6: TestFn; // anonymous local
@@ -781,8 +781,8 @@ pub fn test_attributes::tests::test_foo() -> TestDescAndFn
     storage_dead(_5)
     storage_dead(_4)
     storage_dead(_3)
-    conditional_drop[impl_Destruct_for_TestName::drop_glue<'19>] _2
-    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'21>] _1
+    conditional_drop[impl_Destruct_for_TestName::drop_glue<'21>] _2
+    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'23>] _1
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_2)
@@ -795,12 +795,12 @@ pub fn test_attributes::tests::test_foo() -> TestDescAndFn
     _6 = TestFn::StaticTestFn { _0: move _7 }
     storage_dead(_7)
     _0 = TestDescAndFn { desc: move _1, testfn: move _6 }
-    conditional_drop[impl_Destruct_for_TestFn::drop_glue<'20>] _6
-    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'21>] _1
+    conditional_drop[impl_Destruct_for_TestFn::drop_glue<'22>] _6
+    ↳⚡ conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'23>] _1
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_6)
-    conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'22>] _1
+    conditional_drop[impl_Destruct_for_TestDesc::drop_glue<'24>] _1
     ↳⚡ unwind_continue
     storage_dead(_1)
     return
@@ -812,21 +812,21 @@ pub const test_attributes::tests::test_foo: TestDescAndFn = test_attributes::tes
 pub fn main()
 {
     let _0: (); // return
-    let _1: &'12 [&'13 TestDescAndFn]; // anonymous local
-    let _2: &'28 [&'29 TestDescAndFn; 3usize]; // anonymous local
-    let _3: &'33 [&'34 TestDescAndFn; 3usize]; // anonymous local
-    let _4: &'48 [&'49 TestDescAndFn; 3usize]; // anonymous local
-    let _5: &'53 [&'54 TestDescAndFn; 3usize]; // anonymous local
-    let _6: &'75 [&'76 TestDescAndFn; 3usize]; // anonymous local
-    let _7: [&'80 TestDescAndFn; 3usize]; // anonymous local
-    let _8: &'84 TestDescAndFn; // anonymous local
-    let _9: &'85 TestDescAndFn; // anonymous local
+    let _1: &'13 [&'14 TestDescAndFn]; // anonymous local
+    let _2: &'30 [&'31 TestDescAndFn; 3usize]; // anonymous local
+    let _3: &'35 [&'36 TestDescAndFn; 3usize]; // anonymous local
+    let _4: &'50 [&'51 TestDescAndFn; 3usize]; // anonymous local
+    let _5: &'55 [&'56 TestDescAndFn; 3usize]; // anonymous local
+    let _6: &'77 [&'78 TestDescAndFn; 3usize]; // anonymous local
+    let _7: [&'82 TestDescAndFn; 3usize]; // anonymous local
+    let _8: &'86 TestDescAndFn; // anonymous local
+    let _9: &'87 TestDescAndFn; // anonymous local
     let _10: TestDescAndFn; // anonymous local
-    let _11: &'86 TestDescAndFn; // anonymous local
-    let _12: &'87 TestDescAndFn; // anonymous local
+    let _11: &'88 TestDescAndFn; // anonymous local
+    let _12: &'89 TestDescAndFn; // anonymous local
     let _13: TestDescAndFn; // anonymous local
-    let _14: &'88 TestDescAndFn; // anonymous local
-    let _15: &'89 TestDescAndFn; // anonymous local
+    let _14: &'90 TestDescAndFn; // anonymous local
+    let _15: &'91 TestDescAndFn; // anonymous local
     let _16: TestDescAndFn; // anonymous local
 
     storage_live(_5)
@@ -862,9 +862,9 @@ pub fn main()
     _4 = move _5
     _3 = &(*_4)
     _2 = &(*_3)
-    _1 = unsize_cast<&'28 [&'29 TestDescAndFn; 3usize], &'66 [&'67 TestDescAndFn], 3usize>(move _2)
+    _1 = unsize_cast<&'30 [&'31 TestDescAndFn; 3usize], &'68 [&'69 TestDescAndFn], 3usize>(move _2)
     storage_dead(_2)
-    _0 = test_main_static<'73, '74>(move _1)
+    _0 = test_main_static<'75, '76>(move _1)
     ↳⚡ unwind_continue
     storage_dead(_1)
     storage_dead(_3)

--- a/charon/tests/ui/arrays.out
+++ b/charon/tests/ui/arrays.out
@@ -2872,16 +2872,16 @@ where
     TypeOutlives0: T: '_0,
 {
     let _0: (); // return
-    let x: [&'6 mut T; 3usize]; // arg #1
-    let _a: &'10 mut T; // local
-    let _b: &'11 mut T; // local
-    let _c: &'12 mut T; // local
-    let _5: &'_ mut [&'6 mut T; 3usize]; // anonymous local
-    let _6: &'_ mut &'6 mut T; // anonymous local
-    let _7: &'_ mut [&'6 mut T; 3usize]; // anonymous local
-    let _8: &'_ mut &'6 mut T; // anonymous local
-    let _9: &'_ mut [&'6 mut T; 3usize]; // anonymous local
-    let _10: &'_ mut &'6 mut T; // anonymous local
+    let x: [&'8 mut T; 3usize]; // arg #1
+    let _a: &'12 mut T; // local
+    let _b: &'13 mut T; // local
+    let _c: &'14 mut T; // local
+    let _5: &'_ mut [&'8 mut T; 3usize]; // anonymous local
+    let _6: &'_ mut &'8 mut T; // anonymous local
+    let _7: &'_ mut [&'8 mut T; 3usize]; // anonymous local
+    let _8: &'_ mut &'8 mut T; // anonymous local
+    let _9: &'_ mut [&'8 mut T; 3usize]; // anonymous local
+    let _10: &'_ mut &'8 mut T; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -2889,21 +2889,21 @@ where
     storage_live(_5)
     _5 = &mut x
     storage_live(_6)
-    _6 = impl_IndexMut_for_array::index_mut<'_, &'6 mut T, usize, &'6 mut T, 3usize>[{built_in impl Sized for &'6 mut T}, {built_in impl Sized for usize}, impl_IndexMut_for_slice<&'6 mut T, usize, &'6 mut T>[{built_in impl Sized for &'6 mut T}, {built_in impl Sized for usize}, impl_SliceIndex_slice_for_usize<&'6 mut T>[{built_in impl Sized for &'6 mut T}]]](move _5, const 0usize)
+    _6 = impl_IndexMut_for_array::index_mut<'_, &'8 mut T, usize, &'8 mut T, 3usize>[{built_in impl Sized for &'8 mut T}, {built_in impl Sized for usize}, impl_IndexMut_for_slice<&'8 mut T, usize, &'8 mut T>[{built_in impl Sized for &'8 mut T}, {built_in impl Sized for usize}, impl_SliceIndex_slice_for_usize<&'8 mut T>[{built_in impl Sized for &'8 mut T}]]](move _5, const 0usize)
     ↳⚡ undefined_behavior
     _a = move (*_6)
     storage_live(_b)
     storage_live(_7)
     _7 = &mut x
     storage_live(_8)
-    _8 = impl_IndexMut_for_array::index_mut<'_, &'6 mut T, usize, &'6 mut T, 3usize>[{built_in impl Sized for &'6 mut T}, {built_in impl Sized for usize}, impl_IndexMut_for_slice<&'6 mut T, usize, &'6 mut T>[{built_in impl Sized for &'6 mut T}, {built_in impl Sized for usize}, impl_SliceIndex_slice_for_usize<&'6 mut T>[{built_in impl Sized for &'6 mut T}]]](move _7, const 1usize)
+    _8 = impl_IndexMut_for_array::index_mut<'_, &'8 mut T, usize, &'8 mut T, 3usize>[{built_in impl Sized for &'8 mut T}, {built_in impl Sized for usize}, impl_IndexMut_for_slice<&'8 mut T, usize, &'8 mut T>[{built_in impl Sized for &'8 mut T}, {built_in impl Sized for usize}, impl_SliceIndex_slice_for_usize<&'8 mut T>[{built_in impl Sized for &'8 mut T}]]](move _7, const 1usize)
     ↳⚡ undefined_behavior
     _b = move (*_8)
     storage_live(_c)
     storage_live(_9)
     _9 = &mut x
     storage_live(_10)
-    _10 = impl_IndexMut_for_array::index_mut<'_, &'6 mut T, usize, &'6 mut T, 3usize>[{built_in impl Sized for &'6 mut T}, {built_in impl Sized for usize}, impl_IndexMut_for_slice<&'6 mut T, usize, &'6 mut T>[{built_in impl Sized for &'6 mut T}, {built_in impl Sized for usize}, impl_SliceIndex_slice_for_usize<&'6 mut T>[{built_in impl Sized for &'6 mut T}]]](move _9, const 2usize)
+    _10 = impl_IndexMut_for_array::index_mut<'_, &'8 mut T, usize, &'8 mut T, 3usize>[{built_in impl Sized for &'8 mut T}, {built_in impl Sized for usize}, impl_IndexMut_for_slice<&'8 mut T, usize, &'8 mut T>[{built_in impl Sized for &'8 mut T}, {built_in impl Sized for usize}, impl_SliceIndex_slice_for_usize<&'8 mut T>[{built_in impl Sized for &'8 mut T}]]](move _9, const 2usize)
     ↳⚡ undefined_behavior
     _c = move (*_10)
     _0 = ()

--- a/charon/tests/ui/associated_types/associated-types.out
+++ b/charon/tests/ui/associated_types/associated-types.out
@@ -177,8 +177,8 @@ where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: 'a,
 {
-    let _0: Option<&'6 T>[{built_in impl Sized for &'6 T}]; // return
-    let x: Option<&'10 T>[{built_in impl Sized for &'10 T}]; // arg #1
+    let _0: Option<&'8 T>[{built_in impl Sized for &'8 T}]; // return
+    let x: Option<&'12 T>[{built_in impl Sized for &'12 T}]; // arg #1
 
     storage_live(_0)
     _0 = copy x
@@ -302,15 +302,15 @@ where
 fn call_fn()
 {
     let _0: (); // return
-    let _1: Option<&'7 bool>[{built_in impl Sized for &'7 bool}]; // anonymous local
-    let _2: Option<&'11 bool>[{built_in impl Sized for &'11 bool}]; // anonymous local
+    let _1: Option<&'8 bool>[{built_in impl Sized for &'8 bool}]; // anonymous local
+    let _2: Option<&'12 bool>[{built_in impl Sized for &'12 bool}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
     storage_live(_1)
     storage_live(_2)
     _2 = Option::None {  }
-    _1 = external_use_item<'23, &'23 bool, Option<&'23 bool>[{built_in impl Sized for &'23 bool}], &'23 bool>[{built_in impl Sized for &'23 bool}, {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T}<'23, bool>[{built_in impl Sized for bool}], impl_Foo_for_Option<'23, &'23 bool>[{built_in impl Sized for &'23 bool}, {impl Copy for &'_0 T}<'23, bool>]](move _2)
+    _1 = external_use_item<'25, &'25 bool, Option<&'25 bool>[{built_in impl Sized for &'25 bool}], &'25 bool>[{built_in impl Sized for &'25 bool}, {impl test_crate::Foo<'a, Option<&'a T>[{built_in impl Sized for &'a T}]> for &'a T}<'25, bool>[{built_in impl Sized for bool}], impl_Foo_for_Option<'25, &'25 bool>[{built_in impl Sized for &'25 bool}, {impl Copy for &'_0 T}<'25, bool>]](move _2)
     ↳⚡ unwind_continue
     storage_dead(_2)
     storage_dead(_1)

--- a/charon/tests/ui/associated_types/mem-discriminant-from-derive.out
+++ b/charon/tests/ui/associated_types/mem-discriminant-from-derive.out
@@ -91,13 +91,13 @@ pub fn impl_PartialEq_Enum_for_Enum::eq<'_0, '_1>(self: &'_0 Enum, other: &'_1 E
     let _7: bool; // anonymous local
     let _8: isize; // anonymous local
     let _9: isize; // anonymous local
-    let _10: (&'12 Enum, &'13 Enum); // anonymous local
-    let _11: &'17 Enum; // anonymous local
-    let _12: &'18 Enum; // anonymous local
-    let __self_0: &'20 u8; // local
-    let __arg1_0: &'21 u8; // local
-    let _15: &'24 &'25 u8; // anonymous local
-    let _16: &'26 &'27 u8; // anonymous local
+    let _10: (&'13 Enum, &'14 Enum); // anonymous local
+    let _11: &'18 Enum; // anonymous local
+    let _12: &'19 Enum; // anonymous local
+    let __self_0: &'21 u8; // local
+    let __arg1_0: &'22 u8; // local
+    let _15: &'25 &'26 u8; // anonymous local
+    let _16: &'27 &'28 u8; // anonymous local
 
     storage_live(_0)
     storage_live(__self_discr)
@@ -152,7 +152,7 @@ pub fn impl_PartialEq_Enum_for_Enum::eq<'_0, '_1>(self: &'_0 Enum, other: &'_1 E
                     _15 = &__self_0
                     storage_live(_16)
                     _16 = &__arg1_0
-                    _0 = {impl PartialEq<&'_0 B> for &'_1 A}::eq<'41, '42, '45, '46, u8, u8>[impl_PartialEq_u8_for_u8](move _15, move _16)
+                    _0 = {impl PartialEq<&'_0 B> for &'_1 A}::eq<'42, '43, '46, '47, u8, u8>[impl_PartialEq_u8_for_u8](move _15, move _16)
                     ↳⚡ storage_dead(other)
                         storage_dead(self)
                         unwind_continue

--- a/charon/tests/ui/borrowck-statements.out
+++ b/charon/tests/ui/borrowck-statements.out
@@ -507,10 +507,10 @@ where
     storage_live(value_2)
     value_2 = copy value_1
     fake_read(value_2)
-    set_type(typeof(value_2) == &'12 u32)
+    set_type(typeof(value_2) == &'13 u32)
     predicate_holds({built_in impl Sized for &'4 u32})
-    predicate_holds({impl Copy for &'_0 T}<'10, u32>)
-    set_outlives(&'11 u32, 'b)
+    predicate_holds({impl Copy for &'_0 T}<'11, u32>)
+    set_outlives(&'12 u32, 'b)
     _0 = ()
     storage_dead(value_2)
     storage_dead(value_1)

--- a/charon/tests/ui/comments.out
+++ b/charon/tests/ui/comments.out
@@ -518,25 +518,25 @@ fn foo()
     let _13: u32; // anonymous local
     let _14: u32; // anonymous local
     let a: [u32; 10usize]; // local
-    let _16: (&'8 u32, &'9 u32); // anonymous local
-    let _17: &'13 u32; // anonymous local
+    let _16: (&'9 u32, &'10 u32); // anonymous local
+    let _17: &'14 u32; // anonymous local
     let _18: usize; // anonymous local
-    let _19: &'14 u32; // anonymous local
-    let left_val: &'15 u32; // local
-    let right_val: &'16 u32; // local
+    let _19: &'15 u32; // anonymous local
+    let left_val: &'16 u32; // local
+    let right_val: &'17 u32; // local
     let _22: bool; // anonymous local
     let _23: u32; // anonymous local
     let _24: u32; // anonymous local
     let kind: AssertKind; // local
     let _26: AssertKind; // anonymous local
-    let _27: &'17 u32; // anonymous local
-    let _28: &'18 u32; // anonymous local
-    let _29: &'19 u32; // anonymous local
-    let _30: &'20 u32; // anonymous local
-    let _31: Option<Arguments<'28>>[{built_in impl Sized for Arguments<'28>}]; // anonymous local
-    let _32: &'32 u32; // anonymous local
-    let _33: &'33 u32; // anonymous local
-    let _34: &'47 u32; // anonymous local
+    let _27: &'18 u32; // anonymous local
+    let _28: &'19 u32; // anonymous local
+    let _29: &'20 u32; // anonymous local
+    let _30: &'21 u32; // anonymous local
+    let _31: Option<Arguments<'30>>[{built_in impl Sized for Arguments<'30>}]; // anonymous local
+    let _32: &'34 u32; // anonymous local
+    let _33: &'35 u32; // anonymous local
+    let _34: &'50 u32; // anonymous local
     let _35: u32; // anonymous local
     let _36: &'_ [u32; 10usize]; // anonymous local
     let _37: &'_ u32; // anonymous local

--- a/charon/tests/ui/control-flow/issue-297-cfg.out
+++ b/charon/tests/ui/control-flow/issue-297-cfg.out
@@ -212,10 +212,10 @@ fn f2<'_0, '_1>(a: &'_0 [u8], result: &'_1 mut [i16]) -> usize
     let _5: Chunks<'6, u8>[{built_in impl Sized for u8}]; // anonymous local
     let _6: &'7 [u8]; // anonymous local
     let iter: Chunks<'8, u8>[{built_in impl Sized for u8}]; // local
-    let _8: Option<&'15 [u8]>[{built_in impl Sized for &'15 [u8]}]; // anonymous local
-    let _9: &'21 mut Chunks<'22, u8>[{built_in impl Sized for u8}]; // anonymous local
-    let _10: &'23 mut Chunks<'24, u8>[{built_in impl Sized for u8}]; // anonymous local
-    let bytes: &'25 [u8]; // local
+    let _8: Option<&'16 [u8]>[{built_in impl Sized for &'16 [u8]}]; // anonymous local
+    let _9: &'22 mut Chunks<'23, u8>[{built_in impl Sized for u8}]; // anonymous local
+    let _10: &'24 mut Chunks<'25, u8>[{built_in impl Sized for u8}]; // anonymous local
+    let bytes: &'26 [u8]; // local
     let b1: i16; // local
     let _13: u8; // anonymous local
     let _14: usize; // anonymous local
@@ -270,14 +270,14 @@ fn f2<'_0, '_1>(a: &'_0 [u8], result: &'_1 mut [i16]) -> usize
     storage_live(_5)
     storage_live(_6)
     _6 = &(*a) with_metadata(copy a.metadata)
-    _5 = chunks<'27, u8>[{built_in impl Sized for u8}](move _6, const 3usize)
+    _5 = chunks<'28, u8>[{built_in impl Sized for u8}](move _6, const 3usize)
     ↳⚡ storage_dead(_44)
         storage_dead(_37)
         storage_dead(result)
         storage_dead(a)
         unwind_continue
     storage_dead(_6)
-    _4 = into_iter<Chunks<'29, u8>[{built_in impl Sized for u8}]>[{built_in impl Sized for Chunks<'29, u8>[{built_in impl Sized for u8}]}, impl_Iterator_for_Chunks<'29, u8>[{built_in impl Sized for u8}]](move _5)
+    _4 = into_iter<Chunks<'30, u8>[{built_in impl Sized for u8}]>[{built_in impl Sized for Chunks<'30, u8>[{built_in impl Sized for u8}]}, impl_Iterator_for_Chunks<'30, u8>[{built_in impl Sized for u8}]](move _5)
     ↳⚡ storage_dead(_44)
         storage_dead(_37)
         storage_dead(result)
@@ -292,7 +292,7 @@ fn f2<'_0, '_1>(a: &'_0 [u8], result: &'_1 mut [i16]) -> usize
         storage_live(_10)
         _10 = &mut iter
         _9 = &two-phase-mut (*_10)
-        _8 = next<'39, '41, u8>[{built_in impl Sized for u8}](move _9)
+        _8 = next<'41, '43, u8>[{built_in impl Sized for u8}](move _9)
         ↳⚡ storage_dead(_44)
             storage_dead(_37)
             storage_dead(result)

--- a/charon/tests/ui/copy_nonoverlapping.out
+++ b/charon/tests/ui/copy_nonoverlapping.out
@@ -515,8 +515,8 @@ pub fn panic_nounwind_fmt<'_0>(fmt: Arguments<'_0>, force_no_backtrace: bool) ->
     let _0: !; // return
     let fmt: Arguments<'1>; // arg #1
     let force_no_backtrace: bool; // arg #2
-    let _3: (Arguments<'8>, bool); // anonymous local
-    let _4: Arguments<'12>; // anonymous local
+    let _3: (Arguments<'9>, bool); // anonymous local
+    let _4: Arguments<'13>; // anonymous local
     let _5: bool; // anonymous local
 
     storage_live(_0)
@@ -528,7 +528,7 @@ pub fn panic_nounwind_fmt<'_0>(fmt: Arguments<'_0>, force_no_backtrace: bool) ->
     _3 = (move _4, move _5)
     storage_dead(_5)
     storage_dead(_4)
-    _0 = core::panicking::panic_nounwind_fmt::runtime<'18>(move _3._0, move _3._1)
+    _0 = core::panicking::panic_nounwind_fmt::runtime<'19>(move _3._0, move _3._1)
     ↳⚡ storage_dead(_3)
         storage_dead(force_no_backtrace)
         storage_dead(fmt)

--- a/charon/tests/ui/dyn/box-dyn-fnonce-raw.out
+++ b/charon/tests/ui/dyn/box-dyn-fnonce-raw.out
@@ -686,39 +686,39 @@ where
 // Full name: test_crate::box_box
 pub fn box_box(f: Box<(dyn FnOnce<(), Output = ()> + 'static), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + 'static)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]) -> Box<(dyn FnOnce<(), Output = ()> + 'static), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + 'static)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]
 {
-    let _0: Box<(dyn FnOnce<(), Output = ()> + '5), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '7)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // return
-    let f: Box<(dyn FnOnce<(), Output = ()> + '8), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '10)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // arg #1
-    let _2: Box<(dyn FnOnce<(), Output = ()> + '11), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '13)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // anonymous local
-    let _3: Box<Box<(dyn FnOnce<(), Output = ()> + '28), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '30)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '34), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '36)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // anonymous local
-    let _4: Box<(dyn FnOnce<(), Output = ()> + '37), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '39)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // anonymous local
+    let _0: Box<(dyn FnOnce<(), Output = ()> + '6), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '8)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // return
+    let f: Box<(dyn FnOnce<(), Output = ()> + '9), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '11)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // arg #1
+    let _2: Box<(dyn FnOnce<(), Output = ()> + '12), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '14)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // anonymous local
+    let _3: Box<Box<(dyn FnOnce<(), Output = ()> + '36), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '38)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '42), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '44)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // anonymous local
+    let _4: Box<(dyn FnOnce<(), Output = ()> + '45), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '47)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]; // anonymous local
 
     storage_live(_0)
     storage_live(_2)
     storage_live(_3)
     storage_live(_4)
     _4 = move f
-    _3 = new<Box<(dyn FnOnce<(), Output = ()> + '45), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '47)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]>[{built_in impl Sized for Box<(dyn FnOnce<(), Output = ()> + '53), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '55)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}](move _4)
-    ↳⚡ conditional_drop[drop_glue<'79, (dyn FnOnce<(), Output = ()> + '75), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '75)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _4
+    _3 = new<Box<(dyn FnOnce<(), Output = ()> + '54), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '56)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]>[{built_in impl Sized for Box<(dyn FnOnce<(), Output = ()> + '63), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '65)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}](move _4)
+    ↳⚡ conditional_drop[drop_glue<'98, (dyn FnOnce<(), Output = ()> + '93), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '93)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _4
         ↳⚡ unwind_terminate
-        conditional_drop[drop_glue<'167, (dyn FnOnce<(), Output = ()> + '163), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '163)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
+        conditional_drop[drop_glue<'207, (dyn FnOnce<(), Output = ()> + '202), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '202)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
         ↳⚡ unwind_terminate
         unwind_continue
-    _2 = unsize_cast<Box<Box<(dyn FnOnce<(), Output = ()> + '28), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '30)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '34), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '36)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Box<(dyn FnOnce<(), Output = ()> + '80), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '82)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], &impl_FnOnce_for_Box::{vtable}<(), (dyn FnOnce<(), Output = ()> + '106), Global>[{built_in impl Sized for ()}, {built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '108)}, {built_in impl Sized for Global}, {built_in impl Tuple for ()}, FnOnce<(dyn FnOnce<(), Output = ()> + '111), ()>, impl_Allocator_for_Global]>(move _3)
-    conditional_drop[drop_glue<'154, Box<(dyn FnOnce<(), Output = ()> + '140), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '142)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '140), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '142)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _3
-    ↳⚡ conditional_drop[drop_glue<'79, (dyn FnOnce<(), Output = ()> + '75), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '75)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _4
+    _2 = unsize_cast<Box<Box<(dyn FnOnce<(), Output = ()> + '36), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '38)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '42), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '44)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Box<(dyn FnOnce<(), Output = ()> + '99), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '101)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], &impl_FnOnce_for_Box::{vtable}<(), (dyn FnOnce<(), Output = ()> + '128), Global>[{built_in impl Sized for ()}, {built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '130)}, {built_in impl Sized for Global}, {built_in impl Tuple for ()}, FnOnce<(dyn FnOnce<(), Output = ()> + '134), ()>, impl_Allocator_for_Global]>(move _3)
+    conditional_drop[drop_glue<'192, Box<(dyn FnOnce<(), Output = ()> + '171), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '173)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Global>[{built_in impl MetaSized for Box<(dyn FnOnce<(), Output = ()> + '171), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '173)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _3
+    ↳⚡ conditional_drop[drop_glue<'98, (dyn FnOnce<(), Output = ()> + '93), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '93)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _4
         ↳⚡ unwind_terminate
-        conditional_drop[drop_glue<'167, (dyn FnOnce<(), Output = ()> + '163), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '163)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
+        conditional_drop[drop_glue<'207, (dyn FnOnce<(), Output = ()> + '202), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '202)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_4)
     storage_dead(_3)
-    _0 = unsize_cast<Box<(dyn FnOnce<(), Output = ()> + '11), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '13)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Box<(dyn FnOnce<(), Output = ()> + '168), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '170)}, {built_in impl Sized for Global}, impl_Allocator_for_Global],  at []>(move _2)
-    conditional_drop[drop_glue<'183, (dyn FnOnce<(), Output = ()> + '179), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '179)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _2
-    ↳⚡ conditional_drop[drop_glue<'167, (dyn FnOnce<(), Output = ()> + '163), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '163)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
+    _0 = unsize_cast<Box<(dyn FnOnce<(), Output = ()> + '12), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '14)}, {built_in impl Sized for Global}, impl_Allocator_for_Global], Box<(dyn FnOnce<(), Output = ()> + '208), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '210)}, {built_in impl Sized for Global}, impl_Allocator_for_Global],  at []>(move _2)
+    conditional_drop[drop_glue<'225, (dyn FnOnce<(), Output = ()> + '220), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '220)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] _2
+    ↳⚡ conditional_drop[drop_glue<'207, (dyn FnOnce<(), Output = ()> + '202), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '202)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_2)
-    conditional_drop[drop_glue<'196, (dyn FnOnce<(), Output = ()> + '192), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '192)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
+    conditional_drop[drop_glue<'240, (dyn FnOnce<(), Output = ()> + '235), Global>[{built_in impl MetaSized for (dyn FnOnce<(), Output = ()> + '235)}, {built_in impl Sized for Global}, impl_Allocator_for_Global]] f
     ↳⚡ unwind_continue
     return
 }

--- a/charon/tests/ui/dyn/dyn-cast-to-supertrait.out
+++ b/charon/tests/ui/dyn/dyn-cast-to-supertrait.out
@@ -431,7 +431,7 @@ fn main()
     storage_live(_9)
     storage_live(_10)
     _10 = &(*dyn_cat) with_metadata(copy dyn_cat.metadata)
-    _9 = takes_pettable<'47, (dyn Cat + '40)>[{built_in impl MetaSized for (dyn Cat + '42)}, Cat<(dyn Cat + '45)>::ImpliedClause2](move _10)
+    _9 = takes_pettable<'48, (dyn Cat + '40)>[{built_in impl MetaSized for (dyn Cat + '42)}, Cat<(dyn Cat + '46)>::ImpliedClause2](move _10)
     ↳⚡ unwind_continue
     storage_dead(_10)
     storage_dead(_9)

--- a/charon/tests/ui/dyn/dyn-trait.out
+++ b/charon/tests/ui/dyn/dyn-trait.out
@@ -136,7 +136,7 @@ fn destruct<'_0>(x: &'_0 (dyn Display + '_0)) -> String
     storage_live(_0)
     storage_live(_2)
     _2 = &(*x) with_metadata(copy x.metadata)
-    _0 = to_string<'16, (dyn Display + '9)>[{built_in impl MetaSized for (dyn Display + '11)}, Display<(dyn Display + '14)>](move _2)
+    _0 = to_string<'17, (dyn Display + '9)>[{built_in impl MetaSized for (dyn Display + '11)}, Display<(dyn Display + '15)>](move _2)
     ↳⚡ storage_dead(x)
         unwind_continue
     storage_dead(_2)

--- a/charon/tests/ui/dyn/vtables.out
+++ b/charon/tests/ui/dyn/vtables.out
@@ -1285,100 +1285,100 @@ fn main()
     let _15: String; // anonymous local
     let _16: &'23 str; // anonymous local
     let _17: &'24 str; // anonymous local
-    let _18: (&'32 i32, &'33 i32); // anonymous local
-    let _19: &'37 i32; // anonymous local
+    let _18: (&'33 i32, &'34 i32); // anonymous local
+    let _19: &'38 i32; // anonymous local
     let _20: i32; // anonymous local
-    let _21: &'38 mut (dyn Modifiable<i32> + '39); // anonymous local
-    let _22: &'40 i32; // anonymous local
-    let _23: &'41 mut i32; // anonymous local
+    let _21: &'39 mut (dyn Modifiable<i32> + '40); // anonymous local
+    let _22: &'41 i32; // anonymous local
+    let _23: &'42 mut i32; // anonymous local
     let _24: i32; // anonymous local
-    let _25: &'42 i32; // anonymous local
-    let left_val_26: &'43 i32; // local
-    let right_val_27: &'44 i32; // local
+    let _25: &'43 i32; // anonymous local
+    let left_val_26: &'44 i32; // local
+    let right_val_27: &'45 i32; // local
     let _28: bool; // anonymous local
     let _29: i32; // anonymous local
     let _30: i32; // anonymous local
     let kind_31: AssertKind; // local
     let _32: AssertKind; // anonymous local
-    let _33: &'45 i32; // anonymous local
-    let _34: &'46 i32; // anonymous local
-    let _35: &'47 i32; // anonymous local
-    let _36: &'48 i32; // anonymous local
-    let _37: Option<Arguments<'56>>[{built_in impl Sized for Arguments<'56>}]; // anonymous local
-    let z: &'63 (dyn NoParam + '64); // local
-    let _39: &'65 (dyn NoParam + '66); // anonymous local
-    let _40: &'67 (dyn NoParam + '68); // anonymous local
-    let _41: &'69 i32; // anonymous local
-    let _42: &'70 i32; // anonymous local
+    let _33: &'46 i32; // anonymous local
+    let _34: &'47 i32; // anonymous local
+    let _35: &'48 i32; // anonymous local
+    let _36: &'49 i32; // anonymous local
+    let _37: Option<Arguments<'58>>[{built_in impl Sized for Arguments<'58>}]; // anonymous local
+    let z: &'65 (dyn NoParam + '66); // local
+    let _39: &'67 (dyn NoParam + '68); // anonymous local
+    let _40: &'69 (dyn NoParam + '70); // anonymous local
+    let _41: &'71 i32; // anonymous local
+    let _42: &'72 i32; // anonymous local
     let _43: (); // anonymous local
-    let _44: &'71 (dyn NoParam + '72); // anonymous local
-    let a: &'76 (dyn Both32And64 + '77); // local
-    let _46: &'78 i32; // anonymous local
-    let _47: &'79 i32; // anonymous local
+    let _44: &'73 (dyn NoParam + '74); // anonymous local
+    let a: &'78 (dyn Both32And64 + '79); // local
+    let _46: &'80 i32; // anonymous local
+    let _47: &'81 i32; // anonymous local
     let _48: (); // anonymous local
-    let _49: &'80 (dyn Both32And64 + '81); // anonymous local
-    let _50: &'82 i32; // anonymous local
-    let _51: &'83 i32; // anonymous local
-    let _52: &'85 i64; // anonymous local
-    let _53: &'86 i64; // anonymous local
-    let b: &'90 (dyn LifetimeTrait<Ty = i32> + '91); // local
-    let _55: &'92 i32; // anonymous local
-    let _56: &'93 i32; // anonymous local
-    let _57: (&'94 i32, &'95 i32); // anonymous local
-    let _58: &'99 i32; // anonymous local
-    let _59: &'100 i32; // anonymous local
-    let _60: &'101 (dyn LifetimeTrait<Ty = i32> + '102); // anonymous local
-    let _61: &'103 (dyn LifetimeTrait<Ty = i32> + '104); // anonymous local
-    let _62: &'105 i32; // anonymous local
-    let _63: &'106 i32; // anonymous local
-    let _64: &'107 i32; // anonymous local
-    let left_val_65: &'108 i32; // local
-    let right_val_66: &'109 i32; // local
+    let _49: &'82 (dyn Both32And64 + '83); // anonymous local
+    let _50: &'84 i32; // anonymous local
+    let _51: &'85 i32; // anonymous local
+    let _52: &'87 i64; // anonymous local
+    let _53: &'88 i64; // anonymous local
+    let b: &'92 (dyn LifetimeTrait<Ty = i32> + '93); // local
+    let _55: &'94 i32; // anonymous local
+    let _56: &'95 i32; // anonymous local
+    let _57: (&'96 i32, &'97 i32); // anonymous local
+    let _58: &'101 i32; // anonymous local
+    let _59: &'102 i32; // anonymous local
+    let _60: &'103 (dyn LifetimeTrait<Ty = i32> + '104); // anonymous local
+    let _61: &'105 (dyn LifetimeTrait<Ty = i32> + '106); // anonymous local
+    let _62: &'107 i32; // anonymous local
+    let _63: &'108 i32; // anonymous local
+    let _64: &'109 i32; // anonymous local
+    let left_val_65: &'110 i32; // local
+    let right_val_66: &'111 i32; // local
     let _67: bool; // anonymous local
     let _68: i32; // anonymous local
     let _69: i32; // anonymous local
     let kind_70: AssertKind; // local
     let _71: AssertKind; // anonymous local
-    let _72: &'110 i32; // anonymous local
-    let _73: &'111 i32; // anonymous local
-    let _74: &'112 i32; // anonymous local
-    let _75: &'113 i32; // anonymous local
-    let _76: Option<Arguments<'114>>[{built_in impl Sized for Arguments<'114>}]; // anonymous local
-    let _77: &'118 i32; // anonymous local
-    let _78: &'119 i32; // anonymous local
-    let _79: &'120 i32; // anonymous local
-    let _80: &'121 i64; // anonymous local
-    let _81: &'122 i32; // anonymous local
-    let _82: &'123 i32; // anonymous local
-    let _83: &'124 i32; // anonymous local
-    let _84: &'125 i32; // anonymous local
-    let _85: &'126 i32; // anonymous local
-    let _86: &'127 i32; // anonymous local
-    let _87: &'158 i32; // anonymous local
-    let _88: &'166 i32; // anonymous local
-    let _89: &'184 i32; // anonymous local
-    let _90: &'190 i32; // anonymous local
-    let _91: &'191 i64; // anonymous local
-    let _92: &'197 i32; // anonymous local
-    let _93: &'205 i32; // anonymous local
-    let _94: &'210 i32; // anonymous local
-    let _95: &'224 i32; // anonymous local
+    let _72: &'112 i32; // anonymous local
+    let _73: &'113 i32; // anonymous local
+    let _74: &'114 i32; // anonymous local
+    let _75: &'115 i32; // anonymous local
+    let _76: Option<Arguments<'116>>[{built_in impl Sized for Arguments<'116>}]; // anonymous local
+    let _77: &'120 i32; // anonymous local
+    let _78: &'121 i32; // anonymous local
+    let _79: &'122 i32; // anonymous local
+    let _80: &'123 i64; // anonymous local
+    let _81: &'124 i32; // anonymous local
+    let _82: &'125 i32; // anonymous local
+    let _83: &'126 i32; // anonymous local
+    let _84: &'127 i32; // anonymous local
+    let _85: &'128 i32; // anonymous local
+    let _86: &'129 i32; // anonymous local
+    let _87: &'160 i32; // anonymous local
+    let _88: &'168 i32; // anonymous local
+    let _89: &'187 i32; // anonymous local
+    let _90: &'193 i32; // anonymous local
+    let _91: &'194 i64; // anonymous local
+    let _92: &'200 i32; // anonymous local
+    let _93: &'208 i32; // anonymous local
+    let _94: &'213 i32; // anonymous local
+    let _95: &'228 i32; // anonymous local
     let _96: i32; // anonymous local
-    let _97: &'225 i32; // anonymous local
+    let _97: &'229 i32; // anonymous local
     let _98: i32; // anonymous local
-    let _99: &'226 i32; // anonymous local
+    let _99: &'230 i32; // anonymous local
     let _100: i32; // anonymous local
-    let _101: &'227 i32; // anonymous local
+    let _101: &'231 i32; // anonymous local
     let _102: i32; // anonymous local
-    let _103: &'228 i32; // anonymous local
+    let _103: &'232 i32; // anonymous local
     let _104: i32; // anonymous local
-    let _105: &'229 i64; // anonymous local
+    let _105: &'233 i64; // anonymous local
     let _106: i64; // anonymous local
-    let _107: &'230 i32; // anonymous local
+    let _107: &'234 i32; // anonymous local
     let _108: i32; // anonymous local
-    let _109: &'231 i32; // anonymous local
+    let _109: &'235 i32; // anonymous local
     let _110: i32; // anonymous local
-    let _111: &'232 i32; // anonymous local
+    let _111: &'236 i32; // anonymous local
     let _112: i32; // anonymous local
 
     storage_live(_86)
@@ -1404,10 +1404,10 @@ fn main()
     _85 = move _86
     _3 = &(*_85)
     _2 = &(*_3)
-    x = unsize_cast<&'6 i32, &'128 (dyn Checkable<i32> + '129), &impl_Checkable_i32_for_i32::{vtable}>(move _2)
+    x = unsize_cast<&'6 i32, &'130 (dyn Checkable<i32> + '131), &impl_Checkable_i32_for_i32::{vtable}>(move _2)
     storage_dead(_2)
     fake_read(x)
-    set_type(typeof(x) == &'130 (dyn Checkable<i32> + '131))
+    set_type(typeof(x) == &'132 (dyn Checkable<i32> + '133))
     storage_dead(_3)
     storage_live(_4)
     storage_live(_5)
@@ -1448,10 +1448,10 @@ fn main()
     _9 = const 99i32
     _8 = &mut _9
     _7 = &mut (*_8)
-    y = unsize_cast<&'16 mut i32, &'136 mut (dyn Modifiable<i32> + '137), &impl_Modifiable_for_i32::{vtable}<i32>[{built_in impl Sized for i32}, impl_Clone_for_i32]>(move _7)
+    y = unsize_cast<&'16 mut i32, &'138 mut (dyn Modifiable<i32> + '139), &impl_Modifiable_for_i32::{vtable}<i32>[{built_in impl Sized for i32}, impl_Clone_for_i32]>(move _7)
     storage_dead(_7)
     fake_read(y)
-    set_type(typeof(y) == &'138 mut (dyn Modifiable<i32> + '139))
+    set_type(typeof(y) == &'140 mut (dyn Modifiable<i32> + '141))
     storage_dead(_8)
     storage_live(_10)
     storage_live(_11)
@@ -1463,7 +1463,7 @@ fn main()
     storage_live(_17)
     _17 = const "Hello"
     _16 = &(*_17) with_metadata(copy _17.metadata)
-    _15 = to_string<'142, str>[{built_in impl MetaSized for str}, {impl#16}](move _16)
+    _15 = to_string<'144, str>[{built_in impl MetaSized for str}, {impl#16}](move _16)
     ↳⚡ storage_dead(_85)
         storage_dead(_84)
         storage_dead(_83)
@@ -1491,8 +1491,8 @@ fn main()
     storage_dead(_16)
     _14 = &_15
     _13 = &(*_14)
-    _12 = modify_trait_object<'144, String>[{built_in impl Sized for String}, impl_Clone_for_String](move _13)
-    ↳⚡ conditional_drop[drop_glue<'145>] _15
+    _12 = modify_trait_object<'146, String>[{built_in impl Sized for String}, impl_Clone_for_String](move _13)
+    ↳⚡ conditional_drop[drop_glue<'147>] _15
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -1570,8 +1570,8 @@ fn main()
         unwind_continue
     _11 = &_12
     storage_dead(_13)
-    _10 = is_empty<'147>(move _11)
-    ↳⚡ conditional_drop[drop_glue<'148>] _12
+    _10 = is_empty<'149>(move _11)
+    ↳⚡ conditional_drop[drop_glue<'150>] _12
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -1623,7 +1623,7 @@ fn main()
             storage_dead(_87)
             storage_dead(_86)
             unwind_terminate
-        conditional_drop[drop_glue<'145>] _15
+        conditional_drop[drop_glue<'147>] _15
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -1702,8 +1702,8 @@ fn main()
     if move _10 {
     } else {
         storage_dead(_11)
-        conditional_drop[drop_glue<'150>] _12
-        ↳⚡ conditional_drop[drop_glue<'145>] _15
+        conditional_drop[drop_glue<'152>] _12
+        ↳⚡ conditional_drop[drop_glue<'147>] _15
             ↳⚡ storage_dead(_85)
                 storage_dead(_84)
                 storage_dead(_83)
@@ -1779,7 +1779,7 @@ fn main()
             storage_dead(_32)
             storage_dead(kind_31)
             unwind_continue
-        conditional_drop[drop_glue<'152>] _15
+        conditional_drop[drop_glue<'154>] _15
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -1964,7 +1964,7 @@ fn main()
         _83 = move _88
         _42 = &(*_83)
         _41 = &(*_42)
-        _40 = to_dyn_obj<'168, i32>[{built_in impl Sized for i32}, impl_NoParam_for_i32](move _41)
+        _40 = to_dyn_obj<'170, i32>[{built_in impl Sized for i32}, impl_NoParam_for_i32](move _41)
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -1990,11 +1990,11 @@ fn main()
             storage_dead(kind_31)
             unwind_continue
         _39 = &(*_40) with_metadata(copy _40.metadata)
-        z = unsize_cast<&'65 (dyn NoParam + '66), &'176 (dyn NoParam + '177),  at []>(move _39)
+        z = unsize_cast<&'67 (dyn NoParam + '68), &'179 (dyn NoParam + '180),  at []>(move _39)
         storage_dead(_41)
         storage_dead(_39)
         fake_read(z)
-        set_type(typeof(z) == &'178 (dyn NoParam + '179))
+        set_type(typeof(z) == &'181 (dyn NoParam + '182))
         storage_dead(_42)
         storage_dead(_40)
         storage_live(_43)
@@ -2051,10 +2051,10 @@ fn main()
         _82 = move _89
         _47 = &(*_82)
         _46 = &(*_47)
-        a = unsize_cast<&'78 i32, &'185 (dyn Both32And64 + '186), &impl_Both32And64_for_i32::{vtable}>(move _46)
+        a = unsize_cast<&'80 i32, &'188 (dyn Both32And64 + '189), &impl_Both32And64_for_i32::{vtable}>(move _46)
         storage_dead(_46)
         fake_read(a)
-        set_type(typeof(a) == &'187 (dyn Both32And64 + '188))
+        set_type(typeof(a) == &'190 (dyn Both32And64 + '191))
         storage_dead(_47)
         storage_live(_48)
         storage_live(_49)
@@ -2118,10 +2118,10 @@ fn main()
         _79 = move _92
         _56 = &(*_79)
         _55 = &(*_56)
-        b = unsize_cast<&'92 i32, &'198 (dyn LifetimeTrait<Ty = i32> + '199), &impl_LifetimeTrait_for_i32::{vtable}>(move _55)
+        b = unsize_cast<&'94 i32, &'201 (dyn LifetimeTrait<Ty = i32> + '202), &impl_LifetimeTrait_for_i32::{vtable}>(move _55)
         storage_dead(_55)
         fake_read(b)
-        set_type(typeof(b) == &'200 (dyn LifetimeTrait<Ty = i32> + '201))
+        set_type(typeof(b) == &'203 (dyn LifetimeTrait<Ty = i32> + '204))
         storage_dead(_56)
         storage_live(_57)
         storage_live(_58)
@@ -2129,14 +2129,14 @@ fn main()
         storage_live(_60)
         storage_live(_61)
         _61 = &(*b) with_metadata(copy b.metadata)
-        _60 = unsize_cast<&'103 (dyn LifetimeTrait<Ty = i32> + '104), &'203 (dyn LifetimeTrait<Ty = i32> + '204),  at []>(move _61)
+        _60 = unsize_cast<&'105 (dyn LifetimeTrait<Ty = i32> + '106), &'206 (dyn LifetimeTrait<Ty = i32> + '207),  at []>(move _61)
         storage_dead(_61)
         storage_live(_62)
         storage_live(_63)
         _78 = move _93
         _63 = &(*_78)
         _62 = &(*_63)
-        _59 = use_lifetime_trait<'208, '209>(move _60, move _62)
+        _59 = use_lifetime_trait<'211, '212>(move _60, move _62)
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -2325,8 +2325,8 @@ fn main()
         return
     }
     storage_dead(_11)
-    conditional_drop[drop_glue<'149>] _12
-    ↳⚡ conditional_drop[drop_glue<'145>] _15
+    conditional_drop[drop_glue<'151>] _12
+    ↳⚡ conditional_drop[drop_glue<'147>] _15
         ↳⚡ storage_dead(_85)
             storage_dead(_84)
             storage_dead(_83)
@@ -2402,7 +2402,7 @@ fn main()
         storage_dead(_32)
         storage_dead(kind_31)
         unwind_continue
-    conditional_drop[drop_glue<'151>] _15
+    conditional_drop[drop_glue<'153>] _15
     ↳⚡ storage_dead(_85)
         storage_dead(_84)
         storage_dead(_83)

--- a/charon/tests/ui/gosim-demo.out
+++ b/charon/tests/ui/gosim-demo.out
@@ -86,30 +86,30 @@ where
     let _2: Iter<'3, T>[TraitClause0]; // anonymous local
     let _3: &'4 [T]; // anonymous local
     let iter: Iter<'5, T>[TraitClause0]; // local
-    let _5: Option<&'13 T>[{built_in impl Sized for &'13 T}]; // anonymous local
-    let _6: &'19 mut Iter<'20, T>[TraitClause0]; // anonymous local
-    let _7: &'21 mut Iter<'22, T>[TraitClause0]; // anonymous local
-    let x: &'23 T; // local
+    let _5: Option<&'14 T>[{built_in impl Sized for &'14 T}]; // anonymous local
+    let _6: &'20 mut Iter<'21, T>[TraitClause0]; // anonymous local
+    let _7: &'22 mut Iter<'23, T>[TraitClause0]; // anonymous local
+    let x: &'24 T; // local
     let _9: (); // anonymous local
-    let _10: Arguments<'25>; // anonymous local
-    let args_11: (&'30 &'31 T,); // local
-    let _12: &'32 &'33 T; // anonymous local
-    let args_13: [Argument<'41>; 1usize]; // local
-    let _14: Argument<'45>; // anonymous local
-    let _15: &'46 &'47 T; // anonymous local
-    let _16: &'49 [u8; 7usize]; // anonymous local
-    let _17: &'50 [u8; 7usize]; // anonymous local
-    let _18: &'56 [Argument<'57>; 1usize]; // anonymous local
-    let _19: &'61 [Argument<'62>; 1usize]; // anonymous local
+    let _10: Arguments<'26>; // anonymous local
+    let args_11: (&'31 &'32 T,); // local
+    let _12: &'33 &'34 T; // anonymous local
+    let args_13: [Argument<'43>; 1usize]; // local
+    let _14: Argument<'47>; // anonymous local
+    let _15: &'48 &'49 T; // anonymous local
+    let _16: &'51 [u8; 7usize]; // anonymous local
+    let _17: &'52 [u8; 7usize]; // anonymous local
+    let _18: &'58 [Argument<'59>; 1usize]; // anonymous local
+    let _19: &'63 [Argument<'64>; 1usize]; // anonymous local
     let _20: [u8; 7usize]; // anonymous local
-    let _21: &'95 [u8; 7usize]; // anonymous local
+    let _21: &'98 [u8; 7usize]; // anonymous local
 
     storage_live(_0)
     _0 = ()
     storage_live(_2)
     storage_live(_3)
     _3 = copy slice
-    _2 = into_iter<'66, T>[TraitClause0](move _3)
+    _2 = into_iter<'68, T>[TraitClause0](move _3)
     ↳⚡ storage_dead(slice)
         unwind_continue
     storage_dead(_3)
@@ -121,7 +121,7 @@ where
         storage_live(_7)
         _7 = &mut iter
         _6 = &two-phase-mut (*_7)
-        _5 = next<'68, '70, T>[TraitClause0](move _6)
+        _5 = next<'70, '72, T>[TraitClause0](move _6)
         ↳⚡ storage_dead(slice)
             unwind_continue
         storage_dead(_6)
@@ -146,7 +146,7 @@ where
         storage_live(_14)
         storage_live(_15)
         _15 = &(*args_11._0)
-        _14 = new_debug<'81, '93, &'83 T>[{built_in impl Sized for &'85 T}, {impl#8}<'91, T>[TraitClause1]](move _15)
+        _14 = new_debug<'83, '96, &'85 T>[{built_in impl Sized for &'87 T}, {impl#8}<'94, T>[TraitClause1]](move _15)
         ↳⚡ storage_dead(slice)
             unwind_continue
         storage_dead(_15)
@@ -165,14 +165,14 @@ where
         storage_live(_19)
         _19 = &args_13
         _18 = &(*_19)
-        _10 = new<'100, 7usize, 1usize>(move _16, move _18)
+        _10 = new<'103, 7usize, 1usize>(move _16, move _18)
         ↳⚡ storage_dead(slice)
             unwind_continue
         storage_dead(_19)
         storage_dead(_18)
         storage_dead(_17)
         storage_dead(_16)
-        _9 = _eprint<'102>(move _10)
+        _9 = _eprint<'105>(move _10)
         ↳⚡ storage_dead(slice)
             unwind_continue
         storage_dead(_10)

--- a/charon/tests/ui/impl-trait.out
+++ b/charon/tests/ui/impl-trait.out
@@ -314,11 +314,11 @@ where
     TraitClause0: (U: Sized),
     TypeOutlives0: U: '_0,
 {
-    let _0: WrapClone<&'9 U>[{built_in impl Sized for &'9 U}, {impl Clone for &'_0 T}<'9, U>]; // return
+    let _0: WrapClone<&'11 U>[{built_in impl Sized for &'11 U}, {impl Clone for &'_0 T}<'11, U>]; // return
     let _1: {closure}<U>[TraitClause0]; // arg #1
     let tupled_args: (&'_0 U,); // arg #2
-    let x: &'15 U; // local
-    let _4: &'16 U; // anonymous local
+    let x: &'17 U; // local
+    let _4: &'18 U; // anonymous local
 
     storage_live(_0)
     storage_live(x)
@@ -377,14 +377,14 @@ pub fn use_wrap()
 {
     let _0: (); // return
     let f: {closure}<u32>[{built_in impl Sized for u32}]; // local
-    let _2: WrapClone<&'10 u32>[{built_in impl Sized for &'10 u32}, {impl Clone for &'_0 T}<'10, u32>]; // anonymous local
+    let _2: WrapClone<&'11 u32>[{built_in impl Sized for &'11 u32}, {impl Clone for &'_0 T}<'11, u32>]; // anonymous local
     let _3: {closure}<u32>[{built_in impl Sized for u32}]; // anonymous local
-    let _4: (&'17 u32,); // anonymous local
-    let _5: &'18 u32; // anonymous local
-    let _6: &'19 u32; // anonymous local
-    let _7: &'20 u32; // anonymous local
-    let _8: &'21 u32; // anonymous local
-    let _9: &'36 u32; // anonymous local
+    let _4: (&'18 u32,); // anonymous local
+    let _5: &'19 u32; // anonymous local
+    let _6: &'20 u32; // anonymous local
+    let _7: &'21 u32; // anonymous local
+    let _8: &'22 u32; // anonymous local
+    let _9: &'37 u32; // anonymous local
     let _10: u32; // anonymous local
 
     storage_live(_0)
@@ -411,14 +411,14 @@ pub fn use_wrap()
     _6 = &(*_7)
     _5 = &(*_6)
     _4 = (move _5,)
-    _2 = call_once<'26, u32>[{built_in impl Sized for u32}](move _3, move _4)
-    ↳⚡ conditional_drop[drop_glue<'27, u32>[{built_in impl Sized for u32}]] _3
+    _2 = call_once<'27, u32>[{built_in impl Sized for u32}](move _3, move _4)
+    ↳⚡ conditional_drop[drop_glue<'28, u32>[{built_in impl Sized for u32}]] _3
         ↳⚡ storage_dead(_7)
             storage_dead(_10)
             storage_dead(_9)
             storage_dead(_8)
             unwind_terminate
-        conditional_drop[drop_glue<'35, u32>[{built_in impl Sized for u32}]] f
+        conditional_drop[drop_glue<'36, u32>[{built_in impl Sized for u32}]] f
         ↳⚡ storage_dead(_7)
             storage_dead(_10)
             storage_dead(_9)
@@ -429,11 +429,11 @@ pub fn use_wrap()
     storage_dead(_5)
     storage_dead(_4)
     storage_dead(_3)
-    set_type(typeof(_2) <= WrapClone<&'28 u32>[{built_in impl Sized for &'28 u32}, {impl Clone for &'_0 T}<'28, u32>])
+    set_type(typeof(_2) <= WrapClone<&'29 u32>[{built_in impl Sized for &'29 u32}, {impl Clone for &'_0 T}<'29, u32>])
     storage_dead(_6)
     storage_dead(_2)
     _0 = ()
-    conditional_drop[drop_glue<'34, u32>[{built_in impl Sized for u32}]] f
+    conditional_drop[drop_glue<'35, u32>[{built_in impl Sized for u32}]] f
     ↳⚡ storage_dead(_7)
         unwind_continue
     storage_dead(f)

--- a/charon/tests/ui/issue-1409-anonymous-method-lifetime.out
+++ b/charon/tests/ui/issue-1409-anonymous-method-lifetime.out
@@ -191,7 +191,7 @@ pub fn test<'a>(x: &'a u64)
     storage_live(_2)
     storage_live(_3)
     _3 = &(*x)
-    _2 = use_fn<'3, from<'5>>[{built_in impl Sized for from<'7>}, {impl FnMut<(&'_0 u64,)> for from<'_0>}<'3>](move _3, const from<'19>)
+    _2 = use_fn<'3, from<'5>>[{built_in impl Sized for from<'7>}, {impl FnMut<(&'_0 u64,)> for from<'_0>}<'3>](move _3, const from<'20>)
     ↳⚡ storage_dead(x)
         unwind_continue
     storage_dead(_3)

--- a/charon/tests/ui/issue-394-rpit-with-lifetime.out
+++ b/charon/tests/ui/issue-394-rpit-with-lifetime.out
@@ -174,13 +174,13 @@ impl<'a> "impl_FnMut_unit_for_closure" FnMut<()> for {closure}<'a> {
 // Full name: test_crate::sparse_transitions
 fn sparse_transitions<'a>() -> FromFn<{closure}<'a>>[{built_in impl Sized for {closure}<'a>}]
 {
-    let _0: FromFn<{closure}<'6>>[{built_in impl Sized for {closure}<'6>}]; // return
-    let _1: {closure}<'10>; // anonymous local
+    let _0: FromFn<{closure}<'8>>[{built_in impl Sized for {closure}<'8>}]; // return
+    let _1: {closure}<'12>; // anonymous local
 
     storage_live(_0)
     storage_live(_1)
     _1 = {closure} {  }
-    _0 = from_fn<u8, {closure}<'13>>[{built_in impl Sized for u8}, {built_in impl Sized for {closure}<'13>}, impl_FnMut_unit_for_closure<'13>](move _1)
+    _0 = from_fn<u8, {closure}<'15>>[{built_in impl Sized for u8}, {built_in impl Sized for {closure}<'15>}, impl_FnMut_unit_for_closure<'15>](move _1)
     ↳⚡ unwind_continue
     storage_dead(_1)
     return

--- a/charon/tests/ui/issue-45-misc.out
+++ b/charon/tests/ui/issue-45-misc.out
@@ -656,25 +656,25 @@ fn select<'_0, '_1>(lhs: &'_0 [u8], rhs: &'_1 [u8])
     let lhs: &'1 [u8]; // arg #1
     let rhs: &'2 [u8]; // arg #2
     let _3: bool; // anonymous local
-    let _4: (&'11 usize, &'12 usize); // anonymous local
-    let _5: &'16 usize; // anonymous local
+    let _4: (&'12 usize, &'13 usize); // anonymous local
+    let _5: &'17 usize; // anonymous local
     let _6: usize; // anonymous local
-    let _7: &'17 [u8]; // anonymous local
-    let _8: &'18 usize; // anonymous local
+    let _7: &'18 [u8]; // anonymous local
+    let _8: &'19 usize; // anonymous local
     let _9: usize; // anonymous local
-    let _10: &'19 [u8]; // anonymous local
-    let left_val: &'20 usize; // local
-    let right_val: &'21 usize; // local
+    let _10: &'20 [u8]; // anonymous local
+    let left_val: &'21 usize; // local
+    let right_val: &'22 usize; // local
     let _13: bool; // anonymous local
     let _14: usize; // anonymous local
     let _15: usize; // anonymous local
     let kind: AssertKind; // local
     let _17: AssertKind; // anonymous local
-    let _18: &'22 usize; // anonymous local
-    let _19: &'23 usize; // anonymous local
-    let _20: &'24 usize; // anonymous local
-    let _21: &'25 usize; // anonymous local
-    let _22: Option<Arguments<'33>>[{built_in impl Sized for Arguments<'33>}]; // anonymous local
+    let _18: &'23 usize; // anonymous local
+    let _19: &'24 usize; // anonymous local
+    let _20: &'25 usize; // anonymous local
+    let _21: &'26 usize; // anonymous local
+    let _22: Option<Arguments<'35>>[{built_in impl Sized for Arguments<'35>}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -686,7 +686,7 @@ fn select<'_0, '_1>(lhs: &'_0 [u8], rhs: &'_1 [u8])
         storage_live(_6)
         storage_live(_7)
         _7 = &(*lhs) with_metadata(copy lhs.metadata)
-        _6 = core::slice::{[T]}::len<'38, u8>[{built_in impl Sized for u8}](move _7)
+        _6 = core::slice::{[T]}::len<'40, u8>[{built_in impl Sized for u8}](move _7)
         ↳⚡ storage_dead(_22)
             storage_dead(_21)
             storage_dead(_20)
@@ -703,7 +703,7 @@ fn select<'_0, '_1>(lhs: &'_0 [u8], rhs: &'_1 [u8])
         storage_live(_9)
         storage_live(_10)
         _10 = &(*rhs) with_metadata(copy rhs.metadata)
-        _9 = core::slice::{[T]}::len<'40, u8>[{built_in impl Sized for u8}](move _10)
+        _9 = core::slice::{[T]}::len<'42, u8>[{built_in impl Sized for u8}](move _10)
         ↳⚡ storage_dead(_22)
             storage_dead(_21)
             storage_dead(_20)

--- a/charon/tests/ui/iterator.out
+++ b/charon/tests/ui/iterator.out
@@ -5481,47 +5481,47 @@ fn main()
     let _15: &'7 [i32]; // anonymous local
     let _16: &'9 [i32; 7usize]; // anonymous local
     let iter_17: Iter<'10, i32>[{built_in impl Sized for i32}]; // local
-    let _18: Option<&'18 i32>[{built_in impl Sized for &'18 i32}]; // anonymous local
-    let _19: &'24 mut Iter<'25, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _20: &'26 mut Iter<'27, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let v_21: &'28 i32; // local
+    let _18: Option<&'19 i32>[{built_in impl Sized for &'19 i32}]; // anonymous local
+    let _19: &'25 mut Iter<'26, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _20: &'27 mut Iter<'28, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let v_21: &'29 i32; // local
     let _22: (); // anonymous local
-    let _23: &'30 mut i32; // anonymous local
-    let _24: &'31 i32; // anonymous local
-    let _25: Chunks<'33, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _26: Chunks<'34, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _27: &'35 [i32]; // anonymous local
-    let _28: &'36 [i32; 7usize]; // anonymous local
-    let iter_29: Chunks<'37, i32>[{built_in impl Sized for i32}]; // local
-    let _30: Option<&'44 [i32]>[{built_in impl Sized for &'44 [i32]}]; // anonymous local
-    let _31: &'50 mut Chunks<'51, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _32: &'52 mut Chunks<'53, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _23: &'31 mut i32; // anonymous local
+    let _24: &'32 i32; // anonymous local
+    let _25: Chunks<'34, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _26: Chunks<'35, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _27: &'36 [i32]; // anonymous local
+    let _28: &'37 [i32; 7usize]; // anonymous local
+    let iter_29: Chunks<'38, i32>[{built_in impl Sized for i32}]; // local
+    let _30: Option<&'46 [i32]>[{built_in impl Sized for &'46 [i32]}]; // anonymous local
+    let _31: &'52 mut Chunks<'53, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _32: &'54 mut Chunks<'55, i32>[{built_in impl Sized for i32}]; // anonymous local
     let _33: i32; // anonymous local
-    let _34: ChunksExact<'55, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _35: ChunksExact<'56, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _36: &'57 [i32]; // anonymous local
-    let _37: &'58 [i32; 7usize]; // anonymous local
-    let iter_38: ChunksExact<'59, i32>[{built_in impl Sized for i32}]; // local
-    let _39: Option<&'60 [i32]>[{built_in impl Sized for &'60 [i32]}]; // anonymous local
-    let _40: &'66 mut ChunksExact<'67, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _41: &'68 mut ChunksExact<'69, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _34: ChunksExact<'57, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _35: ChunksExact<'58, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _36: &'59 [i32]; // anonymous local
+    let _37: &'60 [i32; 7usize]; // anonymous local
+    let iter_38: ChunksExact<'61, i32>[{built_in impl Sized for i32}]; // local
+    let _39: Option<&'62 [i32]>[{built_in impl Sized for &'62 [i32]}]; // anonymous local
+    let _40: &'68 mut ChunksExact<'69, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _41: &'70 mut ChunksExact<'71, i32>[{built_in impl Sized for i32}]; // anonymous local
     let _42: i32; // anonymous local
     let expected: i32; // local
-    let _44: (&'77 i32, &'78 i32); // anonymous local
-    let _45: &'82 i32; // anonymous local
-    let _46: &'83 i32; // anonymous local
-    let left_val: &'84 i32; // local
-    let right_val: &'85 i32; // local
+    let _44: (&'80 i32, &'81 i32); // anonymous local
+    let _45: &'85 i32; // anonymous local
+    let _46: &'86 i32; // anonymous local
+    let left_val: &'87 i32; // local
+    let right_val: &'88 i32; // local
     let _49: bool; // anonymous local
     let _50: i32; // anonymous local
     let _51: i32; // anonymous local
     let kind: AssertKind; // local
     let _53: AssertKind; // anonymous local
-    let _54: &'86 i32; // anonymous local
-    let _55: &'87 i32; // anonymous local
-    let _56: &'88 i32; // anonymous local
-    let _57: &'89 i32; // anonymous local
-    let _58: Option<Arguments<'97>>[{built_in impl Sized for Arguments<'97>}]; // anonymous local
+    let _54: &'89 i32; // anonymous local
+    let _55: &'90 i32; // anonymous local
+    let _56: &'91 i32; // anonymous local
+    let _57: &'92 i32; // anonymous local
+    let _58: Option<Arguments<'101>>[{built_in impl Sized for Arguments<'101>}]; // anonymous local
 
     storage_live(_0)
     storage_live(_12)
@@ -5552,7 +5552,7 @@ fn main()
         unwind_continue
     storage_dead(_5)
     _3 = impl_IntoIterator_for_T::into_iter<IntoIter<i32, 7usize>[{built_in impl Sized for i32}]>[{built_in impl Sized for IntoIter<i32, 7usize>[{built_in impl Sized for i32}]}, impl_Iterator_for_IntoIter<i32, 7usize>[{built_in impl Sized for i32}]](move _4)
-    ↳⚡ conditional_drop[drop_glue<'101, i32, 7usize>[{built_in impl Sized for i32}]] _4
+    ↳⚡ conditional_drop[drop_glue<'105, i32, 7usize>[{built_in impl Sized for i32}]] _4
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5584,8 +5584,8 @@ fn main()
         storage_live(_9)
         _9 = &mut iter_6
         _8 = &two-phase-mut (*_9)
-        _7 = impl_Iterator_for_IntoIter::next<'103, i32, 7usize>[{built_in impl Sized for i32}](move _8)
-        ↳⚡ conditional_drop[drop_glue<'104, i32, 7usize>[{built_in impl Sized for i32}]] iter_6
+        _7 = impl_Iterator_for_IntoIter::next<'107, i32, 7usize>[{built_in impl Sized for i32}](move _8)
+        ↳⚡ conditional_drop[drop_glue<'108, i32, 7usize>[{built_in impl Sized for i32}]] iter_6
             ↳⚡ storage_dead(_58)
                 storage_dead(_57)
                 storage_dead(_56)
@@ -5597,7 +5597,7 @@ fn main()
                 storage_dead(_33)
                 storage_dead(_12)
                 unwind_terminate
-            conditional_drop[drop_glue<'105, i32, 7usize>[{built_in impl Sized for i32}]] _3
+            conditional_drop[drop_glue<'109, i32, 7usize>[{built_in impl Sized for i32}]] _3
             ↳⚡ storage_dead(_58)
                 storage_dead(_57)
                 storage_dead(_56)
@@ -5642,8 +5642,8 @@ fn main()
     }
     storage_dead(_9)
     storage_dead(_7)
-    conditional_drop[drop_glue<'106, i32, 7usize>[{built_in impl Sized for i32}]] iter_6
-    ↳⚡ conditional_drop[drop_glue<'105, i32, 7usize>[{built_in impl Sized for i32}]] _3
+    conditional_drop[drop_glue<'110, i32, 7usize>[{built_in impl Sized for i32}]] iter_6
+    ↳⚡ conditional_drop[drop_glue<'109, i32, 7usize>[{built_in impl Sized for i32}]] _3
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5667,7 +5667,7 @@ fn main()
         storage_dead(_12)
         unwind_continue
     storage_dead(iter_6)
-    conditional_drop[drop_glue<'107, i32, 7usize>[{built_in impl Sized for i32}]] _3
+    conditional_drop[drop_glue<'111, i32, 7usize>[{built_in impl Sized for i32}]] _3
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5688,7 +5688,7 @@ fn main()
     _15 = as_slice<'_, i32, 7usize>[{built_in impl Sized for i32}](move _16)
     ↳⚡ undefined_behavior
     storage_dead(_16)
-    _14 = iter<'110, i32>[{built_in impl Sized for i32}](move _15)
+    _14 = iter<'114, i32>[{built_in impl Sized for i32}](move _15)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5701,7 +5701,7 @@ fn main()
         storage_dead(_12)
         unwind_continue
     storage_dead(_15)
-    _13 = impl_IntoIterator_for_T::into_iter<Iter<'112, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Iter<'112, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_Iter<'112, i32>[{built_in impl Sized for i32}]](move _14)
+    _13 = impl_IntoIterator_for_T::into_iter<Iter<'116, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Iter<'116, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_Iter<'116, i32>[{built_in impl Sized for i32}]](move _14)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5722,7 +5722,7 @@ fn main()
         storage_live(_20)
         _20 = &mut iter_17
         _19 = &two-phase-mut (*_20)
-        _18 = impl_Iterator_for_Iter::next<'122, '124, i32>[{built_in impl Sized for i32}](move _19)
+        _18 = impl_Iterator_for_Iter::next<'127, '129, i32>[{built_in impl Sized for i32}](move _19)
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5749,7 +5749,7 @@ fn main()
         _23 = &two-phase-mut i
         storage_live(_24)
         _24 = copy v_21
-        _22 = add_assign<'130, '132>(move _23, move _24)
+        _22 = add_assign<'135, '137>(move _23, move _24)
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5781,7 +5781,7 @@ fn main()
     _27 = as_slice<'_, i32, 7usize>[{built_in impl Sized for i32}](move _28)
     ↳⚡ undefined_behavior
     storage_dead(_28)
-    _26 = chunks<'135, i32>[{built_in impl Sized for i32}](move _27, const 2usize)
+    _26 = chunks<'140, i32>[{built_in impl Sized for i32}](move _27, const 2usize)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5794,7 +5794,7 @@ fn main()
         storage_dead(_12)
         unwind_continue
     storage_dead(_27)
-    _25 = impl_IntoIterator_for_T::into_iter<Chunks<'137, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Chunks<'137, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_Chunks<'137, i32>[{built_in impl Sized for i32}]](move _26)
+    _25 = impl_IntoIterator_for_T::into_iter<Chunks<'142, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for Chunks<'142, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_Chunks<'142, i32>[{built_in impl Sized for i32}]](move _26)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5815,7 +5815,7 @@ fn main()
         storage_live(_32)
         _32 = &mut iter_29
         _31 = &two-phase-mut (*_32)
-        _30 = impl_Iterator_for_Chunks::next<'147, '149, i32>[{built_in impl Sized for i32}](move _31)
+        _30 = impl_Iterator_for_Chunks::next<'153, '155, i32>[{built_in impl Sized for i32}](move _31)
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)
@@ -5853,7 +5853,7 @@ fn main()
     _36 = as_slice<'_, i32, 7usize>[{built_in impl Sized for i32}](move _37)
     ↳⚡ undefined_behavior
     storage_dead(_37)
-    _35 = chunks_exact<'152, i32>[{built_in impl Sized for i32}](move _36, const 2usize)
+    _35 = chunks_exact<'158, i32>[{built_in impl Sized for i32}](move _36, const 2usize)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5866,7 +5866,7 @@ fn main()
         storage_dead(_12)
         unwind_continue
     storage_dead(_36)
-    _34 = impl_IntoIterator_for_T::into_iter<ChunksExact<'154, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for ChunksExact<'154, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_ChunksExact<'154, i32>[{built_in impl Sized for i32}]](move _35)
+    _34 = impl_IntoIterator_for_T::into_iter<ChunksExact<'160, i32>[{built_in impl Sized for i32}]>[{built_in impl Sized for ChunksExact<'160, i32>[{built_in impl Sized for i32}]}, impl_Iterator_for_ChunksExact<'160, i32>[{built_in impl Sized for i32}]](move _35)
     ↳⚡ storage_dead(_58)
         storage_dead(_57)
         storage_dead(_56)
@@ -5887,7 +5887,7 @@ fn main()
         storage_live(_41)
         _41 = &mut iter_38
         _40 = &two-phase-mut (*_41)
-        _39 = impl_Iterator_for_ChunksExact::next<'164, '166, i32>[{built_in impl Sized for i32}](move _40)
+        _39 = impl_Iterator_for_ChunksExact::next<'171, '173, i32>[{built_in impl Sized for i32}](move _40)
         ↳⚡ storage_dead(_58)
             storage_dead(_57)
             storage_dead(_56)

--- a/charon/tests/ui/ml-name-matcher-tests.out
+++ b/charon/tests/ui/ml-name-matcher-tests.out
@@ -636,7 +636,7 @@ fn mono_usage()
 {
     let _0: (); // return
     let _container1: MonoContainer<i32>[{built_in impl Sized for i32}]; // local
-    let _container2: MonoContainer<&'7 str>[{built_in impl Sized for &'7 str}]; // local
+    let _container2: MonoContainer<&'8 str>[{built_in impl Sized for &'8 str}]; // local
 
     storage_live(_0)
     _0 = ()
@@ -645,7 +645,7 @@ fn mono_usage()
     ↳⚡ unwind_continue
     fake_read(_container1)
     storage_live(_container2)
-    _container2 = create<&'12 str>[{built_in impl Sized for &'12 str}](const "test")
+    _container2 = create<&'13 str>[{built_in impl Sized for &'13 str}](const "test")
     ↳⚡ unwind_continue
     fake_read(_container2)
     _0 = ()

--- a/charon/tests/ui/ml-partial-mono-name-matcher-tests.out
+++ b/charon/tests/ui/ml-partial-mono-name-matcher-tests.out
@@ -126,17 +126,17 @@ where
     let x: A; // arg #1
     let _2: &'1 mut A; // anonymous local
     let _3: &'2 mut A; // anonymous local
-    let _4: Option<&'9 mut A>; // anonymous local
-    let _5: Option<&'13 mut A>; // anonymous local
-    let _6: &'17 mut A; // anonymous local
+    let _4: Option<&'10 mut A>; // anonymous local
+    let _5: Option<&'14 mut A>; // anonymous local
+    let _6: &'18 mut A; // anonymous local
 
     storage_live(_0)
     _0 = ()
     storage_live(_2)
     storage_live(_3)
     _3 = &mut x
-    _2 = test_crate::identity::<&_ mut _><'19, A>[{built_in impl core::marker::Sized::<&_ mut _><'19> for A}](move _3)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'25>] x
+    _2 = test_crate::identity::<&_ mut _><'20, A>[{built_in impl core::marker::Sized::<&_ mut _><'20> for A}](move _3)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'27>] x
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_3)
@@ -147,14 +147,14 @@ where
     _6 = &mut x
     _5 = Option::Some { _0: move _6 }
     storage_dead(_6)
-    _4 = test_crate::identity::<Option<&_ mut _>><'39, A>[{built_in impl core::marker::Sized::<Option<&_ mut _>><'39> for A}](move _5)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'25>] x
+    _4 = test_crate::identity::<Option<&_ mut _>><'43, A>[{built_in impl core::marker::Sized::<Option<&_ mut _>><'43> for A}](move _5)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'27>] x
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_5)
     storage_dead(_4)
     _0 = ()
-    conditional_drop[{built_in impl Destruct for A}::drop_glue<'69>] x
+    conditional_drop[{built_in impl Destruct for A}::drop_glue<'83>] x
     ↳⚡ unwind_continue
     return
 }

--- a/charon/tests/ui/monomorphization/issue-1159-assoc-const.out
+++ b/charon/tests/ui/monomorphization/issue-1159-assoc-const.out
@@ -148,13 +148,13 @@ const ARR: [u64; 1usize] = ARR()
 // Full name: test_crate::{impl MyConfig for Concrete}::SLICE_HOLDER
 pub fn {impl MyConfig for Concrete}::SLICE_HOLDER() -> Option<&'static [u64]>[{built_in impl Sized for &'static [u64]}]
 {
-    let _0: Option<&'6 [u64]>[{built_in impl Sized for &'6 [u64]}]; // return
-    let _1: &'10 [u64]; // anonymous local
-    let _2: &'12 [u64; 1usize]; // anonymous local
-    let _3: &'13 [u64; 1usize]; // anonymous local
-    let _4: &'14 [u64; 1usize]; // anonymous local
-    let _5: &'15 [u64; 1usize]; // anonymous local
-    let _6: &'23 [u64; 1usize]; // anonymous local
+    let _0: Option<&'8 [u64]>[{built_in impl Sized for &'8 [u64]}]; // return
+    let _1: &'12 [u64]; // anonymous local
+    let _2: &'14 [u64; 1usize]; // anonymous local
+    let _3: &'15 [u64; 1usize]; // anonymous local
+    let _4: &'16 [u64; 1usize]; // anonymous local
+    let _5: &'17 [u64; 1usize]; // anonymous local
+    let _6: &'26 [u64; 1usize]; // anonymous local
     let _7: [u64; 1usize]; // anonymous local
 
     storage_live(_5)
@@ -171,7 +171,7 @@ pub fn {impl MyConfig for Concrete}::SLICE_HOLDER() -> Option<&'static [u64]>[{b
     _4 = move _5
     _3 = &(*_4)
     _2 = &(*_3)
-    _1 = unsize_cast<&'12 [u64; 1usize], &'16 [u64], 1usize>(move _2)
+    _1 = unsize_cast<&'14 [u64; 1usize], &'18 [u64], 1usize>(move _2)
     storage_dead(_2)
     _0 = Option::Some { _0: move _1 }
     storage_dead(_1)

--- a/charon/tests/ui/monomorphize-mut-no-types.out
+++ b/charon/tests/ui/monomorphize-mut-no-types.out
@@ -167,17 +167,17 @@ where
     let _4: &'4 mut u32; // anonymous local
     let _5: &'5 mut u32; // anonymous local
     let _6: u32; // anonymous local
-    let _7: Option<&'12 mut u32>; // anonymous local
-    let _8: Option<&'16 mut u32>; // anonymous local
-    let _9: &'20 mut u32; // anonymous local
+    let _7: Option<&'13 mut u32>; // anonymous local
+    let _8: Option<&'17 mut u32>; // anonymous local
+    let _9: &'21 mut u32; // anonymous local
     let _10: u32; // anonymous local
-    let _11: Option<Option<&'58 mut A>>; // anonymous local
-    let _12: Option<Option<&'74 mut A>>; // anonymous local
-    let _13: Option<&'90 mut A>; // anonymous local
-    let _14: &'94 mut A; // anonymous local
-    let _15: &'95 u32; // anonymous local
-    let _16: &'96 u32; // anonymous local
-    let _17: &'367 u32; // anonymous local
+    let _11: Option<Option<&'70 mut A>>; // anonymous local
+    let _12: Option<Option<&'86 mut A>>; // anonymous local
+    let _13: Option<&'102 mut A>; // anonymous local
+    let _14: &'106 mut A; // anonymous local
+    let _15: &'107 u32; // anonymous local
+    let _16: &'108 u32; // anonymous local
+    let _17: &'485 u32; // anonymous local
     let _18: u32; // anonymous local
 
     storage_live(_16)
@@ -193,8 +193,8 @@ where
     storage_live(_3)
     _15 = move _16
     _3 = &(*_15)
-    _2 = identity<&'98 u32>[{built_in impl Sized for &'98 u32}](move _3)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'104>] x
+    _2 = identity<&'110 u32>[{built_in impl Sized for &'110 u32}](move _3)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'117>] x
         ↳⚡ storage_dead(_15)
             storage_dead(x)
             storage_dead(_18)
@@ -211,8 +211,8 @@ where
     storage_live(_6)
     _6 = const 0u32
     _5 = &mut _6
-    _4 = test_crate::identity::<&_ mut _><'106, u32>[{built_in impl core::marker::Sized::<&_ mut _><'106> for u32}](move _5)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'104>] x
+    _4 = test_crate::identity::<&_ mut _><'119, u32>[{built_in impl core::marker::Sized::<&_ mut _><'119> for u32}](move _5)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'117>] x
         ↳⚡ storage_dead(_15)
             storage_dead(x)
             storage_dead(_18)
@@ -233,8 +233,8 @@ where
     _9 = &mut _10
     _8 = Option::Some { _0: move _9 }
     storage_dead(_9)
-    _7 = test_crate::identity::<Option<&_ mut _>><'125, u32>[{built_in impl core::marker::Sized::<Option<&_ mut _>><'125> for u32}](move _8)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'104>] x
+    _7 = test_crate::identity::<Option<&_ mut _>><'141, u32>[{built_in impl core::marker::Sized::<Option<&_ mut _>><'141> for u32}](move _8)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'117>] x
         ↳⚡ storage_dead(_15)
             storage_dead(x)
             storage_dead(_18)
@@ -256,8 +256,8 @@ where
     storage_dead(_14)
     _12 = Option::Some { _0: move _13 }
     storage_dead(_13)
-    _11 = test_crate::identity::<Option<Option<&_ mut _>>><'228, A>[{built_in impl core::marker::Sized::<Option<Option<&_ mut _>>><'228> for A}](move _12)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'104>] x
+    _11 = test_crate::identity::<Option<Option<&_ mut _>>><'276, A>[{built_in impl core::marker::Sized::<Option<Option<&_ mut _>>><'276> for A}](move _12)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'117>] x
         ↳⚡ storage_dead(_15)
             storage_dead(x)
             storage_dead(_18)
@@ -270,7 +270,7 @@ where
     storage_dead(_12)
     storage_dead(_11)
     _0 = ()
-    conditional_drop[{built_in impl Destruct for A}::drop_glue<'366>] x
+    conditional_drop[{built_in impl Destruct for A}::drop_glue<'484>] x
     ↳⚡ storage_dead(_15)
         storage_dead(x)
         unwind_continue

--- a/charon/tests/ui/monomorphize-mut.out
+++ b/charon/tests/ui/monomorphize-mut.out
@@ -339,17 +339,17 @@ where
 {
     let _0: (); // return
     let x: A; // arg #1
-    let _2: core::option::Option::<&_ mut _><'7, u32>[{built_in impl core::marker::Sized::<&_ mut _><'7> for u32}]; // anonymous local
-    let _3: &'11 mut u32; // anonymous local
+    let _2: core::option::Option::<&_ mut _><'8, u32>[{built_in impl core::marker::Sized::<&_ mut _><'8> for u32}]; // anonymous local
+    let _3: &'12 mut u32; // anonymous local
     let _4: u32; // anonymous local
-    let _5: core::option::Option::<&_ mut _><'19, A>[{built_in impl core::marker::Sized::<&_ mut _><'19> for A}]; // anonymous local
-    let _6: &'23 mut A; // anonymous local
-    let _7: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'54, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'54>[{built_in impl core::marker::Sized::<&_ mut _><'54> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'54> for A}]; // anonymous local
-    let _8: core::option::Option::<&_ mut _><'70, A>[{built_in impl core::marker::Sized::<&_ mut _><'70> for A}]; // anonymous local
-    let _9: &'74 mut A; // anonymous local
-    let _10: core::option::Option::<&_ mut &_ mut _><'91, '92, u32>[{built_in impl core::marker::Sized::<&_ mut &_ mut _><'91, '92> for u32}]; // anonymous local
-    let _11: &'99 mut &'100 mut u32; // anonymous local
-    let _12: &'101 mut u32; // anonymous local
+    let _5: core::option::Option::<&_ mut _><'21, A>[{built_in impl core::marker::Sized::<&_ mut _><'21> for A}]; // anonymous local
+    let _6: &'25 mut A; // anonymous local
+    let _7: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'66, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'66>[{built_in impl core::marker::Sized::<&_ mut _><'66> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'66> for A}]; // anonymous local
+    let _8: core::option::Option::<&_ mut _><'82, A>[{built_in impl core::marker::Sized::<&_ mut _><'82> for A}]; // anonymous local
+    let _9: &'86 mut A; // anonymous local
+    let _10: core::option::Option::<&_ mut &_ mut _><'106, '107, u32>[{built_in impl core::marker::Sized::<&_ mut &_ mut _><'106, '107> for u32}]; // anonymous local
+    let _11: &'114 mut &'115 mut u32; // anonymous local
+    let _12: &'116 mut u32; // anonymous local
     let _13: u32; // anonymous local
 
     storage_live(_0)
@@ -391,7 +391,7 @@ where
     storage_dead(_13)
     storage_dead(_12)
     storage_dead(_4)
-    conditional_drop[{built_in impl Destruct for A}::drop_glue<'164>] x
+    conditional_drop[{built_in impl Destruct for A}::drop_glue<'195>] x
     ↳⚡ storage_dead(x)
         unwind_continue
     storage_dead(x)
@@ -560,24 +560,24 @@ where
     let _4: &'4 mut u32; // anonymous local
     let _5: &'5 mut u32; // anonymous local
     let _6: u32; // anonymous local
-    let _7: core::option::Option::<&_ mut _><'12, u32>[{built_in impl core::marker::Sized::<&_ mut _><'12> for u32}]; // anonymous local
-    let _8: core::option::Option::<&_ mut _><'16, u32>[{built_in impl core::marker::Sized::<&_ mut _><'16> for u32}]; // anonymous local
-    let _9: &'20 mut u32; // anonymous local
+    let _7: core::option::Option::<&_ mut _><'13, u32>[{built_in impl core::marker::Sized::<&_ mut _><'13> for u32}]; // anonymous local
+    let _8: core::option::Option::<&_ mut _><'17, u32>[{built_in impl core::marker::Sized::<&_ mut _><'17> for u32}]; // anonymous local
+    let _9: &'21 mut u32; // anonymous local
     let _10: u32; // anonymous local
-    let _11: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'58, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'58>[{built_in impl core::marker::Sized::<&_ mut _><'58> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'58> for A}]; // anonymous local
-    let _12: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'74, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'74>[{built_in impl core::marker::Sized::<&_ mut _><'74> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'74> for A}]; // anonymous local
-    let _13: core::option::Option::<&_ mut _><'90, A>[{built_in impl core::marker::Sized::<&_ mut _><'90> for A}]; // anonymous local
-    let _14: &'94 mut A; // anonymous local
-    let _15: Option<&'101 u32>[{built_in impl Sized for &'101 u32}]; // anonymous local
-    let _16: Option<&'105 u32>[{built_in impl Sized for &'105 u32}]; // anonymous local
-    let _17: &'109 u32; // anonymous local
-    let _18: &'110 u32; // anonymous local
-    let _19: &'111 u32; // anonymous local
-    let _20: &'112 u32; // anonymous local
-    let _21: &'382 u32; // anonymous local
-    let _22: &'489 u32; // anonymous local
+    let _11: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'70, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'70>[{built_in impl core::marker::Sized::<&_ mut _><'70> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'70> for A}]; // anonymous local
+    let _12: core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'86, A>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'86>[{built_in impl core::marker::Sized::<&_ mut _><'86> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'86> for A}]; // anonymous local
+    let _13: core::option::Option::<&_ mut _><'102, A>[{built_in impl core::marker::Sized::<&_ mut _><'102> for A}]; // anonymous local
+    let _14: &'106 mut A; // anonymous local
+    let _15: Option<&'114 u32>[{built_in impl Sized for &'114 u32}]; // anonymous local
+    let _16: Option<&'118 u32>[{built_in impl Sized for &'118 u32}]; // anonymous local
+    let _17: &'122 u32; // anonymous local
+    let _18: &'123 u32; // anonymous local
+    let _19: &'124 u32; // anonymous local
+    let _20: &'125 u32; // anonymous local
+    let _21: &'501 u32; // anonymous local
+    let _22: &'627 u32; // anonymous local
     let _23: u32; // anonymous local
-    let _24: &'490 u32; // anonymous local
+    let _24: &'628 u32; // anonymous local
     let _25: u32; // anonymous local
 
     storage_live(_20)
@@ -594,13 +594,13 @@ where
     storage_live(_3)
     _19 = move _20
     _3 = &(*_19)
-    _2 = identity<&'114 u32>[{built_in impl Sized for &'114 u32}](move _3)
+    _2 = identity<&'127 u32>[{built_in impl Sized for &'127 u32}](move _3)
     ↳⚡ // Make sure we do generics right.
         // Use a function pointer.
         // These cause errors because of missing normalization :'(
         // let _ = Some(&mut 0u32).map(identity);
         // let _ = Some(&mut 0u32).map(mutable_identity);
-        conditional_drop[{built_in impl Destruct for A}::drop_glue<'120>] x
+        conditional_drop[{built_in impl Destruct for A}::drop_glue<'134>] x
         ↳⚡ storage_dead(_19)
             storage_dead(_18)
             storage_dead(x)
@@ -622,8 +622,8 @@ where
     storage_live(_6)
     _6 = const 0u32
     _5 = &mut _6
-    _4 = test_crate::identity::<&_ mut _><'122, u32>[{built_in impl core::marker::Sized::<&_ mut _><'122> for u32}](move _5)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'120>] x
+    _4 = test_crate::identity::<&_ mut _><'136, u32>[{built_in impl core::marker::Sized::<&_ mut _><'136> for u32}](move _5)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'134>] x
         ↳⚡ storage_dead(_19)
             storage_dead(_18)
             storage_dead(x)
@@ -649,8 +649,8 @@ where
     _9 = &mut _10
     _8 = core::option::Option::<&_ mut _>::Some { _0: move _9 }
     storage_dead(_9)
-    _7 = test_crate::identity::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'141, u32>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'141>[{built_in impl core::marker::Sized::<&_ mut _><'141> for u32}] for u32}, {built_in impl core::marker::Sized::<&_ mut _><'141> for u32}](move _8)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'120>] x
+    _7 = test_crate::identity::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><'158, u32>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'158>[{built_in impl core::marker::Sized::<&_ mut _><'158> for u32}] for u32}, {built_in impl core::marker::Sized::<&_ mut _><'158> for u32}](move _8)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'134>] x
         ↳⚡ storage_dead(_19)
             storage_dead(_18)
             storage_dead(x)
@@ -677,8 +677,8 @@ where
     storage_dead(_14)
     _12 = core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]>::Some { _0: move _13 }
     storage_dead(_13)
-    _11 = test_crate::identity::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause1, TraitClause2]><'244, A>[{built_in impl core::marker::Sized::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause0, TraitClause1]><'244>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'244>[{built_in impl core::marker::Sized::<&_ mut _><'244> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'244> for A}] for A}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'244>[{built_in impl core::marker::Sized::<&_ mut _><'244> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'244> for A}](move _12)
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'120>] x
+    _11 = test_crate::identity::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause1, TraitClause2]><'293, A>[{built_in impl core::marker::Sized::<core::option::Option::<core::option::Option::<&_ mut _><_, _>[TraitClause1]><_, _>[TraitClause0, TraitClause1]><'293>[{built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'293>[{built_in impl core::marker::Sized::<&_ mut _><'293> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'293> for A}] for A}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'293>[{built_in impl core::marker::Sized::<&_ mut _><'293> for A}] for A}, {built_in impl core::marker::Sized::<&_ mut _><'293> for A}](move _12)
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'134>] x
         ↳⚡ storage_dead(_19)
             storage_dead(_18)
             storage_dead(x)
@@ -708,8 +708,8 @@ where
     _17 = &(*_18)
     _16 = Option::Some { _0: move _17 }
     storage_dead(_17)
-    _15 = map<&'390 u32, &'391 u32, identity<&'399 u32>[{built_in impl Sized for &'399 u32}]>[{built_in impl Sized for &'390 u32}, {built_in impl Sized for &'391 u32}, {built_in impl Sized for identity<&'420 u32>[{built_in impl Sized for &'420 u32}]}, {impl FnOnce<(T,)> for identity<T>[TraitClause0]}<&'390 u32>[{built_in impl Sized for &'390 u32}], {built_in impl Destruct for identity<&'466 u32>[{built_in impl Sized for &'466 u32}]}](move _16, const identity<&'482 u32>[{built_in impl Sized for &'482 u32}])
-    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'120>] x
+    _15 = map<&'510 u32, &'511 u32, identity<&'520 u32>[{built_in impl Sized for &'520 u32}]>[{built_in impl Sized for &'510 u32}, {built_in impl Sized for &'511 u32}, {built_in impl Sized for identity<&'544 u32>[{built_in impl Sized for &'544 u32}]}, {impl FnOnce<(T,)> for identity<T>[TraitClause0]}<&'510 u32>[{built_in impl Sized for &'510 u32}], {built_in impl Destruct for identity<&'602 u32>[{built_in impl Sized for &'602 u32}]}](move _16, const identity<&'619 u32>[{built_in impl Sized for &'619 u32}])
+    ↳⚡ conditional_drop[{built_in impl Destruct for A}::drop_glue<'134>] x
         ↳⚡ storage_dead(_19)
             storage_dead(_18)
             storage_dead(x)
@@ -727,7 +727,7 @@ where
     storage_dead(_16)
     storage_dead(_15)
     _0 = ()
-    conditional_drop[{built_in impl Destruct for A}::drop_glue<'488>] x
+    conditional_drop[{built_in impl Destruct for A}::drop_glue<'626>] x
     ↳⚡ storage_dead(_19)
         storage_dead(_18)
         storage_dead(x)
@@ -793,7 +793,7 @@ where
 fn use_foo<'_0>(_1: test_crate::Foo3::<&_ mut _><'_0, u32>[{built_in impl core::marker::Sized::<&_ mut _><'_0> for u32}])
 {
     let _0: (); // return
-    let _1: test_crate::Foo3::<&_ mut _><'6, u32>[{built_in impl core::marker::Sized::<&_ mut _><'6> for u32}]; // arg #1
+    let _1: test_crate::Foo3::<&_ mut _><'8, u32>[{built_in impl core::marker::Sized::<&_ mut _><'8> for u32}]; // arg #1
 
     storage_live(_0)
     _0 = ()
@@ -839,7 +839,7 @@ where
     RegionOutlives0: 'b: 'a,
 {
     let _0: (); // return
-    let _1: test_crate::Triple::<_, &_ mut &_ mut _, core::option::Option::<&_ mut _><_, _>[TraitClause3]><'44, '45, '46, u32, T, bool>[{built_in impl Sized for u32}, {built_in impl core::marker::Sized::<&_ mut &_ mut _><'44, '45> for T}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'46>[{built_in impl core::marker::Sized::<&_ mut _><'46> for bool}] for bool}, {built_in impl core::marker::Sized::<&_ mut _><'46> for bool}]; // arg #1
+    let _1: test_crate::Triple::<_, &_ mut &_ mut _, core::option::Option::<&_ mut _><_, _>[TraitClause3]><'68, '69, '70, u32, T, bool>[{built_in impl Sized for u32}, {built_in impl core::marker::Sized::<&_ mut &_ mut _><'68, '69> for T}, {built_in impl core::marker::Sized::<core::option::Option::<&_ mut _><_, _>[TraitClause0]><'70>[{built_in impl core::marker::Sized::<&_ mut _><'70> for bool}] for bool}, {built_in impl core::marker::Sized::<&_ mut _><'70> for bool}]; // arg #1
 
     storage_live(_0)
     _0 = ()
@@ -888,7 +888,7 @@ where
     RegionOutlives0: '_1: '_0,
 {
     let _0: (); // return
-    let _1: &'11 test_crate::List::<&_ mut _><'12, u32>[{built_in impl core::marker::Sized::<&_ mut _><'12> for u32}]; // arg #1
+    let _1: &'13 test_crate::List::<&_ mut _><'14, u32>[{built_in impl core::marker::Sized::<&_ mut _><'14> for u32}]; // arg #1
 
     storage_live(_0)
     _0 = ()
@@ -913,7 +913,7 @@ where
     TypeOutlives0: bool: 'a,
 {
     let _0: (); // return
-    let _1: core::option::Option::<Iter<_, _>[TraitClause1]><'6, bool>[{built_in impl core::marker::Sized::<Iter<_, _>[TraitClause0]><'6>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}]; // arg #1
+    let _1: core::option::Option::<Iter<_, _>[TraitClause1]><'8, bool>[{built_in impl core::marker::Sized::<Iter<_, _>[TraitClause0]><'8>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}]; // arg #1
 
     storage_live(_0)
     _0 = ()
@@ -930,7 +930,7 @@ where
     TypeOutlives1: T: 'b,
 {
     let _0: (); // return
-    let _1: test_crate::Iter::<_, &_ mut _><'7, '8, T>[{built_in impl core::marker::Sized::<&_ mut _><'8> for T}]; // arg #1
+    let _1: test_crate::Iter::<_, &_ mut _><'9, '10, T>[{built_in impl core::marker::Sized::<&_ mut _><'10> for T}]; // arg #1
 
     storage_live(_0)
     _0 = ()
@@ -946,7 +946,7 @@ where
     TypeOutlives0: bool: 'a,
 {
     let _0: (); // return
-    let _1: core::option::Option::<IterWrapper<_, _>[TraitClause1]><'6, bool>[{built_in impl core::marker::Sized::<IterWrapper<_, _>[TraitClause0]><'6>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}]; // arg #1
+    let _1: core::option::Option::<IterWrapper<_, _>[TraitClause1]><'8, bool>[{built_in impl core::marker::Sized::<IterWrapper<_, _>[TraitClause0]><'8>[{built_in impl Sized for bool}] for bool}, {built_in impl Sized for bool}]; // arg #1
 
     storage_live(_0)
     _0 = ()
@@ -981,8 +981,8 @@ where
 fn use_const_generic<'_0, '_1>(_1: test_crate::ArrayWrapper::<&_ mut _, 1usize><'_0, u32>[{built_in impl core::marker::Sized::<&_ mut _><'_0> for u32}], _2: test_crate::ArrayWrapper::<&_ mut _, 2usize><'_1, u32>[{built_in impl core::marker::Sized::<&_ mut _><'_1> for u32}])
 {
     let _0: (); // return
-    let _1: test_crate::ArrayWrapper::<&_ mut _, 1usize><'6, u32>[{built_in impl core::marker::Sized::<&_ mut _><'6> for u32}]; // arg #1
-    let _2: test_crate::ArrayWrapper::<&_ mut _, 2usize><'16, u32>[{built_in impl core::marker::Sized::<&_ mut _><'16> for u32}]; // arg #2
+    let _1: test_crate::ArrayWrapper::<&_ mut _, 1usize><'8, u32>[{built_in impl core::marker::Sized::<&_ mut _><'8> for u32}]; // arg #1
+    let _2: test_crate::ArrayWrapper::<&_ mut _, 2usize><'19, u32>[{built_in impl core::marker::Sized::<&_ mut _><'19> for u32}]; // arg #2
 
     storage_live(_0)
     _0 = ()

--- a/charon/tests/ui/multi-target/issue-1213-merge-methods-when-missing.out
+++ b/charon/tests/ui/multi-target/issue-1213-merge-methods-when-missing.out
@@ -229,9 +229,9 @@ fn test_crate::f<'_0>(blocks: &'_0 mut [u8])
     let _3: core::slice::iter::IterMut<'4, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
     let _4: &'5 mut [u8]; // anonymous local
     let iter: core::slice::iter::IterMut<'6, u8>[{built_in impl core::marker::Sized for u8}]; // local
-    let _6: core::option::Option<&'14 mut u8>[{built_in impl core::marker::Sized for &'14 mut u8}]; // anonymous local
-    let _7: &'20 mut core::slice::iter::IterMut<'21, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
-    let _8: &'22 mut core::slice::iter::IterMut<'23, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
+    let _6: core::option::Option<&'15 mut u8>[{built_in impl core::marker::Sized for &'15 mut u8}]; // anonymous local
+    let _7: &'21 mut core::slice::iter::IterMut<'22, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
+    let _8: &'23 mut core::slice::iter::IterMut<'24, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -239,11 +239,11 @@ fn test_crate::f<'_0>(blocks: &'_0 mut [u8])
     storage_live(_3)
     storage_live(_4)
     _4 = &two-phase-mut (*blocks) with_metadata(copy blocks.metadata)
-    _3 = core::slice::{[T]}::iter_mut<'25, u8>[{built_in impl core::marker::Sized for u8}](move _4)
+    _3 = core::slice::{[T]}::iter_mut<'26, u8>[{built_in impl core::marker::Sized for u8}](move _4)
     ↳⚡ storage_dead(blocks)
         unwind_continue
     storage_dead(_4)
-    _2 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::slice::iter::IterMut<'27, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::IterMut<'27, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}<'27, u8>[{built_in impl core::marker::Sized for u8}]](move _3)
+    _2 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::slice::iter::IterMut<'28, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::IterMut<'28, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}<'28, u8>[{built_in impl core::marker::Sized for u8}]](move _3)
     ↳⚡ storage_dead(blocks)
         unwind_continue
     storage_dead(_3)
@@ -255,7 +255,7 @@ fn test_crate::f<'_0>(blocks: &'_0 mut [u8])
         storage_live(_8)
         _8 = &mut iter
         _7 = &two-phase-mut (*_8)
-        _6 = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}::next<'37, '39, u8>[{built_in impl core::marker::Sized for u8}](move _7)
+        _6 = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::IterMut<'a, T>[TraitClause0]}::next<'39, '41, u8>[{built_in impl core::marker::Sized for u8}](move _7)
         ↳⚡ storage_dead(blocks)
             unwind_continue
         storage_dead(_7)
@@ -284,16 +284,16 @@ fn test_crate::g<'_0, '_1>(s0: &'_0 [u8], s1: &'_1 [u8])
     let _0: (); // return
     let s0: &'1 [u8]; // arg #1
     let s1: &'2 [u8]; // arg #2
-    let _3: core::iter::adapters::zip::Zip<core::slice::iter::Iter<'16, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'17, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'16, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'17, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
-    let _4: core::iter::adapters::zip::Zip<core::slice::iter::Iter<'24, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'25, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'24, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'25, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
-    let _5: core::slice::iter::Iter<'32, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
-    let _6: &'33 [u8]; // anonymous local
-    let _7: core::slice::iter::Iter<'34, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
-    let _8: &'35 [u8]; // anonymous local
-    let iter: core::iter::adapters::zip::Zip<core::slice::iter::Iter<'36, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'37, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'36, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'37, u8>[{built_in impl core::marker::Sized for u8}]}]; // local
-    let _10: core::option::Option<(&'88 u8, &'89 u8)>[{built_in impl core::marker::Sized for (&'88 u8, &'89 u8)}]; // anonymous local
-    let _11: &'117 mut core::iter::adapters::zip::Zip<core::slice::iter::Iter<'118, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'119, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'118, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'119, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
-    let _12: &'126 mut core::iter::adapters::zip::Zip<core::slice::iter::Iter<'127, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'128, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'127, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'128, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
+    let _3: core::iter::adapters::zip::Zip<core::slice::iter::Iter<'18, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'19, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'18, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'19, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
+    let _4: core::iter::adapters::zip::Zip<core::slice::iter::Iter<'26, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'27, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'26, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'27, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
+    let _5: core::slice::iter::Iter<'34, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
+    let _6: &'35 [u8]; // anonymous local
+    let _7: core::slice::iter::Iter<'36, u8>[{built_in impl core::marker::Sized for u8}]; // anonymous local
+    let _8: &'37 [u8]; // anonymous local
+    let iter: core::iter::adapters::zip::Zip<core::slice::iter::Iter<'38, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'39, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'38, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'39, u8>[{built_in impl core::marker::Sized for u8}]}]; // local
+    let _10: core::option::Option<(&'102 u8, &'103 u8)>[{built_in impl core::marker::Sized for (&'102 u8, &'103 u8)}]; // anonymous local
+    let _11: &'131 mut core::iter::adapters::zip::Zip<core::slice::iter::Iter<'132, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'133, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'132, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'133, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
+    let _12: &'140 mut core::iter::adapters::zip::Zip<core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'142, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'142, u8>[{built_in impl core::marker::Sized for u8}]}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -302,7 +302,7 @@ fn test_crate::g<'_0, '_1>(s0: &'_0 [u8], s1: &'_1 [u8])
     storage_live(_5)
     storage_live(_6)
     _6 = &(*s0) with_metadata(copy s0.metadata)
-    _5 = core::slice::{[T]}::iter<'136, u8>[{built_in impl core::marker::Sized for u8}](move _6)
+    _5 = core::slice::{[T]}::iter<'150, u8>[{built_in impl core::marker::Sized for u8}](move _6)
     ↳⚡ storage_dead(s1)
         storage_dead(s0)
         unwind_continue
@@ -310,18 +310,18 @@ fn test_crate::g<'_0, '_1>(s0: &'_0 [u8], s1: &'_1 [u8])
     storage_live(_7)
     storage_live(_8)
     _8 = &(*s1) with_metadata(copy s1.metadata)
-    _7 = core::slice::{[T]}::iter<'138, u8>[{built_in impl core::marker::Sized for u8}](move _8)
+    _7 = core::slice::{[T]}::iter<'152, u8>[{built_in impl core::marker::Sized for u8}](move _8)
     ↳⚡ storage_dead(s1)
         storage_dead(s0)
         unwind_continue
     storage_dead(_8)
-    _4 = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}::zip<'140, u8, core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for u8}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'140, u8>[{built_in impl core::marker::Sized for u8}]}, core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}<core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'141, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'141, u8>[{built_in impl core::marker::Sized for u8}]]](move _5, move _7)
+    _4 = core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}::zip<'154, u8, core::slice::iter::Iter<'155, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for u8}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'155, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'154, u8>[{built_in impl core::marker::Sized for u8}]}, core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}<core::slice::iter::Iter<'155, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'155, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'155, u8>[{built_in impl core::marker::Sized for u8}]]](move _5, move _7)
     ↳⚡ storage_dead(s1)
         storage_dead(s0)
         unwind_continue
     storage_dead(_7)
     storage_dead(_5)
-    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::iter::adapters::zip::Zip<core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]}]>[{built_in impl core::marker::Sized for core::iter::adapters::zip::Zip<core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]}]}, core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}<core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'183, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'186, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'183, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'186, u8>[{built_in impl core::marker::Sized for u8}]]](move _4)
+    _3 = core::iter::traits::collect::{impl core::iter::traits::collect::IntoIterator for I}::into_iter<core::iter::adapters::zip::Zip<core::slice::iter::Iter<'202, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'205, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'202, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'205, u8>[{built_in impl core::marker::Sized for u8}]}]>[{built_in impl core::marker::Sized for core::iter::adapters::zip::Zip<core::slice::iter::Iter<'202, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'205, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'202, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'205, u8>[{built_in impl core::marker::Sized for u8}]}]}, core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}<core::slice::iter::Iter<'202, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'205, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'202, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'205, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'202, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'205, u8>[{built_in impl core::marker::Sized for u8}]]](move _4)
     ↳⚡ storage_dead(s1)
         storage_dead(s0)
         unwind_continue
@@ -334,7 +334,7 @@ fn test_crate::g<'_0, '_1>(s0: &'_0 [u8], s1: &'_1 [u8])
         storage_live(_12)
         _12 = &mut iter
         _11 = &two-phase-mut (*_12)
-        _10 = core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}::next<'304, core::slice::iter::Iter<'285, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'286, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'285, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'286, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'285, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'286, u8>[{built_in impl core::marker::Sized for u8}]](move _11)
+        _10 = core::iter::adapters::zip::{impl core::iter::traits::iterator::Iterator for core::iter::adapters::zip::Zip<A, B>[TraitClause0, TraitClause1]}::next<'348, core::slice::iter::Iter<'327, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::Iter<'328, u8>[{built_in impl core::marker::Sized for u8}]>[{built_in impl core::marker::Sized for core::slice::iter::Iter<'327, u8>[{built_in impl core::marker::Sized for u8}]}, {built_in impl core::marker::Sized for core::slice::iter::Iter<'328, u8>[{built_in impl core::marker::Sized for u8}]}, core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'327, u8>[{built_in impl core::marker::Sized for u8}], core::slice::iter::{impl core::iter::traits::iterator::Iterator for core::slice::iter::Iter<'a, T>[TraitClause0]}<'328, u8>[{built_in impl core::marker::Sized for u8}]](move _11)
         ↳⚡ storage_dead(s1)
             storage_dead(s0)
             unwind_continue

--- a/charon/tests/ui/partial-monomorphization/issue-1204-partial-mono-tuples.out
+++ b/charon/tests/ui/partial-monomorphization/issue-1204-partial-mono-tuples.out
@@ -89,14 +89,14 @@ where
     TypeOutlives0: T: 'a,
     TypeOutlives1: U: 'a,
 {
-    let _0: (&'8 mut T, &'9 mut U); // return
-    let x: (&'13 mut T, &'14 mut U); // arg #1
-    let _2: (&'18 mut T, &'19 mut U); // anonymous local
+    let _0: (&'10 mut T, &'11 mut U); // return
+    let x: (&'15 mut T, &'16 mut U); // arg #1
+    let _2: (&'20 mut T, &'21 mut U); // anonymous local
 
     storage_live(_0)
     storage_live(_2)
     _2 = move x
-    _0 = test_crate::id::<(&_ mut _, &_ mut _)><'32, '33, T, U>[{built_in impl core::marker::Sized::<(&_ mut _, &_ mut _)><'32, '33, U> for T}](move _2)
+    _0 = test_crate::id::<(&_ mut _, &_ mut _)><'35, '36, T, U>[{built_in impl core::marker::Sized::<(&_ mut _, &_ mut _)><'35, '36, U> for T}](move _2)
     ↳⚡ storage_dead(x)
         unwind_continue
     storage_dead(_2)

--- a/charon/tests/ui/partial-monomorphization/mono-mut-tuple.out
+++ b/charon/tests/ui/partial-monomorphization/mono-mut-tuple.out
@@ -191,24 +191,24 @@ fn call<'a, T>(x: (&'a mut u32, T)) -> (&'a mut u32, T)
 where
     TraitClause0: (T: Sized),
 {
-    let _0: (&'6 mut u32, T); // return
-    let x: (&'10 mut u32, T); // arg #1
-    let _2: (&'14 mut u32, T); // anonymous local
+    let _0: (&'8 mut u32, T); // return
+    let x: (&'12 mut u32, T); // arg #1
+    let _2: (&'16 mut u32, T); // anonymous local
 
     storage_live(_0)
     storage_live(_2)
     _2 = move x
-    _0 = test_crate::id::<(&_ mut _, _)><'25, u32, T>[{built_in impl core::marker::Sized::<(&_ mut _, _)><'25, T>[{built_in impl core::marker::Sized::<&_ mut _><'25> for u32}] for u32}, {built_in impl core::marker::Sized::<&_ mut _><'25> for u32}](move _2)
-    ↳⚡ conditional_drop[(_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'72, '66, u32, T>[{built_in impl core::marker::Sized::<&_ mut _><'66> for u32}]] _2
+    _0 = test_crate::id::<(&_ mut _, _)><'28, u32, T>[{built_in impl core::marker::Sized::<(&_ mut _, _)><'28, T>[{built_in impl core::marker::Sized::<&_ mut _><'28> for u32}] for u32}, {built_in impl core::marker::Sized::<&_ mut _><'28> for u32}](move _2)
+    ↳⚡ conditional_drop[(_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'87, '80, u32, T>[{built_in impl core::marker::Sized::<&_ mut _><'80> for u32}]] _2
         ↳⚡ storage_dead(x)
             unwind_terminate
-        conditional_drop[(_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'108, '102, u32, T>[{built_in impl core::marker::Sized::<&_ mut _><'102> for u32}]] x
+        conditional_drop[(_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'127, '120, u32, T>[{built_in impl core::marker::Sized::<&_ mut _><'120> for u32}]] x
         ↳⚡ storage_dead(x)
             unwind_terminate
         storage_dead(x)
         unwind_continue
     storage_dead(_2)
-    conditional_drop[(_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'90, '84, u32, T>[{built_in impl core::marker::Sized::<&_ mut _><'84> for u32}]] x
+    conditional_drop[(_, _)::impl_Destruct_for_tuple::drop_glue::<_, &_ mut _, _><'107, '100, u32, T>[{built_in impl core::marker::Sized::<&_ mut _><'100> for u32}]] x
     ↳⚡ storage_dead(x)
         unwind_continue
     storage_dead(x)

--- a/charon/tests/ui/polonius_map.out
+++ b/charon/tests/ui/polonius_map.out
@@ -248,25 +248,25 @@ pub fn get_or_insert<'_0>(map: &'_0 mut HashMap<u32, u32, RandomState, Global>[{
 {
     let _0: &'1 u32; // return
     let map: &'3 mut HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]; // arg #1
-    let _2: Option<&'10 u32>[{built_in impl Sized for &'10 u32}]; // anonymous local
-    let _3: &'15 HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]; // anonymous local
-    let _4: &'16 u32; // anonymous local
-    let _5: &'17 u32; // anonymous local
-    let v: &'18 u32; // local
+    let _2: Option<&'11 u32>[{built_in impl Sized for &'11 u32}]; // anonymous local
+    let _3: &'16 HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]; // anonymous local
+    let _4: &'17 u32; // anonymous local
+    let _5: &'18 u32; // anonymous local
+    let v: &'19 u32; // local
     let _7: Option<u32>[{built_in impl Sized for u32}]; // anonymous local
-    let _8: &'19 mut HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]; // anonymous local
-    let _9: &'20 u32; // anonymous local
-    let _10: &'21 u32; // anonymous local
-    let _11: &'22 HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]; // anonymous local
-    let _12: &'23 u32; // anonymous local
-    let _13: &'24 u32; // anonymous local
-    let _14: &'25 u32; // anonymous local
-    let _15: &'26 u32; // anonymous local
-    let _16: &'27 u32; // anonymous local
-    let _17: &'34 u32; // anonymous local
-    let _18: &'43 u32; // anonymous local
+    let _8: &'20 mut HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]; // anonymous local
+    let _9: &'21 u32; // anonymous local
+    let _10: &'22 u32; // anonymous local
+    let _11: &'23 HashMap<u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}]; // anonymous local
+    let _12: &'24 u32; // anonymous local
+    let _13: &'25 u32; // anonymous local
+    let _14: &'26 u32; // anonymous local
+    let _15: &'27 u32; // anonymous local
+    let _16: &'28 u32; // anonymous local
+    let _17: &'35 u32; // anonymous local
+    let _18: &'44 u32; // anonymous local
     let _19: u32; // anonymous local
-    let _20: &'44 u32; // anonymous local
+    let _20: &'45 u32; // anonymous local
     let _21: u32; // anonymous local
 
     storage_live(_16)
@@ -286,7 +286,7 @@ pub fn get_or_insert<'_0>(map: &'_0 mut HashMap<u32, u32, RandomState, Global>[{
     _15 = move _16
     _5 = &(*_15)
     _4 = &(*_5)
-    _2 = std::collections::hash::map::{HashMap<K, V, S, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::get<'30, '31, u32, u32, RandomState, Global, u32>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}, impl_Eq_for_u32, impl_Hash_for_u32, impl_BuildHasher_for_RandomState, {built_in impl MetaSized for u32}, impl_Borrow_for_T<u32>[{built_in impl MetaSized for u32}], impl_Hash_for_u32, impl_Eq_for_u32](move _3, move _4)
+    _2 = std::collections::hash::map::{HashMap<K, V, S, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3]}::get<'31, '32, u32, u32, RandomState, Global, u32>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}, impl_Eq_for_u32, impl_Hash_for_u32, impl_BuildHasher_for_RandomState, {built_in impl MetaSized for u32}, impl_Borrow_for_T<u32>[{built_in impl MetaSized for u32}], impl_Hash_for_u32, impl_Eq_for_u32](move _3, move _4)
     ↳⚡ storage_dead(_15)
         storage_dead(_14)
         storage_dead(map)
@@ -318,7 +318,7 @@ pub fn get_or_insert<'_0>(map: &'_0 mut HashMap<u32, u32, RandomState, Global>[{
     storage_live(_7)
     storage_live(_8)
     _8 = &two-phase-mut (*map)
-    _7 = insert<'33, u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}, impl_Eq_for_u32, impl_Hash_for_u32, impl_BuildHasher_for_RandomState](move _8, const 22u32, const 33u32)
+    _7 = insert<'34, u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}, impl_Eq_for_u32, impl_Hash_for_u32, impl_BuildHasher_for_RandomState](move _8, const 22u32, const 33u32)
     ↳⚡ storage_dead(_15)
         storage_dead(_14)
         storage_dead(map)
@@ -340,7 +340,7 @@ pub fn get_or_insert<'_0>(map: &'_0 mut HashMap<u32, u32, RandomState, Global>[{
     _14 = move _17
     _13 = &(*_14)
     _12 = &(*_13)
-    _10 = impl_Index_for_HashMap::index<'35, '37, u32, u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl MetaSized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}, impl_Eq_for_u32, impl_Hash_for_u32, impl_Borrow_for_T<u32>[{built_in impl MetaSized for u32}], impl_Eq_for_u32, impl_Hash_for_u32, impl_BuildHasher_for_RandomState](move _11, move _12)
+    _10 = impl_Index_for_HashMap::index<'36, '38, u32, u32, u32, RandomState, Global>[{built_in impl Sized for u32}, {built_in impl MetaSized for u32}, {built_in impl Sized for u32}, {built_in impl Sized for RandomState}, {built_in impl Sized for Global}, impl_Eq_for_u32, impl_Hash_for_u32, impl_Borrow_for_T<u32>[{built_in impl MetaSized for u32}], impl_Eq_for_u32, impl_Hash_for_u32, impl_BuildHasher_for_RandomState](move _11, move _12)
     ↳⚡ storage_dead(_15)
         storage_dead(_14)
         storage_dead(map)

--- a/charon/tests/ui/predicates-on-late-bound-vars.out
+++ b/charon/tests/ui/predicates-on-late-bound-vars.out
@@ -90,9 +90,9 @@ where
 // Full name: test_crate::wrap
 fn wrap<'a>(x: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'a u32}]
 {
-    let _0: Option<&'6 u32>[{built_in impl Sized for &'6 u32}]; // return
-    let x: &'10 u32; // arg #1
-    let _2: &'11 u32; // anonymous local
+    let _0: Option<&'8 u32>[{built_in impl Sized for &'8 u32}]; // return
+    let x: &'12 u32; // arg #1
+    let _2: &'13 u32; // anonymous local
 
     storage_live(_0)
     storage_live(_2)
@@ -108,9 +108,9 @@ fn wrap2<'a>(x: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'a u32}]
 where
     TraitClause0: (&'a (): Clone),
 {
-    let _0: Option<&'6 u32>[{built_in impl Sized for &'6 u32}]; // return
-    let x: &'10 u32; // arg #1
-    let _2: &'11 u32; // anonymous local
+    let _0: Option<&'8 u32>[{built_in impl Sized for &'8 u32}]; // return
+    let x: &'12 u32; // arg #1
+    let _2: &'13 u32; // anonymous local
 
     storage_live(_0)
     storage_live(_2)
@@ -126,8 +126,8 @@ fn foo()
 {
     let _0: (); // return
     let ref_b: RefCell<bool>[{built_in impl MetaSized for bool}]; // local
-    let _2: Result<Ref<'7, bool>[{built_in impl MetaSized for bool}], BorrowError>[{built_in impl Sized for Ref<'7, bool>[{built_in impl MetaSized for bool}]}, {built_in impl Sized for BorrowError}]; // anonymous local
-    let _3: &'12 RefCell<bool>[{built_in impl MetaSized for bool}]; // anonymous local
+    let _2: Result<Ref<'8, bool>[{built_in impl MetaSized for bool}], BorrowError>[{built_in impl Sized for Ref<'8, bool>[{built_in impl MetaSized for bool}]}, {built_in impl Sized for BorrowError}]; // anonymous local
+    let _3: &'13 RefCell<bool>[{built_in impl MetaSized for bool}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -139,10 +139,10 @@ fn foo()
     storage_live(_3)
     // `try_borrow` has a type that includes predicates on late bound regions.
     _3 = &ref_b
-    _2 = try_borrow<'14, bool>[{built_in impl MetaSized for bool}](move _3)
+    _2 = try_borrow<'15, bool>[{built_in impl MetaSized for bool}](move _3)
     ↳⚡ unwind_continue
     storage_dead(_3)
-    conditional_drop[drop_glue<'32, Ref<'26, bool>[{built_in impl MetaSized for bool}], BorrowError>[{built_in impl Sized for Ref<'26, bool>[{built_in impl MetaSized for bool}]}, {built_in impl Sized for BorrowError}]] _2
+    conditional_drop[drop_glue<'35, Ref<'28, bool>[{built_in impl MetaSized for bool}], BorrowError>[{built_in impl Sized for Ref<'28, bool>[{built_in impl MetaSized for bool}]}, {built_in impl Sized for BorrowError}]] _2
     ↳⚡ unwind_continue
     storage_dead(_2)
     _0 = ()

--- a/charon/tests/ui/quantified-clause.out
+++ b/charon/tests/ui/quantified-clause.out
@@ -180,8 +180,8 @@ where
 // Full name: test_crate::f
 pub fn f<'a>(_1: &'a ()) -> Option<(&'a u8,)>[{built_in impl Sized for (&'a u8,)}]
 {
-    let _0: Option<(&'8 u8,)>[{built_in impl Sized for (&'8 u8,)}]; // return
-    let _1: &'13 (); // arg #1
+    let _0: Option<(&'12 u8,)>[{built_in impl Sized for (&'12 u8,)}]; // return
+    let _1: &'17 (); // arg #1
 
     storage_live(_0)
     _0 = Option::None {  }

--- a/charon/tests/ui/regressions/issue-1073-out-of-bounds-body-region.out
+++ b/charon/tests/ui/regressions/issue-1073-out-of-bounds-body-region.out
@@ -33,16 +33,16 @@ where
     RegionOutlives1: '_2: '_1,
 {
     let _0: (); // return
-    let bufs: &'17 mut &'18 mut [IoSlice<'19>]; // arg #1
+    let bufs: &'19 mut &'20 mut [IoSlice<'21>]; // arg #1
     let _2: (); // anonymous local
-    let _3: &'23 mut &'24 mut [IoSlice<'25>]; // anonymous local
+    let _3: &'25 mut &'26 mut [IoSlice<'27>]; // anonymous local
 
     storage_live(_0)
     _0 = ()
     storage_live(_2)
     storage_live(_3)
     _3 = &two-phase-mut (*bufs)
-    _2 = advance_slices<'34, '37, '38>(move _3, const 0usize)
+    _2 = advance_slices<'36, '39, '40>(move _3, const 0usize)
     ↳⚡ storage_dead(bufs)
         unwind_continue
     storage_dead(_3)

--- a/charon/tests/ui/rust-name-matcher-tests.out
+++ b/charon/tests/ui/rust-name-matcher-tests.out
@@ -246,9 +246,9 @@ fn use_generic()
 {
     let _0: (); // return
     let _int_generic: Generic<i32>[{built_in impl Sized for i32}]; // local
-    let _str_generic: Generic<&'7 str>[{built_in impl Sized for &'7 str}]; // local
-    let _3: &'12 i32; // anonymous local
-    let _4: &'14 Generic<i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _str_generic: Generic<&'8 str>[{built_in impl Sized for &'8 str}]; // local
+    let _3: &'13 i32; // anonymous local
+    let _4: &'15 Generic<i32>[{built_in impl Sized for i32}]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -257,13 +257,13 @@ fn use_generic()
     ↳⚡ unwind_continue
     fake_read(_int_generic)
     storage_live(_str_generic)
-    _str_generic = new<&'16 str>[{built_in impl Sized for &'16 str}](const "hello")
+    _str_generic = new<&'17 str>[{built_in impl Sized for &'17 str}](const "hello")
     ↳⚡ unwind_continue
     fake_read(_str_generic)
     storage_live(_3)
     storage_live(_4)
     _4 = &_int_generic
-    _3 = test_crate::{Generic<T>[TraitClause0]}::get<'24, i32>[{built_in impl Sized for i32}](move _4)
+    _3 = test_crate::{Generic<T>[TraitClause0]}::get<'26, i32>[{built_in impl Sized for i32}](move _4)
     ↳⚡ unwind_continue
     storage_dead(_4)
     storage_dead(_3)

--- a/charon/tests/ui/simple/catch-unwind.out
+++ b/charon/tests/ui/simple/catch-unwind.out
@@ -139,7 +139,7 @@ impl "impl_FnOnce_unit_for_closure" FnOnce<()> for {closure} {
 fn main()
 {
     let _0: (); // return
-    let _1: Result<(), Box<(dyn Any + Send + '27)>[{built_in impl MetaSized for (dyn Any + Send + '29)}, {built_in impl Sized for Global}]>[{built_in impl Sized for ()}, {built_in impl Sized for Box<(dyn Any + Send + '36)>[{built_in impl MetaSized for (dyn Any + Send + '38)}, {built_in impl Sized for Global}]}]; // anonymous local
+    let _1: Result<(), Box<(dyn Any + Send + '36)>[{built_in impl MetaSized for (dyn Any + Send + '38)}, {built_in impl Sized for Global}]>[{built_in impl Sized for ()}, {built_in impl Sized for Box<(dyn Any + Send + '45)>[{built_in impl MetaSized for (dyn Any + Send + '47)}, {built_in impl Sized for Global}]}]; // anonymous local
     let _2: {closure}; // anonymous local
 
     storage_live(_0)
@@ -150,7 +150,7 @@ fn main()
     _1 = catch_unwind<{closure}, ()>[{built_in impl Sized for {closure}}, {built_in impl Sized for ()}, impl_FnOnce_unit_for_closure, {built_in impl UnwindSafe for {closure}}](move _2)
     ↳⚡ unwind_continue
     storage_dead(_2)
-    conditional_drop[drop_glue<'100, (), Box<(dyn Any + Send + '78)>[{built_in impl MetaSized for (dyn Any + Send + '80)}, {built_in impl Sized for Global}]>[{built_in impl Sized for ()}, {built_in impl Sized for Box<(dyn Any + Send + '78)>[{built_in impl MetaSized for (dyn Any + Send + '80)}, {built_in impl Sized for Global}]}]] _1
+    conditional_drop[drop_glue<'126, (), Box<(dyn Any + Send + '96)>[{built_in impl MetaSized for (dyn Any + Send + '98)}, {built_in impl Sized for Global}]>[{built_in impl Sized for ()}, {built_in impl Sized for Box<(dyn Any + Send + '96)>[{built_in impl MetaSized for (dyn Any + Send + '98)}, {built_in impl Sized for Global}]}]] _1
     ↳⚡ unwind_continue
     storage_dead(_1)
     _0 = ()

--- a/charon/tests/ui/simple/closure-fn.out
+++ b/charon/tests/ui/simple/closure-fn.out
@@ -393,7 +393,7 @@ fn main()
     storage_live(_11)
     _11 = &f
     _10 = &(*_11)
-    _9 = apply_to<'62, {closure}<'43, '44>>[{built_in impl Sized for {closure}<'43, '44>}, impl_Fn_tuple_for_closure<'43, '44>](move _10)
+    _9 = apply_to<'64, {closure}<'43, '44>>[{built_in impl Sized for {closure}<'43, '44>}, impl_Fn_tuple_for_closure<'43, '44>](move _10)
     ↳⚡ unwind_continue
     storage_dead(_10)
     storage_dead(_11)
@@ -403,7 +403,7 @@ fn main()
     storage_live(_14)
     _14 = &mut f
     _13 = &two-phase-mut (*_14)
-    _12 = apply_to_mut<'86, {closure}<'67, '68>>[{built_in impl Sized for {closure}<'67, '68>}, impl_FnMut_tuple_for_closure<'67, '68>](move _13)
+    _12 = apply_to_mut<'90, {closure}<'69, '70>>[{built_in impl Sized for {closure}<'69, '70>}, impl_FnMut_tuple_for_closure<'69, '70>](move _13)
     ↳⚡ unwind_continue
     storage_dead(_13)
     storage_dead(_14)
@@ -411,7 +411,7 @@ fn main()
     storage_live(_15)
     storage_live(_16)
     _16 = copy f
-    _15 = apply_to_once<{closure}<'89, '90>>[{built_in impl Sized for {closure}<'89, '90>}, impl_FnOnce_tuple_for_closure<'89, '90>](move _16)
+    _15 = apply_to_once<{closure}<'93, '94>>[{built_in impl Sized for {closure}<'93, '94>}, impl_FnOnce_tuple_for_closure<'93, '94>](move _16)
     ↳⚡ unwind_continue
     storage_dead(_16)
     storage_dead(_15)

--- a/charon/tests/ui/simple/lending-iterator-gat.out
+++ b/charon/tests/ui/simple/lending-iterator-gat.out
@@ -140,12 +140,12 @@ where
     TypeOutlives1: T: '_1,
     RegionOutlives0: 'a: '_1,
 {
-    let _0: Option<&'6 T>[{built_in impl Sized for &'6 T}]; // return
-    let self: &'15 mut Option<&'16 T>[{built_in impl Sized for &'16 T}]; // arg #1
-    let item_2: &'22 mut &'23 T; // local
-    let item_3: &'24 T; // local
-    let _4: Option<&'25 T>[{built_in impl Sized for &'25 T}]; // anonymous local
-    let _5: &'29 T; // anonymous local
+    let _0: Option<&'8 T>[{built_in impl Sized for &'8 T}]; // return
+    let self: &'17 mut Option<&'18 T>[{built_in impl Sized for &'18 T}]; // arg #1
+    let item_2: &'24 mut &'25 T; // local
+    let item_3: &'26 T; // local
+    let _4: Option<&'27 T>[{built_in impl Sized for &'27 T}]; // anonymous local
+    let _5: &'31 T; // anonymous local
 
     storage_live(_0)
     match (*self) {
@@ -497,35 +497,35 @@ pub fn main()
 {
     let _0: (); // return
     let x: i32; // local
-    let iter: Option<&'7 i32>[{built_in impl Sized for &'7 i32}]; // local
-    let _3: &'11 i32; // anonymous local
+    let iter: Option<&'8 i32>[{built_in impl Sized for &'8 i32}]; // local
+    let _3: &'12 i32; // anonymous local
     let sum: i32; // local
     let _5: (); // anonymous local
-    let _6: Option<&'12 i32>[{built_in impl Sized for &'12 i32}]; // anonymous local
-    let _7: {closure}<'17>; // anonymous local
-    let _8: &'19 mut i32; // anonymous local
-    let _9: (&'27 i32, &'28 i32); // anonymous local
-    let _10: &'32 i32; // anonymous local
-    let _11: &'33 i32; // anonymous local
-    let left_val: &'34 i32; // local
-    let right_val: &'35 i32; // local
+    let _6: Option<&'13 i32>[{built_in impl Sized for &'13 i32}]; // anonymous local
+    let _7: {closure}<'18>; // anonymous local
+    let _8: &'20 mut i32; // anonymous local
+    let _9: (&'29 i32, &'30 i32); // anonymous local
+    let _10: &'34 i32; // anonymous local
+    let _11: &'35 i32; // anonymous local
+    let left_val: &'36 i32; // local
+    let right_val: &'37 i32; // local
     let _14: bool; // anonymous local
     let _15: i32; // anonymous local
     let _16: i32; // anonymous local
     let kind: AssertKind; // local
     let _18: AssertKind; // anonymous local
-    let _19: &'36 i32; // anonymous local
-    let _20: &'37 i32; // anonymous local
-    let _21: &'38 i32; // anonymous local
-    let _22: &'39 i32; // anonymous local
-    let _23: Option<Arguments<'47>>[{built_in impl Sized for Arguments<'47>}]; // anonymous local
-    let _24: &'51 i32; // anonymous local
-    let _25: &'52 i32; // anonymous local
-    let _26: &'53 i32; // anonymous local
-    let _27: &'121 i32; // anonymous local
-    let _28: &'135 i32; // anonymous local
+    let _19: &'38 i32; // anonymous local
+    let _20: &'39 i32; // anonymous local
+    let _21: &'40 i32; // anonymous local
+    let _22: &'41 i32; // anonymous local
+    let _23: Option<Arguments<'50>>[{built_in impl Sized for Arguments<'50>}]; // anonymous local
+    let _24: &'54 i32; // anonymous local
+    let _25: &'55 i32; // anonymous local
+    let _26: &'56 i32; // anonymous local
+    let _27: &'138 i32; // anonymous local
+    let _28: &'153 i32; // anonymous local
     let _29: i32; // anonymous local
-    let _30: &'136 i32; // anonymous local
+    let _30: &'154 i32; // anonymous local
     let _31: i32; // anonymous local
 
     storage_live(_26)
@@ -559,7 +559,7 @@ pub fn main()
     _8 = &mut sum
     _7 = {closure} { _0: move _8 }
     storage_dead(_8)
-    _5 = for_each<Option<&'71 i32>[{built_in impl Sized for &'71 i32}], {closure}<'73>>[{built_in impl Sized for Option<&'71 i32>[{built_in impl Sized for &'71 i32}]}, {built_in impl Sized for {closure}<'73>}, impl_LendingIterator_for_Option<'71, i32>[{built_in impl Sized for i32}], impl_FnMut_tuple_for_closure<'73, '120>](move _6, move _7)
+    _5 = for_each<Option<&'76 i32>[{built_in impl Sized for &'76 i32}], {closure}<'78>>[{built_in impl Sized for Option<&'76 i32>[{built_in impl Sized for &'76 i32}]}, {built_in impl Sized for {closure}<'78>}, impl_LendingIterator_for_Option<'76, i32>[{built_in impl Sized for i32}], impl_FnMut_tuple_for_closure<'78, '137>](move _6, move _7)
     ↳⚡ storage_dead(_25)
         storage_dead(_24)
         storage_dead(_23)

--- a/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
+++ b/charon/tests/ui/simple/pass-higher-kinded-fn-item-as-closure.out
@@ -196,7 +196,7 @@ pub fn flibidi()
     storage_live(_0)
     _0 = ()
     storage_live(_1)
-    _1 = test_crate::call<'0, for<'a> flabada<'a>>[{built_in impl Sized for for<'a> flabada<'a>}, {impl Fn<(&'a (),), &'a ()> for for<'a> flabada<'a>}<'0>](const flabada<'11>)
+    _1 = test_crate::call<'0, for<'a> flabada<'a>>[{built_in impl Sized for for<'a> flabada<'a>}, {impl Fn<(&'a (),), &'a ()> for for<'a> flabada<'a>}<'0>](const flabada<'12>)
     ↳⚡ unwind_continue
     storage_dead(_1)
     _0 = ()

--- a/charon/tests/ui/simple/slice_index_range.out
+++ b/charon/tests/ui/simple/slice_index_range.out
@@ -17,22 +17,22 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     let start: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 57usize]; // anonymous local
-    let _13: &'34 [u8; 57usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 57usize]; // anonymous local
+    let _13: &'36 [u8; 57usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 57usize]; // anonymous local
-    let _19: &'66 [u8; 57usize]; // anonymous local
+    let _19: &'68 [u8; 57usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -51,7 +51,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -65,7 +65,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -90,7 +90,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = core::fmt::{Arguments<'a>}::new<'71, 57usize, 2usize>(move _12, move _14)
+    _3 = core::fmt::{Arguments<'a>}::new<'73, 57usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -122,22 +122,22 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     let end: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 55usize]; // anonymous local
-    let _13: &'34 [u8; 55usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 55usize]; // anonymous local
+    let _13: &'36 [u8; 55usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 55usize]; // anonymous local
-    let _19: &'66 [u8; 55usize]; // anonymous local
+    let _19: &'68 [u8; 55usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -156,7 +156,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -170,7 +170,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -195,7 +195,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = core::fmt::{Arguments<'a>}::new<'71, 55usize, 2usize>(move _12, move _14)
+    _3 = core::fmt::{Arguments<'a>}::new<'73, 55usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -227,22 +227,22 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     let start: usize; // arg #1
     let end: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 40usize]; // anonymous local
-    let _13: &'34 [u8; 40usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 40usize]; // anonymous local
+    let _13: &'36 [u8; 40usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 40usize]; // anonymous local
-    let _19: &'66 [u8; 40usize]; // anonymous local
+    let _19: &'68 [u8; 40usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -261,7 +261,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -275,7 +275,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -300,7 +300,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = core::fmt::{Arguments<'a>}::new<'71, 40usize, 2usize>(move _12, move _14)
+    _3 = core::fmt::{Arguments<'a>}::new<'73, 40usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -332,22 +332,22 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     let end: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 55usize]; // anonymous local
-    let _13: &'34 [u8; 55usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 55usize]; // anonymous local
+    let _13: &'36 [u8; 55usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 55usize]; // anonymous local
-    let _19: &'66 [u8; 55usize]; // anonymous local
+    let _19: &'68 [u8; 55usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -366,7 +366,7 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#7}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -380,7 +380,7 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#7}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -405,7 +405,7 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = core::fmt::{Arguments<'a>}::new<'71, 55usize, 2usize>(move _12, move _14)
+    _3 = core::fmt::{Arguments<'a>}::new<'73, 55usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -884,9 +884,9 @@ where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_0,
 {
-    let _0: Option<&'6 [T]>[{built_in impl Sized for &'6 [T]}]; // return
+    let _0: Option<&'8 [T]>[{built_in impl Sized for &'8 [T]}]; // return
     let self: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice: &'10 [T]; // arg #2
+    let slice: &'12 [T]; // arg #2
     let _3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _4: usize; // anonymous local
     let _5: usize; // anonymous local
@@ -894,9 +894,9 @@ where
     let _7: bool; // anonymous local
     let _8: usize; // anonymous local
     let _9: usize; // anonymous local
-    let _10: &'11 [T]; // anonymous local
-    let _11: &'12 [T]; // anonymous local
-    let _12: &'13 [T]; // anonymous local
+    let _10: &'13 [T]; // anonymous local
+    let _11: &'14 [T]; // anonymous local
+    let _12: &'15 [T]; // anonymous local
     let _13: *const [T]; // anonymous local
     let _14: *const [T]; // anonymous local
     let _15: usize; // anonymous local
@@ -924,7 +924,7 @@ where
             storage_live(_9)
             storage_live(_10)
             _10 = &(*slice) with_metadata(copy slice.metadata)
-            _9 = core::slice::{[T]}::len<'15, T>[TraitClause0](move _10)
+            _9 = core::slice::{[T]}::len<'17, T>[TraitClause0](move _10)
             ↳⚡ storage_dead(slice)
                 storage_dead(self)
                 unwind_continue
@@ -984,9 +984,9 @@ where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_0,
 {
-    let _0: Option<&'6 mut [T]>[{built_in impl Sized for &'6 mut [T]}]; // return
+    let _0: Option<&'8 mut [T]>[{built_in impl Sized for &'8 mut [T]}]; // return
     let self: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice: &'10 mut [T]; // arg #2
+    let slice: &'12 mut [T]; // arg #2
     let _3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _4: usize; // anonymous local
     let _5: usize; // anonymous local
@@ -994,9 +994,9 @@ where
     let _7: bool; // anonymous local
     let _8: usize; // anonymous local
     let _9: usize; // anonymous local
-    let _10: &'12 [T]; // anonymous local
-    let _11: &'13 mut [T]; // anonymous local
-    let _12: &'14 mut [T]; // anonymous local
+    let _10: &'14 [T]; // anonymous local
+    let _11: &'15 mut [T]; // anonymous local
+    let _12: &'16 mut [T]; // anonymous local
     let _13: *mut [T]; // anonymous local
     let _14: *mut [T]; // anonymous local
     let _15: usize; // anonymous local
@@ -1024,7 +1024,7 @@ where
             storage_live(_9)
             storage_live(_10)
             _10 = &(*slice) with_metadata(copy slice.metadata)
-            _9 = core::slice::{[T]}::len<'16, T>[TraitClause0](move _10)
+            _9 = core::slice::{[T]}::len<'18, T>[TraitClause0](move _10)
             ↳⚡ storage_dead(slice)
                 storage_dead(self)
                 unwind_continue
@@ -1830,18 +1830,18 @@ where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_0,
 {
-    let _0: Option<&'6 mut [T]>[{built_in impl Sized for &'6 mut [T]}]; // return
+    let _0: Option<&'8 mut [T]>[{built_in impl Sized for &'8 mut [T]}]; // return
     let self: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice: &'10 mut [T]; // arg #2
+    let slice: &'12 mut [T]; // arg #2
     let _3: bool; // anonymous local
     let _4: usize; // anonymous local
-    let _5: &'12 usize; // anonymous local
-    let _6: &'14 RangeInclusive<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _5: &'14 usize; // anonymous local
+    let _6: &'16 RangeInclusive<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _7: usize; // anonymous local
-    let _8: &'16 [T]; // anonymous local
+    let _8: &'18 [T]; // anonymous local
     let _9: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _10: RangeInclusive<usize>[{built_in impl Sized for usize}]; // anonymous local
-    let _11: &'17 mut [T]; // anonymous local
+    let _11: &'19 mut [T]; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
@@ -1849,7 +1849,7 @@ where
     storage_live(_5)
     storage_live(_6)
     _6 = &self
-    _5 = end<'19, usize>[{built_in impl Sized for usize}](move _6)
+    _5 = end<'21, usize>[{built_in impl Sized for usize}](move _6)
     ↳⚡ storage_dead(slice)
         storage_dead(self)
         unwind_continue
@@ -1858,7 +1858,7 @@ where
     storage_live(_7)
     storage_live(_8)
     _8 = &(*slice) with_metadata(copy slice.metadata)
-    _7 = core::slice::{[T]}::len<'21, T>[TraitClause0](move _8)
+    _7 = core::slice::{[T]}::len<'23, T>[TraitClause0](move _8)
     ↳⚡ storage_dead(slice)
         storage_dead(self)
         unwind_continue
@@ -1879,7 +1879,7 @@ where
         storage_dead(_10)
         storage_live(_11)
         _11 = &two-phase-mut (*slice) with_metadata(copy slice.metadata)
-        _0 = impl_SliceIndex_slice_for_Range_usize::get_mut<'29, T>[TraitClause0](move _9, move _11)
+        _0 = impl_SliceIndex_slice_for_Range_usize::get_mut<'32, T>[TraitClause0](move _9, move _11)
         ↳⚡ storage_dead(slice)
             storage_dead(self)
             unwind_continue
@@ -1906,18 +1906,18 @@ where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_0,
 {
-    let _0: Option<&'6 [T]>[{built_in impl Sized for &'6 [T]}]; // return
+    let _0: Option<&'8 [T]>[{built_in impl Sized for &'8 [T]}]; // return
     let self: RangeInclusive<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice: &'10 [T]; // arg #2
+    let slice: &'12 [T]; // arg #2
     let _3: bool; // anonymous local
     let _4: usize; // anonymous local
-    let _5: &'12 usize; // anonymous local
-    let _6: &'14 RangeInclusive<usize>[{built_in impl Sized for usize}]; // anonymous local
+    let _5: &'14 usize; // anonymous local
+    let _6: &'16 RangeInclusive<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _7: usize; // anonymous local
-    let _8: &'15 [T]; // anonymous local
+    let _8: &'17 [T]; // anonymous local
     let _9: Range<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _10: RangeInclusive<usize>[{built_in impl Sized for usize}]; // anonymous local
-    let _11: &'16 [T]; // anonymous local
+    let _11: &'18 [T]; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
@@ -1925,7 +1925,7 @@ where
     storage_live(_5)
     storage_live(_6)
     _6 = &self
-    _5 = end<'18, usize>[{built_in impl Sized for usize}](move _6)
+    _5 = end<'20, usize>[{built_in impl Sized for usize}](move _6)
     ↳⚡ storage_dead(slice)
         storage_dead(self)
         unwind_continue
@@ -1934,7 +1934,7 @@ where
     storage_live(_7)
     storage_live(_8)
     _8 = &(*slice) with_metadata(copy slice.metadata)
-    _7 = core::slice::{[T]}::len<'20, T>[TraitClause0](move _8)
+    _7 = core::slice::{[T]}::len<'22, T>[TraitClause0](move _8)
     ↳⚡ storage_dead(slice)
         storage_dead(self)
         unwind_continue
@@ -1955,7 +1955,7 @@ where
         storage_dead(_10)
         storage_live(_11)
         _11 = &(*slice) with_metadata(copy slice.metadata)
-        _0 = impl_SliceIndex_slice_for_Range_usize::get<'28, T>[TraitClause0](move _9, move _11)
+        _0 = impl_SliceIndex_slice_for_Range_usize::get<'31, T>[TraitClause0](move _9, move _11)
         ↳⚡ storage_dead(slice)
             storage_dead(self)
             unwind_continue

--- a/charon/tests/ui/simple/thread-local.out
+++ b/charon/tests/ui/simple/thread-local.out
@@ -284,10 +284,10 @@ fn {impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_
     let _0: *const u32; // return
     let _1: &'1 test_crate::FOO::{const}::{closure}; // arg #1
     let tupled_args: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],); // arg #2
-    let __rust_std_internal_init: Option<&'8 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'8 mut Option<u32>[{built_in impl Sized for u32}]}]; // local
-    let _4: &'13 Storage<u32, ()>[{built_in impl Sized for u32}, {built_in impl Sized for ()}]; // anonymous local
-    let _5: &'14 Storage<u32, ()>[{built_in impl Sized for u32}, {built_in impl Sized for ()}]; // anonymous local
-    let _6: Option<&'15 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'15 mut Option<u32>[{built_in impl Sized for u32}]}]; // anonymous local
+    let __rust_std_internal_init: Option<&'10 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'10 mut Option<u32>[{built_in impl Sized for u32}]}]; // local
+    let _4: &'15 Storage<u32, ()>[{built_in impl Sized for u32}, {built_in impl Sized for ()}]; // anonymous local
+    let _5: &'16 Storage<u32, ()>[{built_in impl Sized for u32}, {built_in impl Sized for ()}]; // anonymous local
+    let _6: Option<&'17 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'17 mut Option<u32>[{built_in impl Sized for u32}]}]; // anonymous local
 
     storage_live(_0)
     storage_live(__rust_std_internal_init)
@@ -298,7 +298,7 @@ fn {impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_
     _4 = &(*_5)
     storage_live(_6)
     _6 = move __rust_std_internal_init
-    _0 = get_or_init<'21, '22, u32, (), __rust_std_internal_init_fn>[{built_in impl Sized for u32}, {built_in impl Sized for ()}, impl_DestroyedState_for_unit, {built_in impl Sized for __rust_std_internal_init_fn}, {impl FnOnce<()> for __rust_std_internal_init_fn}](move _4, move _6, const __rust_std_internal_init_fn)
+    _0 = get_or_init<'23, '24, u32, (), __rust_std_internal_init_fn>[{built_in impl Sized for u32}, {built_in impl Sized for ()}, impl_DestroyedState_for_unit, {built_in impl Sized for __rust_std_internal_init_fn}, {impl FnOnce<()> for __rust_std_internal_init_fn}](move _4, move _6, const __rust_std_internal_init_fn)
     ↳⚡ storage_dead(__rust_std_internal_init)
         storage_dead(tupled_args)
         storage_dead(_1)
@@ -339,14 +339,14 @@ fn {impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{bu
 {
     let _0: *const u32; // return
     let _1: test_crate::FOO::{const}::{closure}; // arg #1
-    let _2: (Option<&'10 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'10 mut Option<u32>[{built_in impl Sized for u32}]}],); // arg #2
-    let _3: &'15 mut test_crate::FOO::{const}::{closure}; // anonymous local
+    let _2: (Option<&'12 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'12 mut Option<u32>[{built_in impl Sized for u32}]}],); // arg #2
+    let _3: &'17 mut test_crate::FOO::{const}::{closure}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_mut<'_0, '32>(move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::FOO::{const}::{closure}}::drop_glue<'33>] _1
+    _0 = {impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure}}::call_mut<'_0, '35>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::FOO::{const}::{closure}}::drop_glue<'36>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -355,7 +355,7 @@ fn {impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{bu
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::FOO::{const}::{closure}}::drop_glue<'34>] _1
+    drop[{impl Destruct for test_crate::FOO::{const}::{closure}}::drop_glue<'37>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)
@@ -458,10 +458,10 @@ fn {impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_
     let _0: *const u32; // return
     let _1: &'1 test_crate::FOO::{const}::{closure#1}; // arg #1
     let tupled_args: (Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],); // arg #2
-    let __rust_std_internal_init: Option<&'8 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'8 mut Option<u32>[{built_in impl Sized for u32}]}]; // local
-    let _4: &'13 Storage<u32, !>[{built_in impl Sized for u32}, {built_in impl Sized for !}]; // anonymous local
-    let _5: &'14 Storage<u32, !>[{built_in impl Sized for u32}, {built_in impl Sized for !}]; // anonymous local
-    let _6: Option<&'15 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'15 mut Option<u32>[{built_in impl Sized for u32}]}]; // anonymous local
+    let __rust_std_internal_init: Option<&'10 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'10 mut Option<u32>[{built_in impl Sized for u32}]}]; // local
+    let _4: &'15 Storage<u32, !>[{built_in impl Sized for u32}, {built_in impl Sized for !}]; // anonymous local
+    let _5: &'16 Storage<u32, !>[{built_in impl Sized for u32}, {built_in impl Sized for !}]; // anonymous local
+    let _6: Option<&'17 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'17 mut Option<u32>[{built_in impl Sized for u32}]}]; // anonymous local
 
     storage_live(_0)
     storage_live(__rust_std_internal_init)
@@ -472,7 +472,7 @@ fn {impl Fn<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_
     _4 = &(*_5)
     storage_live(_6)
     _6 = move __rust_std_internal_init
-    _0 = get_or_init<'21, '22, u32, !, __rust_std_internal_init_fn>[{built_in impl Sized for u32}, {built_in impl Sized for !}, {impl DestroyedState for !}, {built_in impl Sized for __rust_std_internal_init_fn}, {impl FnOnce<()> for __rust_std_internal_init_fn}](move _4, move _6, const __rust_std_internal_init_fn)
+    _0 = get_or_init<'23, '24, u32, !, __rust_std_internal_init_fn>[{built_in impl Sized for u32}, {built_in impl Sized for !}, {impl DestroyedState for !}, {built_in impl Sized for __rust_std_internal_init_fn}, {impl FnOnce<()> for __rust_std_internal_init_fn}](move _4, move _6, const __rust_std_internal_init_fn)
     ↳⚡ storage_dead(__rust_std_internal_init)
         storage_dead(tupled_args)
         storage_dead(_1)
@@ -513,14 +513,14 @@ fn {impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{bu
 {
     let _0: *const u32; // return
     let _1: test_crate::FOO::{const}::{closure#1}; // arg #1
-    let _2: (Option<&'10 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'10 mut Option<u32>[{built_in impl Sized for u32}]}],); // arg #2
-    let _3: &'15 mut test_crate::FOO::{const}::{closure#1}; // anonymous local
+    let _2: (Option<&'12 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'12 mut Option<u32>[{built_in impl Sized for u32}]}],); // arg #2
+    let _3: &'17 mut test_crate::FOO::{const}::{closure#1}; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
     _3 = &mut _1
-    _0 = {impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_mut<'_0, '32>(move _3, move _2)
-    ↳⚡ drop[{impl Destruct for test_crate::FOO::{const}::{closure#1}}::drop_glue<'33>] _1
+    _0 = {impl FnMut<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{built_in impl Sized for &'_0 mut Option<u32>[{built_in impl Sized for u32}]}],)> for test_crate::FOO::{const}::{closure#1}}::call_mut<'_0, '35>(move _3, move _2)
+    ↳⚡ drop[{impl Destruct for test_crate::FOO::{const}::{closure#1}}::drop_glue<'36>] _1
         ↳⚡ storage_dead(_3)
             storage_dead(_2)
             storage_dead(_1)
@@ -529,7 +529,7 @@ fn {impl FnOnce<(Option<&'_0 mut Option<u32>[{built_in impl Sized for u32}]>[{bu
         storage_dead(_2)
         storage_dead(_1)
         unwind_continue
-    drop[{impl Destruct for test_crate::FOO::{const}::{closure#1}}::drop_glue<'34>] _1
+    drop[{impl Destruct for test_crate::FOO::{const}::{closure#1}}::drop_glue<'37>] _1
     ↳⚡ storage_dead(_3)
         storage_dead(_2)
         storage_dead(_1)

--- a/charon/tests/ui/simple/well-formedness-bound.out
+++ b/charon/tests/ui/simple/well-formedness-bound.out
@@ -29,9 +29,9 @@ struct () {}
 
 pub fn test_crate::get<'a>(x: &'a u32) -> Option<&'a u32>[{built_in impl Sized for &'a u32}]
 {
-    let _0: Option<&'6 u32>[{built_in impl Sized for &'6 u32}]; // return
-    let x: &'10 u32; // arg #1
-    let _2: &'11 u32; // anonymous local
+    let _0: Option<&'8 u32>[{built_in impl Sized for &'8 u32}]; // return
+    let x: &'12 u32; // arg #1
+    let _2: &'13 u32; // anonymous local
 
     storage_live(_0)
     storage_live(_2)

--- a/charon/tests/ui/slice-index-range.out
+++ b/charon/tests/ui/slice-index-range.out
@@ -55,22 +55,22 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     let start: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 57usize]; // anonymous local
-    let _13: &'34 [u8; 57usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 57usize]; // anonymous local
+    let _13: &'36 [u8; 57usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 57usize]; // anonymous local
-    let _19: &'66 [u8; 57usize]; // anonymous local
+    let _19: &'68 [u8; 57usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -89,7 +89,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -103,7 +103,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -128,7 +128,7 @@ fn core::slice::index::slice_index_fail::do_panic::runtime(start: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = new<'71, 57usize, 2usize>(move _12, move _14)
+    _3 = new<'73, 57usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -160,22 +160,22 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     let end: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 55usize]; // anonymous local
-    let _13: &'34 [u8; 55usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 55usize]; // anonymous local
+    let _13: &'36 [u8; 55usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 55usize]; // anonymous local
-    let _19: &'66 [u8; 55usize]; // anonymous local
+    let _19: &'68 [u8; 55usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -194,7 +194,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -208,7 +208,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -233,7 +233,7 @@ fn core::slice::index::slice_index_fail::do_panic#1::runtime(end: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = new<'71, 55usize, 2usize>(move _12, move _14)
+    _3 = new<'73, 55usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -265,22 +265,22 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     let start: usize; // arg #1
     let end: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 40usize]; // anonymous local
-    let _13: &'34 [u8; 40usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 40usize]; // anonymous local
+    let _13: &'36 [u8; 40usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 40usize]; // anonymous local
-    let _19: &'66 [u8; 40usize]; // anonymous local
+    let _19: &'68 [u8; 40usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -299,7 +299,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -313,7 +313,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -338,7 +338,7 @@ fn core::slice::index::slice_index_fail::do_panic#2::runtime(start: usize, end: 
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = new<'71, 40usize, 2usize>(move _12, move _14)
+    _3 = new<'73, 40usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -370,22 +370,22 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     let end: usize; // arg #1
     let len: usize; // arg #2
     let _3: Arguments<'1>; // anonymous local
-    let args_4: (&'10 usize, &'11 usize); // local
-    let _5: &'15 usize; // anonymous local
-    let _6: &'16 usize; // anonymous local
-    let args_7: [Argument<'24>; 2usize]; // local
-    let _8: Argument<'28>; // anonymous local
-    let _9: &'29 usize; // anonymous local
-    let _10: Argument<'30>; // anonymous local
-    let _11: &'31 usize; // anonymous local
-    let _12: &'33 [u8; 55usize]; // anonymous local
-    let _13: &'34 [u8; 55usize]; // anonymous local
-    let _14: &'40 [Argument<'41>; 2usize]; // anonymous local
-    let _15: &'45 [Argument<'46>; 2usize]; // anonymous local
-    let _16: &'50 usize; // anonymous local
-    let _17: &'51 usize; // anonymous local
+    let args_4: (&'11 usize, &'12 usize); // local
+    let _5: &'16 usize; // anonymous local
+    let _6: &'17 usize; // anonymous local
+    let args_7: [Argument<'26>; 2usize]; // local
+    let _8: Argument<'30>; // anonymous local
+    let _9: &'31 usize; // anonymous local
+    let _10: Argument<'32>; // anonymous local
+    let _11: &'33 usize; // anonymous local
+    let _12: &'35 [u8; 55usize]; // anonymous local
+    let _13: &'36 [u8; 55usize]; // anonymous local
+    let _14: &'42 [Argument<'43>; 2usize]; // anonymous local
+    let _15: &'47 [Argument<'48>; 2usize]; // anonymous local
+    let _16: &'52 usize; // anonymous local
+    let _17: &'53 usize; // anonymous local
     let _18: [u8; 55usize]; // anonymous local
-    let _19: &'66 [u8; 55usize]; // anonymous local
+    let _19: &'68 [u8; 55usize]; // anonymous local
 
     storage_live(_0)
     storage_live(_16)
@@ -404,7 +404,7 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(_9)
     _16 = copy args_4._0
     _9 = &(*_16)
-    _8 = new_display<'58, '60, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
+    _8 = new_display<'60, '62, usize>[{built_in impl Sized for usize}, {impl#6}](move _9)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -418,7 +418,7 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(_11)
     _17 = copy args_4._1
     _11 = &(*_17)
-    _10 = new_display<'62, '64, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
+    _10 = new_display<'64, '66, usize>[{built_in impl Sized for usize}, {impl#6}](move _11)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -443,7 +443,7 @@ fn core::slice::index::slice_index_fail::do_panic#3::runtime(end: usize, len: us
     storage_live(_15)
     _15 = &args_7
     _14 = &(*_15)
-    _3 = new<'71, 55usize, 2usize>(move _12, move _14)
+    _3 = new<'73, 55usize, 2usize>(move _12, move _14)
     ↳⚡ storage_dead(_17)
         storage_dead(_16)
         storage_dead(args_7)
@@ -1585,9 +1585,9 @@ where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_0,
 {
-    let _0: Option<&'6 mut [T]>[{built_in impl Sized for &'6 mut [T]}]; // return
+    let _0: Option<&'8 mut [T]>[{built_in impl Sized for &'8 mut [T]}]; // return
     let self: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice: &'10 mut [T]; // arg #2
+    let slice: &'12 mut [T]; // arg #2
     let _3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _4: usize; // anonymous local
     let _5: usize; // anonymous local
@@ -1595,9 +1595,9 @@ where
     let _7: bool; // anonymous local
     let _8: usize; // anonymous local
     let _9: usize; // anonymous local
-    let _10: &'12 [T]; // anonymous local
-    let _11: &'13 mut [T]; // anonymous local
-    let _12: &'14 mut [T]; // anonymous local
+    let _10: &'14 [T]; // anonymous local
+    let _11: &'15 mut [T]; // anonymous local
+    let _12: &'16 mut [T]; // anonymous local
     let _13: *mut [T]; // anonymous local
     let _14: *mut [T]; // anonymous local
     let _15: usize; // anonymous local
@@ -1625,7 +1625,7 @@ where
             storage_live(_9)
             storage_live(_10)
             _10 = &(*slice) with_metadata(copy slice.metadata)
-            _9 = core::slice::{[T]}::len<'16, T>[TraitClause0](move _10)
+            _9 = core::slice::{[T]}::len<'18, T>[TraitClause0](move _10)
             ↳⚡ storage_dead(slice)
                 storage_dead(self)
                 unwind_continue
@@ -1685,9 +1685,9 @@ where
     TraitClause0: (T: Sized),
     TypeOutlives0: T: '_0,
 {
-    let _0: Option<&'6 [T]>[{built_in impl Sized for &'6 [T]}]; // return
+    let _0: Option<&'8 [T]>[{built_in impl Sized for &'8 [T]}]; // return
     let self: Range<usize>[{built_in impl Sized for usize}]; // arg #1
-    let slice: &'10 [T]; // arg #2
+    let slice: &'12 [T]; // arg #2
     let _3: Option<usize>[{built_in impl Sized for usize}]; // anonymous local
     let _4: usize; // anonymous local
     let _5: usize; // anonymous local
@@ -1695,9 +1695,9 @@ where
     let _7: bool; // anonymous local
     let _8: usize; // anonymous local
     let _9: usize; // anonymous local
-    let _10: &'11 [T]; // anonymous local
-    let _11: &'12 [T]; // anonymous local
-    let _12: &'13 [T]; // anonymous local
+    let _10: &'13 [T]; // anonymous local
+    let _11: &'14 [T]; // anonymous local
+    let _12: &'15 [T]; // anonymous local
     let _13: *const [T]; // anonymous local
     let _14: *const [T]; // anonymous local
     let _15: usize; // anonymous local
@@ -1725,7 +1725,7 @@ where
             storage_live(_9)
             storage_live(_10)
             _10 = &(*slice) with_metadata(copy slice.metadata)
-            _9 = core::slice::{[T]}::len<'15, T>[TraitClause0](move _10)
+            _9 = core::slice::{[T]}::len<'17, T>[TraitClause0](move _10)
             ↳⚡ storage_dead(slice)
                 storage_dead(self)
                 unwind_continue

--- a/charon/tests/ui/traits.out
+++ b/charon/tests/ui/traits.out
@@ -1548,8 +1548,8 @@ impl "impl_RecursiveImpl_for_unit" RecursiveImpl for () {
 // Full name: test_crate::flabada
 pub fn flabada<'a>(_x: &'a ()) -> Wrapper<(bool, &'a ())>[{built_in impl Sized for (bool, &'a ())}]
 {
-    let _0: Wrapper<(bool, &'8 ())>[{built_in impl Sized for (bool, &'8 ())}]; // return
-    let _x: &'12 (); // arg #1
+    let _0: Wrapper<(bool, &'12 ())>[{built_in impl Sized for (bool, &'12 ())}]; // return
+    let _x: &'16 (); // arg #1
 
     storage_live(_0)
     storage_dead(_x)
@@ -1666,7 +1666,7 @@ pub fn flibidi()
     storage_live(_0)
     _0 = ()
     storage_live(_1)
-    _1 = test_crate::call<'0, for<'a> flabada<'a>>[{built_in impl Sized for for<'a> flabada<'a>}, {impl Fn<(&'a (),)> for for<'a> flabada<'a>}<'0>](const flabada<'11>)
+    _1 = test_crate::call<'0, for<'a> flabada<'a>>[{built_in impl Sized for for<'a> flabada<'a>}, {impl Fn<(&'a (),)> for for<'a> flabada<'a>}<'0>](const flabada<'12>)
     ↳⚡ unwind_continue
     storage_dead(_1)
     _0 = ()

--- a/charon/tests/ui/type_inference_is_order_dependent.out
+++ b/charon/tests/ui/type_inference_is_order_dependent.out
@@ -93,15 +93,15 @@ where
     let args_3: (&'4 U,); // local
     let _4: &'5 U; // anonymous local
     let _5: U; // anonymous local
-    let args_6: [Argument<'13>; 1usize]; // local
-    let _7: Argument<'17>; // anonymous local
-    let _8: &'18 U; // anonymous local
-    let _9: &'20 [u8; 4usize]; // anonymous local
-    let _10: &'21 [u8; 4usize]; // anonymous local
-    let _11: &'27 [Argument<'28>; 1usize]; // anonymous local
-    let _12: &'32 [Argument<'33>; 1usize]; // anonymous local
+    let args_6: [Argument<'14>; 1usize]; // local
+    let _7: Argument<'18>; // anonymous local
+    let _8: &'19 U; // anonymous local
+    let _9: &'21 [u8; 4usize]; // anonymous local
+    let _10: &'22 [u8; 4usize]; // anonymous local
+    let _11: &'28 [Argument<'29>; 1usize]; // anonymous local
+    let _12: &'33 [Argument<'34>; 1usize]; // anonymous local
     let _13: [u8; 4usize]; // anonymous local
-    let _14: &'44 [u8; 4usize]; // anonymous local
+    let _14: &'45 [u8; 4usize]; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -120,8 +120,8 @@ where
     storage_live(_7)
     storage_live(_8)
     _8 = &(*args_3._0)
-    _7 = new_debug<'39, '41, U>[TraitClause1, TraitClause5](move _8)
-    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'42>] _5
+    _7 = new_debug<'40, '42, U>[TraitClause1, TraitClause5](move _8)
+    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'43>] _5
         ↳⚡ storage_dead(_14)
             storage_dead(_13)
             unwind_terminate
@@ -142,8 +142,8 @@ where
     storage_live(_12)
     _12 = &args_6
     _11 = &(*_12)
-    _2 = new<'49, 4usize, 1usize>(move _9, move _11)
-    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'42>] _5
+    _2 = new<'50, 4usize, 1usize>(move _9, move _11)
+    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'43>] _5
         ↳⚡ storage_dead(_14)
             storage_dead(_13)
             unwind_terminate
@@ -152,15 +152,15 @@ where
     storage_dead(_11)
     storage_dead(_10)
     storage_dead(_9)
-    _1 = _print<'51>(move _2)
-    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'42>] _5
+    _1 = _print<'52>(move _2)
+    ↳⚡ conditional_drop[{built_in impl Destruct for U}::drop_glue<'43>] _5
         ↳⚡ storage_dead(_14)
             storage_dead(_13)
             unwind_terminate
         unwind_continue
     storage_dead(_2)
     storage_dead(args_6)
-    conditional_drop[{built_in impl Destruct for U}::drop_glue<'52>] _5
+    conditional_drop[{built_in impl Destruct for U}::drop_glue<'53>] _5
     ↳⚡ unwind_continue
     storage_dead(_5)
     storage_dead(args_3)

--- a/charon/tests/ui/unsize.out
+++ b/charon/tests/ui/unsize.out
@@ -315,22 +315,22 @@ fn foo()
     let _18: &'8 (dyn Display + '9); // anonymous local
     let _19: &'11 String; // anonymous local
     let _20: &'12 String; // anonymous local
-    let _21: Box<(dyn Display + '17)>[{built_in impl MetaSized for (dyn Display + '19)}, {built_in impl Sized for Global}]; // anonymous local
+    let _21: Box<(dyn Display + '18)>[{built_in impl MetaSized for (dyn Display + '20)}, {built_in impl Sized for Global}]; // anonymous local
     let _22: Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
     let _23: String; // anonymous local
-    let _24: &'20 String; // anonymous local
-    let _25: Rc<(dyn Display + '25)>[{built_in impl MetaSized for (dyn Display + '27)}, {built_in impl Sized for Global}]; // anonymous local
+    let _24: &'21 String; // anonymous local
+    let _25: Rc<(dyn Display + '27)>[{built_in impl MetaSized for (dyn Display + '29)}, {built_in impl Sized for Global}]; // anonymous local
     let _26: Rc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
     let _27: String; // anonymous local
-    let _28: &'28 String; // anonymous local
-    let _29: Arc<(dyn Display + '33)>[{built_in impl MetaSized for (dyn Display + '35)}, {built_in impl Sized for Global}]; // anonymous local
+    let _28: &'30 String; // anonymous local
+    let _29: Arc<(dyn Display + '36)>[{built_in impl MetaSized for (dyn Display + '38)}, {built_in impl Sized for Global}]; // anonymous local
     let _30: Arc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]; // anonymous local
     let _31: String; // anonymous local
-    let _32: &'36 String; // anonymous local
-    let _33: MyPtr<(dyn Display + '41)>[{built_in impl MetaSized for (dyn Display + '43)}]; // anonymous local
+    let _32: &'39 String; // anonymous local
+    let _33: MyPtr<(dyn Display + '45)>[{built_in impl MetaSized for (dyn Display + '47)}]; // anonymous local
     let _34: MyPtr<String>[{built_in impl MetaSized for String}]; // anonymous local
     let _35: String; // anonymous local
-    let _36: &'44 String; // anonymous local
+    let _36: &'48 String; // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -347,7 +347,7 @@ fn foo()
     _2 = as_slice<'_, i32, 2usize>[{built_in impl Sized for i32}](move _3)
     ↳⚡ undefined_behavior
     storage_dead(_3)
-    set_type(typeof(_2) <= &'46 [i32])
+    set_type(typeof(_2) <= &'50 [i32])
     storage_dead(_4)
     storage_dead(_2)
     storage_live(_5)
@@ -357,14 +357,14 @@ fn foo()
     _6 = alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<[i32; 2usize]>[{built_in impl Sized for [i32; 2usize]}](move _7)
     ↳⚡ unwind_continue
     _5 = unsize_cast<Box<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}], Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 2usize>(move _6)
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'47, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _6
-    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'49, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'51, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _6
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'53, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_7)
     storage_dead(_6)
     set_type(typeof(_5) <= Box<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'48, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'52, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _5
     ↳⚡ unwind_continue
     storage_dead(_5)
     storage_live(_8)
@@ -374,14 +374,14 @@ fn foo()
     _9 = alloc::rc::{Rc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<[i32; 2usize]>[{built_in impl Sized for [i32; 2usize]}](move _10)
     ↳⚡ unwind_continue
     _8 = unsize_cast<Rc<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}], Rc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 2usize>(move _9)
-    conditional_drop[impl_Destruct_for_Rc::drop_glue<'50, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _9
-    ↳⚡ conditional_drop[impl_Destruct_for_Rc::drop_glue<'52, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _8
+    conditional_drop[impl_Destruct_for_Rc::drop_glue<'54, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _9
+    ↳⚡ conditional_drop[impl_Destruct_for_Rc::drop_glue<'56, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _8
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_10)
     storage_dead(_9)
     set_type(typeof(_8) <= Rc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Rc::drop_glue<'51, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _8
+    conditional_drop[impl_Destruct_for_Rc::drop_glue<'55, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _8
     ↳⚡ unwind_continue
     storage_dead(_8)
     storage_live(_11)
@@ -391,14 +391,14 @@ fn foo()
     _12 = alloc::sync::{Arc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<[i32; 2usize]>[{built_in impl Sized for [i32; 2usize]}](move _13)
     ↳⚡ unwind_continue
     _11 = unsize_cast<Arc<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}], Arc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}], 2usize>(move _12)
-    conditional_drop[impl_Destruct_for_Arc::drop_glue<'53, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _12
-    ↳⚡ conditional_drop[impl_Destruct_for_Arc::drop_glue<'55, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _11
+    conditional_drop[impl_Destruct_for_Arc::drop_glue<'57, [i32; 2usize], Global>[{built_in impl MetaSized for [i32; 2usize]}, {built_in impl Sized for Global}]] _12
+    ↳⚡ conditional_drop[impl_Destruct_for_Arc::drop_glue<'59, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _11
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_13)
     storage_dead(_12)
     set_type(typeof(_11) <= Arc<[i32]>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Arc::drop_glue<'54, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _11
+    conditional_drop[impl_Destruct_for_Arc::drop_glue<'58, [i32], Global>[{built_in impl MetaSized for [i32]}, {built_in impl Sized for Global}]] _11
     ↳⚡ unwind_continue
     storage_dead(_11)
     storage_live(_14)
@@ -408,14 +408,14 @@ fn foo()
     _15 = test_crate::{MyPtr<T>[TraitClause0::ImpliedClause0]}::new<[i32; 2usize]>[{built_in impl Sized for [i32; 2usize]}](move _16)
     ↳⚡ unwind_continue
     _14 = unsize_cast<MyPtr<[i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}], MyPtr<[i32]>[{built_in impl MetaSized for [i32]}], 2usize>(move _15)
-    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'56, [i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}]] _15
-    ↳⚡ conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'58, [i32]>[{built_in impl MetaSized for [i32]}]] _14
+    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'60, [i32; 2usize]>[{built_in impl MetaSized for [i32; 2usize]}]] _15
+    ↳⚡ conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'62, [i32]>[{built_in impl MetaSized for [i32]}]] _14
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_16)
     storage_dead(_15)
     set_type(typeof(_14) <= MyPtr<[i32]>[{built_in impl MetaSized for [i32]}])
-    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'57, [i32]>[{built_in impl MetaSized for [i32]}]] _14
+    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'61, [i32]>[{built_in impl MetaSized for [i32]}]] _14
     ↳⚡ unwind_continue
     storage_dead(_14)
     storage_live(string)
@@ -427,9 +427,9 @@ fn foo()
     storage_live(_20)
     _20 = &string
     _19 = &(*_20)
-    _18 = unsize_cast<&'11 String, &'59 (dyn Display + '60), &impl_Display_for_String::{vtable}>(move _19)
+    _18 = unsize_cast<&'11 String, &'63 (dyn Display + '64), &impl_Display_for_String::{vtable}>(move _19)
     storage_dead(_19)
-    set_type(typeof(_18) <= &'61 (dyn Display + '62))
+    set_type(typeof(_18) <= &'65 (dyn Display + '66))
     storage_dead(_20)
     storage_dead(_18)
     storage_live(_21)
@@ -437,31 +437,31 @@ fn foo()
     storage_live(_23)
     storage_live(_24)
     _24 = &string
-    _23 = impl_Clone_for_String::clone<'64>(move _24)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    _23 = impl_Clone_for_String::clone<'68>(move _24)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_24)
     _22 = alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<String>[{built_in impl Sized for String}](move _23)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'66>] _23
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'70>] _23
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
-    _21 = unsize_cast<Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Box<(dyn Display + '67)>[{built_in impl MetaSized for (dyn Display + '69)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _22)
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'70, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _22
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'87>] _23
+    _21 = unsize_cast<Box<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Box<(dyn Display + '71)>[{built_in impl MetaSized for (dyn Display + '73)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _22)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'74, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _22
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'93>] _23
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_Box::drop_glue<'102, (dyn Display + '98), Global>[{built_in impl MetaSized for (dyn Display + '98)}, {built_in impl Sized for Global}]] _21
+        conditional_drop[impl_Destruct_for_Box::drop_glue<'110, (dyn Display + '105), Global>[{built_in impl MetaSized for (dyn Display + '105)}, {built_in impl Sized for Global}]] _21
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_23)
     storage_dead(_22)
-    set_type(typeof(_21) <= Box<(dyn Display + '71)>[{built_in impl MetaSized for (dyn Display + '73)}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Box::drop_glue<'86, (dyn Display + '82), Global>[{built_in impl MetaSized for (dyn Display + '82)}, {built_in impl Sized for Global}]] _21
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    set_type(typeof(_21) <= Box<(dyn Display + '75)>[{built_in impl MetaSized for (dyn Display + '77)}, {built_in impl Sized for Global}])
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'92, (dyn Display + '87), Global>[{built_in impl MetaSized for (dyn Display + '87)}, {built_in impl Sized for Global}]] _21
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_21)
@@ -470,31 +470,31 @@ fn foo()
     storage_live(_27)
     storage_live(_28)
     _28 = &string
-    _27 = impl_Clone_for_String::clone<'89>(move _28)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    _27 = impl_Clone_for_String::clone<'95>(move _28)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_28)
     _26 = alloc::rc::{Rc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<String>[{built_in impl Sized for String}](move _27)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'103>] _27
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'111>] _27
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
-    _25 = unsize_cast<Rc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Rc<(dyn Display + '104)>[{built_in impl MetaSized for (dyn Display + '106)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _26)
-    conditional_drop[impl_Destruct_for_Rc::drop_glue<'107, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _26
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'124>] _27
+    _25 = unsize_cast<Rc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Rc<(dyn Display + '112)>[{built_in impl MetaSized for (dyn Display + '114)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _26)
+    conditional_drop[impl_Destruct_for_Rc::drop_glue<'115, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _26
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'134>] _27
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_Rc::drop_glue<'139, (dyn Display + '135), Global>[{built_in impl MetaSized for (dyn Display + '135)}, {built_in impl Sized for Global}]] _25
+        conditional_drop[impl_Destruct_for_Rc::drop_glue<'151, (dyn Display + '146), Global>[{built_in impl MetaSized for (dyn Display + '146)}, {built_in impl Sized for Global}]] _25
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_27)
     storage_dead(_26)
-    set_type(typeof(_25) <= Rc<(dyn Display + '108)>[{built_in impl MetaSized for (dyn Display + '110)}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Rc::drop_glue<'123, (dyn Display + '119), Global>[{built_in impl MetaSized for (dyn Display + '119)}, {built_in impl Sized for Global}]] _25
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    set_type(typeof(_25) <= Rc<(dyn Display + '116)>[{built_in impl MetaSized for (dyn Display + '118)}, {built_in impl Sized for Global}])
+    conditional_drop[impl_Destruct_for_Rc::drop_glue<'133, (dyn Display + '128), Global>[{built_in impl MetaSized for (dyn Display + '128)}, {built_in impl Sized for Global}]] _25
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_25)
@@ -503,31 +503,31 @@ fn foo()
     storage_live(_31)
     storage_live(_32)
     _32 = &string
-    _31 = impl_Clone_for_String::clone<'126>(move _32)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    _31 = impl_Clone_for_String::clone<'136>(move _32)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_32)
     _30 = alloc::sync::{Arc<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new<String>[{built_in impl Sized for String}](move _31)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'140>] _31
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'152>] _31
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
-    _29 = unsize_cast<Arc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Arc<(dyn Display + '141)>[{built_in impl MetaSized for (dyn Display + '143)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _30)
-    conditional_drop[impl_Destruct_for_Arc::drop_glue<'144, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _30
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'161>] _31
+    _29 = unsize_cast<Arc<String>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}], Arc<(dyn Display + '153)>[{built_in impl MetaSized for (dyn Display + '155)}, {built_in impl Sized for Global}], &impl_Display_for_String::{vtable}>(move _30)
+    conditional_drop[impl_Destruct_for_Arc::drop_glue<'156, String, Global>[{built_in impl MetaSized for String}, {built_in impl Sized for Global}]] _30
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'175>] _31
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_Arc::drop_glue<'176, (dyn Display + '172), Global>[{built_in impl MetaSized for (dyn Display + '172)}, {built_in impl Sized for Global}]] _29
+        conditional_drop[impl_Destruct_for_Arc::drop_glue<'192, (dyn Display + '187), Global>[{built_in impl MetaSized for (dyn Display + '187)}, {built_in impl Sized for Global}]] _29
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_31)
     storage_dead(_30)
-    set_type(typeof(_29) <= Arc<(dyn Display + '145)>[{built_in impl MetaSized for (dyn Display + '147)}, {built_in impl Sized for Global}])
-    conditional_drop[impl_Destruct_for_Arc::drop_glue<'160, (dyn Display + '156), Global>[{built_in impl MetaSized for (dyn Display + '156)}, {built_in impl Sized for Global}]] _29
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    set_type(typeof(_29) <= Arc<(dyn Display + '157)>[{built_in impl MetaSized for (dyn Display + '159)}, {built_in impl Sized for Global}])
+    conditional_drop[impl_Destruct_for_Arc::drop_glue<'174, (dyn Display + '169), Global>[{built_in impl MetaSized for (dyn Display + '169)}, {built_in impl Sized for Global}]] _29
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_29)
@@ -536,36 +536,36 @@ fn foo()
     storage_live(_35)
     storage_live(_36)
     _36 = &string
-    _35 = impl_Clone_for_String::clone<'163>(move _36)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    _35 = impl_Clone_for_String::clone<'177>(move _36)
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_36)
     _34 = test_crate::{MyPtr<T>[TraitClause0::ImpliedClause0]}::new<String>[{built_in impl Sized for String}](move _35)
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'177>] _35
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'193>] _35
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
-    _33 = unsize_cast<MyPtr<String>[{built_in impl MetaSized for String}], MyPtr<(dyn Display + '178)>[{built_in impl MetaSized for (dyn Display + '180)}], &impl_Display_for_String::{vtable}>(move _34)
-    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'181, String>[{built_in impl MetaSized for String}]] _34
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'198>] _35
+    _33 = unsize_cast<MyPtr<String>[{built_in impl MetaSized for String}], MyPtr<(dyn Display + '194)>[{built_in impl MetaSized for (dyn Display + '196)}], &impl_Display_for_String::{vtable}>(move _34)
+    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'197, String>[{built_in impl MetaSized for String}]] _34
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'216>] _35
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'212, (dyn Display + '208)>[{built_in impl MetaSized for (dyn Display + '208)}]] _33
+        conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'232, (dyn Display + '227)>[{built_in impl MetaSized for (dyn Display + '227)}]] _33
         ↳⚡ unwind_terminate
-        conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+        conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_35)
     storage_dead(_34)
-    set_type(typeof(_33) <= MyPtr<(dyn Display + '182)>[{built_in impl MetaSized for (dyn Display + '184)}])
-    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'197, (dyn Display + '193)>[{built_in impl MetaSized for (dyn Display + '193)}]] _33
-    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'65>] string
+    set_type(typeof(_33) <= MyPtr<(dyn Display + '198)>[{built_in impl MetaSized for (dyn Display + '200)}])
+    conditional_drop[impl_Destruct_for_MyPtr::drop_glue<'215, (dyn Display + '210)>[{built_in impl MetaSized for (dyn Display + '210)}]] _33
+    ↳⚡ conditional_drop[impl_Destruct_for_String::drop_glue<'69>] string
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_33)
     _0 = ()
-    conditional_drop[impl_Destruct_for_String::drop_glue<'199>] string
+    conditional_drop[impl_Destruct_for_String::drop_glue<'217>] string
     ↳⚡ unwind_continue
     storage_dead(string)
     storage_dead(array)

--- a/charon/tests/ui/unsupported/issue-79-bound-regions.out
+++ b/charon/tests/ui/unsupported/issue-79-bound-regions.out
@@ -78,13 +78,13 @@ fn main()
     let slice: &'1 [i32]; // local
     let _2: &'3 [i32; 1usize]; // anonymous local
     let _3: &'4 [i32; 1usize]; // anonymous local
-    let _4: Option<&'12 i32>[{built_in impl Sized for &'12 i32}]; // anonymous local
-    let _5: &'19 mut Iter<'20, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _6: Iter<'21, i32>[{built_in impl Sized for i32}]; // anonymous local
-    let _7: &'22 [i32]; // anonymous local
-    let _8: &'23 [i32; 1usize]; // anonymous local
-    let _9: &'24 [i32; 1usize]; // anonymous local
-    let _10: &'32 [i32; 1usize]; // anonymous local
+    let _4: Option<&'13 i32>[{built_in impl Sized for &'13 i32}]; // anonymous local
+    let _5: &'20 mut Iter<'21, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _6: Iter<'22, i32>[{built_in impl Sized for i32}]; // anonymous local
+    let _7: &'23 [i32]; // anonymous local
+    let _8: &'24 [i32; 1usize]; // anonymous local
+    let _9: &'25 [i32; 1usize]; // anonymous local
+    let _10: &'33 [i32; 1usize]; // anonymous local
     let _11: [i32; 1usize]; // anonymous local
 
     storage_live(_9)
@@ -106,19 +106,19 @@ fn main()
     ↳⚡ undefined_behavior
     storage_dead(_2)
     fake_read(slice)
-    set_type(typeof(slice) == &'26 [i32])
+    set_type(typeof(slice) == &'27 [i32])
     storage_dead(_3)
     storage_live(_4)
     storage_live(_5)
     storage_live(_6)
     storage_live(_7)
     _7 = &(*slice) with_metadata(copy slice.metadata)
-    _6 = iter<'28, i32>[{built_in impl Sized for i32}](move _7)
+    _6 = iter<'29, i32>[{built_in impl Sized for i32}](move _7)
     ↳⚡ storage_dead(_8)
         unwind_continue
     _5 = &two-phase-mut _6
     storage_dead(_7)
-    _4 = next<'29, '31, i32>[{built_in impl Sized for i32}](move _5)
+    _4 = next<'30, '32, i32>[{built_in impl Sized for i32}](move _5)
     ↳⚡ storage_dead(_8)
         unwind_continue
     storage_dead(_5)


### PR DESCRIPTION
Minor, in preparation for future PRs that would have a lot of test churn otherwise :) 

In a future PR, the `tref` may refer to the proof of a function pointer, which has lifetimes that can't be skipped.