### PR TITLE
Take by-value `self` vtable receivers via `*mut Self`

### DIFF
--- a/charon/src/bin/charon-driver/hax/types/new/full_def.rs
+++ b/charon/src/bin/charon-driver/hax/types/new/full_def.rs
@@ -497,6 +497,35 @@ pub enum FullDefKind<'tcx> {
     SyntheticCoroutineBody,
 }
 
+/// Whether the trait method declared by `method_decl_id` takes `self: Self` by value.
+pub fn vtable_receiver_is_by_value<'tcx>(tcx: ty::TyCtxt<'tcx>, method_decl_id: RDefId) -> bool {
+    let decl_sig = tcx
+        .fn_sig(method_decl_id)
+        .instantiate_identity()
+        .skip_norm_wip();
+    !decl_sig.inputs().skip_binder().is_empty()
+        && decl_sig.input(0).skip_binder().is_param(0)
+        && tcx.generics_of(method_decl_id).has_self
+}
+
+/// If the method takes `self: Self` by value, make the vtable signature take the receiver via
+/// `*mut Self` instead, like rustc's vtable shims do.
+fn adjust_by_value_vtable_receiver<'tcx>(
+    tcx: ty::TyCtxt<'tcx>,
+    method_decl_id: RDefId,
+    sig: ty::PolyFnSig<'tcx>,
+) -> ty::PolyFnSig<'tcx> {
+    if !vtable_receiver_is_by_value(tcx, method_decl_id) {
+        return sig;
+    }
+    sig.map_bound(|mut sig| {
+        let mut inputs_and_output = sig.inputs_and_output.to_vec();
+        inputs_and_output[0] = ty::Ty::new_mut_ptr(tcx, inputs_and_output[0]);
+        sig.inputs_and_output = tcx.mk_type_list(&inputs_and_output);
+        sig
+    })
+}
+
 fn gen_vtable_sig<'tcx>(
     // The state that owns the method DefId
     s: &impl UnderOwnerState<'tcx>,
@@ -561,6 +590,7 @@ fn gen_vtable_sig<'tcx>(
     // Instantiate and normalize the signature.
     let method_decl_sig = tcx.fn_sig(method_decl_id).instantiate(tcx, trait_args);
     let normalized_sig = normalize(tcx, s.typing_env(), method_decl_sig);
+    let normalized_sig = adjust_by_value_vtable_receiver(tcx, method_decl_id, normalized_sig);
 
     Some(normalized_sig.sinto(s))
 }

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -1169,11 +1169,19 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
     /// // call the impl function and assign the result to ret@0
     /// ret@0 := impl_func(target_self@(N+1), arg1@2, ..., argN@N);
     /// ```
+    ///
+    /// For a method that takes `self: Self` by value, the shim receiver is `*mut dyn Trait`, so
+    /// we concretize the pointer and move out of it:
+    /// ```ignore
+    /// target_self@(N+1) := concretize_cast<*mut dyn Trait, *mut TargetReceiverTy>(shim_self@1);
+    /// ret@0 := impl_func(move (*target_self@(N+1)), arg1@2, ..., argN@N);
+    /// ```
     fn translate_vtable_shim_body(
         &mut self,
         span: Span,
         target_receiver: &Ty,
         shim_signature: &FunSig,
+        receiver_is_by_value: bool,
         impl_func_def: &hax::FullDef,
     ) -> Result<Body, Error> {
         let mut builder = BodyBuilder::new(span, shim_signature.inputs.len());
@@ -1184,10 +1192,21 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
             .iter()
             .map(|ty| builder.new_var(None, ty.clone()))
             .collect_vec();
-        let target_self = builder.new_var(None, target_receiver.clone());
+
+        let cast_target_ty = if receiver_is_by_value {
+            TyKind::RawPtr(target_receiver.clone(), RefKind::Mut).into_ty()
+        } else {
+            target_receiver.clone()
+        };
+        let target_self = builder.new_var(None, cast_target_ty);
 
         // Replace the `dyn Trait` receiver with the concrete one.
-        let shim_self = mem::replace(&mut method_args[0], target_self.clone());
+        let receiver_arg = if receiver_is_by_value {
+            target_self.clone().deref()
+        } else {
+            target_self.clone()
+        };
+        let shim_self = mem::replace(&mut method_args[0], receiver_arg);
 
         // Perform the core concretization cast.
         // FIXME: need to unpack & re-pack the structure for cases like `Rc`, `Arc`, `Pin` and
@@ -1337,6 +1356,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         let hax::FullDefKind::AssocFn {
             vtable_sig: Some(vtable_sig),
             sig: target_signature,
+            associated_item,
             ..
         } = impl_func_def.kind()
         else {
@@ -1351,6 +1371,12 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         let signature = self.translate_fun_sig(span, &vtable_sig.value)?;
         // The concrete receiver we will cast to.
         let target_receiver = self.translate_ty(span, &target_signature.value.inputs[0])?;
+        let receiver_is_by_value = hax::vtable_receiver_is_by_value(
+            self.tcx,
+            associated_item
+                .implemented_trait_item_id()
+                .real_rust_def_id(),
+        );
 
         trace!(
             "[VtableShim] Obtained dyn signature with receiver type: {}",
@@ -1360,7 +1386,13 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
         let body = if item_meta.opacity.with_private_contents().is_opaque() {
             Body::Opaque
         } else {
-            self.translate_vtable_shim_body(span, &target_receiver, &signature, impl_func_def)?
+            self.translate_vtable_shim_body(
+                span,
+                &target_receiver,
+                &signature,
+                receiver_is_by_value,
+                impl_func_def,
+            )?
         };
 
         Ok(FunDecl {

--- a/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
+++ b/charon/src/bin/charon-driver/translate/translate_trait_objects.rs
@@ -430,6 +430,7 @@ impl<'tcx> ItemTransCtx<'tcx, '_> {
     ///   align: usize,
     ///   drop: fn(*mut dyn Trait<...>),
     ///   method_name: fn(&dyn Trait<...>, Args..) -> Output,
+    ///   by_value_method: fn(*mut dyn Trait<...>, Args..) -> Output,
     ///   ... other methods
     ///   super_trait_0: &'static SuperTrait0VTable
     ///   ... other supertraits

--- a/charon/src/transform/normalize/transform_dyn_trait_calls.rs
+++ b/charon/src/transform/normalize/transform_dyn_trait_calls.rs
@@ -141,6 +141,13 @@ fn transform_dyn_trait_call(
             "Dyn trait receiver does not have vtable metadata"
         );
     };
+
+    // this is the the (wide) pointer that has the vtable metadata. by-value receivers (e.g. Box<dyn FnOnce>)
+    // are passed as *p, but it's p that has the vtable, so we need to get that!
+    let dyn_trait_place = match dyn_trait_place.as_projection() {
+        Some((ptr, ProjectionElem::Deref)) => ptr,
+        _ => dyn_trait_place,
+    };
     let receiver_vtable_ty = TyKind::Adt(receiver_vtable_ref).into_ty();
     let ptr_to_vtable_ty = Ty::new(TyKind::RawPtr(receiver_vtable_ty.clone(), RefKind::Shared));
     let mut method_vtable_place = dyn_trait_place

--- a/charon/src/transform/normalize/transform_dyn_trait_calls.rs
+++ b/charon/src/transform/normalize/transform_dyn_trait_calls.rs
@@ -124,12 +124,39 @@ fn transform_dyn_trait_call(
     if call.args.is_empty() {
         raise_error!(ctx.ctx, ctx.span, "Dyn trait call has no arguments!");
     }
-    let dyn_trait_place = match &call.args[0] {
-        Operand::Copy(place) | Operand::Move(place) => place,
+    let mut dyn_trait_place = match &call.args[0] {
+        Operand::Copy(place) | Operand::Move(place) => place.clone(),
         Operand::Const(_) => {
             panic!("Unexpected constant as receiver for dyn trait method call")
         }
     };
+
+    // Rustc may move the unsized first argument of by-value dyn call into a temporary local,
+    // e.g. for `StructWithTail<dyn T>>` and `b.field.by_value()`, we get `_15 = move (*b).field; by_value(move _15)`.
+    // That's an unsized local, which we is not supposed to happen. To avoid that we inline the
+    // place back into the call, giving us: `by_value(move (*b).field)`.
+    if let TyKind::DynTrait(..) = dyn_trait_place.ty().kind()
+        && let PlaceKind::Local(local) = dyn_trait_place.kind
+        && let Some(last) = ctx.statements.last()
+        && let StatementKind::Assign(dest, Rvalue::Use(src, _)) = &last.kind
+        && let Operand::Copy(place) | Operand::Move(place) = src
+        && dest.local_id() == Some(local)
+    {
+        call.args[0] = src.clone();
+        dyn_trait_place = place.clone();
+        ctx.statements.pop();
+    }
+
+    // `dyn Trait` has a carveout for unsized `self` types. It works by calling the method on a place
+    // of type `dyn Trait` directly. The actual shim we generate expects `*mut dyn Trait`, so we must
+    // borrow that unsized place. See `dyn/mono-dyn-call-by-value.out`.
+    if let TyKind::DynTrait(..) = dyn_trait_place.ty().kind() {
+        let ptr_ty = TyKind::RawPtr(dyn_trait_place.ty().clone(), RefKind::Mut).into_ty();
+        let rvalue = ctx.raw_borrow(dyn_trait_place, RefKind::Mut);
+        dyn_trait_place = ctx.fresh_var(None, ptr_ty);
+        ctx.insert_assn_stmt(dyn_trait_place.clone(), rvalue);
+        call.args[0] = Operand::Move(dyn_trait_place.clone());
+    }
 
     let dyn_pred = dyn_proof.trait_decl_ref.clone().erase();
     let dyn_ty = &dyn_pred.generics.types[0];
@@ -142,16 +169,9 @@ fn transform_dyn_trait_call(
         );
     };
 
-    // this is the the (wide) pointer that has the vtable metadata. by-value receivers (e.g. Box<dyn FnOnce>)
-    // are passed as *p, but it's p that has the vtable, so we need to get that!
-    let dyn_trait_place = match dyn_trait_place.as_projection() {
-        Some((ptr, ProjectionElem::Deref)) => ptr,
-        _ => dyn_trait_place,
-    };
     let receiver_vtable_ty = TyKind::Adt(receiver_vtable_ref).into_ty();
     let ptr_to_vtable_ty = Ty::new(TyKind::RawPtr(receiver_vtable_ty.clone(), RefKind::Shared));
     let mut method_vtable_place = dyn_trait_place
-        .clone()
         .project(ProjectionElem::PtrMetadata, ptr_to_vtable_ty)
         .project(ProjectionElem::Deref, receiver_vtable_ty);
 

--- a/charon/src/transform/typecheck_and_unify.rs
+++ b/charon/src/transform/typecheck_and_unify.rs
@@ -215,8 +215,6 @@ impl TypeCheckVisitor<'_> {
                     assert_eq!(instantiated_from(src.id), instantiated_from(tar.id));
                 }
             }
-            // Can happen with `Box`, where the RHS is `Box`. FIXME(#1163): check for Box here.
-            (TyKind::DynTrait(..), TyKind::Adt(..)) => {}
             _ => {
                 let fmt = &self.ctx.into_fmt();
                 self.error(format!(

--- a/charon/tests/ui/dyn/box-dyn-fnonce-raw.out
+++ b/charon/tests/ui/dyn/box-dyn-fnonce-raw.out
@@ -192,7 +192,7 @@ struct core::ops::function::FnOnce::{vtable}<Args, Ty0> {
   size: usize,
   align: usize,
   drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Ty0>)),
-  method_call_once: extern "rust-call" fn((dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
+  method_call_once: extern "rust-call" fn(*mut (dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
   super_trait_0: &'static core::marker::MetaSized::{vtable},
 }
 
@@ -573,7 +573,7 @@ where
 }
 
 // Full name: alloc::boxed::{impl FnOnce<Args> for Box<F, A>[TraitClause1, TraitClause2, TraitClause5]}::call_once::{vtable_method}
-extern "rust-call" fn {vtable_method}<Args, F, A>(_1: (dyn FnOnce<Args, Output = TraitClause4::Output>), _2: Args) -> TraitClause4::Output
+extern "rust-call" fn {vtable_method}<Args, F, A>(_1: *mut (dyn FnOnce<Args, Output = TraitClause4::Output>), _2: Args) -> TraitClause4::Output
 where
     TraitClause0: (Args: Sized),
     TraitClause1: (F: MetaSized),
@@ -583,14 +583,14 @@ where
     TraitClause5: (A: Allocator),
 {
     let _0: TraitClause4::Output; // return
-    let _1: (dyn FnOnce<Args, Output = TraitClause4::Output> + '0); // arg #1
+    let _1: *mut (dyn FnOnce<Args, Output = TraitClause4::Output> + '0); // arg #1
     let _2: Args; // arg #2
-    let _3: Box<F, A>[TraitClause1, TraitClause2, TraitClause5]; // anonymous local
+    let _3: *mut Box<F, A>[TraitClause1, TraitClause2, TraitClause5]; // anonymous local
 
     storage_live(_0)
     storage_live(_3)
-    _3 = concretize<(dyn FnOnce<Args, Output = TraitClause4::Output> + '1), Box<F, A>[TraitClause1, TraitClause2, TraitClause5]>(move _1)
-    _0 = call_once<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5](move _3, move _2)
+    _3 = concretize<*mut (dyn FnOnce<Args, Output = TraitClause4::Output> + '1), *mut Box<F, A>[TraitClause1, TraitClause2, TraitClause5]>(move _1)
+    _0 = call_once<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5](move (*_3), move _2)
     ↳⚡ unwind_continue
     return
 }
@@ -635,7 +635,7 @@ where
     let size: usize; // local
     let align: usize; // local
     let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = TraitClause4::Output> + '1)); // anonymous local
-    let _4: extern "rust-call" fn((dyn FnOnce<Args, Output = TraitClause4::Output> + '2), Args) -> TraitClause4::Output; // anonymous local
+    let _4: extern "rust-call" fn(*mut (dyn FnOnce<Args, Output = TraitClause4::Output> + '2), Args) -> TraitClause4::Output; // anonymous local
     let _5: &'static core::marker::MetaSized::{vtable}; // anonymous local
 
     storage_live(ret)
@@ -646,7 +646,7 @@ where
     storage_live(_3)
     _3 = cast<for<'_0_1> {vtable_drop_shim}<'0, Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5], unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = TraitClause4::Output> + '1))>(const {vtable_drop_shim}<'0, Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5])
     storage_live(_4)
-    _4 = cast<{vtable_method}<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5], extern "rust-call" fn((dyn FnOnce<Args, Output = TraitClause4::Output> + '2), Args) -> TraitClause4::Output>(const {vtable_method}<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5])
+    _4 = cast<{vtable_method}<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5], extern "rust-call" fn(*mut (dyn FnOnce<Args, Output = TraitClause4::Output> + '2), Args) -> TraitClause4::Output>(const {vtable_method}<Args, F, A>[TraitClause0, TraitClause1, TraitClause2, TraitClause3, TraitClause4, TraitClause5])
     storage_live(_5)
     _5 = &core::marker::MetaSized::{vtable}<Box<F, A>[TraitClause1, TraitClause2, TraitClause5]>
     ret = core::ops::function::FnOnce::{vtable} { size: move size, align: move align, drop: move _3, method_call_once: move _4, super_trait_0: move _5 }

--- a/charon/tests/ui/dyn/builtin-vtables.out
+++ b/charon/tests/ui/dyn/builtin-vtables.out
@@ -39,7 +39,7 @@ struct core::ops::function::FnOnce::{vtable}<Args, Ty0> {
   size: usize,
   align: usize,
   drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn FnOnce<Args, Output = Ty0>)),
-  method_call_once: extern "rust-call" fn((dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
+  method_call_once: extern "rust-call" fn(*mut (dyn FnOnce<Args, Output = Ty0>), Args) -> Ty0,
   super_trait_0: &'static core::marker::MetaSized::{vtable},
 }
 

--- a/charon/tests/ui/dyn/by-value-self-vtable.out
+++ b/charon/tests/ui/dyn/by-value-self-vtable.out
@@ -1,0 +1,472 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+// Full name: core::marker::Sized
+#[fundamental]
+#[lang_item(Sized)]
+pub trait Sized<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    non-dyn-compatible
+}
+
+fn core::marker::MetaSized::{vtable}<Self>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}<Self>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}<Self>()
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+// Full name: alloc::alloc::Global
+#[lang_item(GlobalAlloc)]
+pub struct Global {}
+
+// Full name: alloc::boxed::Box
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box<T>
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (type_error("removed allocator parameter"): Sized),
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box<T>[TraitClause0, TraitClause1]}::drop_glue
+unsafe fn impl_Destruct_for_Box::drop_glue<'_0, T, A>(_1: &'_0 mut Box<T>[TraitClause0, TraitClause1])
+where
+    TraitClause0: (T: MetaSized),
+    TraitClause1: (A: Sized),
+    TypeOutlives0: T: '_0,
+    TypeOutlives1: A: '_0,
+= <opaque>
+
+// Full name: alloc::boxed::{Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]}::new
+#[track_caller]
+#[diagnostic_item("box_new")]
+pub fn new<T>(_1: T) -> Box<T>[TraitClause0::ImpliedClause0, {built_in impl Sized for Global}]
+where
+    TraitClause0: (T: Sized),
+= <opaque>
+
+struct test_crate::Consume::{vtable} {
+  size: usize,
+  align: usize,
+  drop: unsafe fn<'_0_1>(&'_0_1 mut (dyn Consume)),
+  method_consume: fn(*mut (dyn Consume)) -> u32,
+  method_read: fn<'_0_1>(&'_0_1 (dyn Consume)) -> u32,
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+// Full name: test_crate::Consume
+trait Consume<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    fn consume;
+    fn read<'_0_1>;
+    vtable: test_crate::Consume::{vtable}
+}
+
+// Full name: test_crate::S
+struct S {
+  _0: u32,
+}
+
+// Full name: test_crate::S::{impl Destruct for S}::drop_glue
+unsafe fn impl_Destruct_for_S::drop_glue<'_0>(_1: &'_0 mut S)
+{
+    let _0: (); // return
+    let _1: &'1 mut S; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::S::{impl Destruct for S}
+impl "impl_Destruct_for_S" Destruct for S {
+    fn drop_glue<'_0_1> = impl_Destruct_for_S::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl Consume for S}::read
+fn impl_Consume_for_S::read<'_0>(self: &'_0 S) -> u32
+{
+    let _0: u32; // return
+    let self: &'1 S; // arg #1
+
+    storage_live(_0)
+    _0 = copy (*self)._0
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::consume
+fn impl_Consume_for_S::consume(self: S) -> u32
+{
+    let _0: u32; // return
+    let self: S; // arg #1
+
+    storage_live(_0)
+    _0 = copy self._0
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::read::{vtable_method}
+fn impl_Consume_for_S::read::{vtable_method}<'_0>(_1: &'_0 (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_0 (dyn Consume + '0); // arg #1
+    let _2: &'_0 S; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<&'_0 (dyn Consume + '1), &'_0 S>(move _1)
+    _0 = impl_Consume_for_S::read<'_0>(move _2)
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::consume::{vtable_method}
+fn impl_Consume_for_S::consume::{vtable_method}(_1: *mut (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: *mut (dyn Consume + '0); // arg #1
+    let _2: *mut S; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<*mut (dyn Consume + '1), *mut S>(move _1)
+    _0 = impl_Consume_for_S::consume(move (*_2))
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::{vtable_drop_shim}
+unsafe fn impl_Consume_for_S::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Consume))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Consume + '0); // arg #1
+    let target_self: &'_0 mut S; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Consume + '1), &'_0 mut S>(move dyn_self)
+    drop[impl_Destruct_for_S::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::{vtable}
+fn impl_Consume_for_S::{vtable}() -> test_crate::Consume::{vtable}
+{
+    let ret: test_crate::Consume::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Consume + '1)); // anonymous local
+    let _4: fn(*mut (dyn Consume + '2)) -> u32; // anonymous local
+    let _5: fn<'_0_1>(&'_0_1 (dyn Consume + '4)) -> u32; // anonymous local
+    let _6: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<S>
+    storage_live(align)
+    align = align_of<S>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> impl_Consume_for_S::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Consume + '1))>(const impl_Consume_for_S::{vtable_drop_shim}<'0>)
+    storage_live(_4)
+    _4 = cast<impl_Consume_for_S::consume::{vtable_method}, fn(*mut (dyn Consume + '2)) -> u32>(const impl_Consume_for_S::consume::{vtable_method})
+    storage_live(_5)
+    _5 = cast<for<'_0_1> impl_Consume_for_S::read::{vtable_method}<'3>, fn<'_0_1>(&'_0_1 (dyn Consume + '4)) -> u32>(const impl_Consume_for_S::read::{vtable_method}<'3>)
+    storage_live(_6)
+    _6 = &core::marker::MetaSized::{vtable}<S>
+    ret = test_crate::Consume::{vtable} { size: move size, align: move align, drop: move _3, method_consume: move _4, method_read: move _5, super_trait_0: move _6 }
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::{vtable}
+static impl_Consume_for_S::{vtable}: test_crate::Consume::{vtable} = impl_Consume_for_S::{vtable}()
+
+// Full name: test_crate::{impl Consume for S}
+impl "impl_Consume_for_S" Consume for S {
+    proof ImpliedClause0: (S: MetaSized) = {built_in impl MetaSized for S}
+    fn consume = impl_Consume_for_S::consume
+    fn read<'_0_1> = impl_Consume_for_S::read<'_0_1>
+    vtable: impl_Consume_for_S::{vtable}
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::read
+fn {impl Consume for *mut u32}::read<'_0>(self: &'_0 *mut u32) -> u32
+{
+    let _0: u32; // return
+    let self: &'1 *mut u32; // arg #1
+
+    storage_live(_0)
+    _0 = copy (*(*self))
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::consume
+fn {impl Consume for *mut u32}::consume(self: *mut u32) -> u32
+{
+    let _0: u32; // return
+    let self: *mut u32; // arg #1
+
+    storage_live(_0)
+    _0 = copy (*self)
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::read::{vtable_method}
+fn {impl Consume for *mut u32}::read::{vtable_method}<'_0>(_1: &'_0 (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_0 (dyn Consume + '0); // arg #1
+    let _2: &'_0 *mut u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<&'_0 (dyn Consume + '1), &'_0 *mut u32>(move _1)
+    _0 = {impl Consume for *mut u32}::read<'_0>(move _2)
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::consume::{vtable_method}
+fn {impl Consume for *mut u32}::consume::{vtable_method}(_1: *mut (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: *mut (dyn Consume + '0); // arg #1
+    let _2: *mut *mut u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<*mut (dyn Consume + '1), *mut *mut u32>(move _1)
+    _0 = {impl Consume for *mut u32}::consume(move (*_2))
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::{vtable_drop_shim}
+unsafe fn {impl Consume for *mut u32}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Consume))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Consume + '0); // arg #1
+    let target_self: &'_0 mut *mut u32; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Consume + '1), &'_0 mut *mut u32>(move dyn_self)
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::{vtable}
+fn {impl Consume for *mut u32}::{vtable}() -> test_crate::Consume::{vtable}
+{
+    let ret: test_crate::Consume::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let _3: unsafe fn<'_0_1>(&'_0_1 mut (dyn Consume + '1)); // anonymous local
+    let _4: fn(*mut (dyn Consume + '2)) -> u32; // anonymous local
+    let _5: fn<'_0_1>(&'_0_1 (dyn Consume + '4)) -> u32; // anonymous local
+    let _6: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<*mut u32>
+    storage_live(align)
+    align = align_of<*mut u32>
+    storage_live(_3)
+    _3 = cast<for<'_0_1> {impl Consume for *mut u32}::{vtable_drop_shim}<'0>, unsafe fn<'_0_1>(&'_0_1 mut (dyn Consume + '1))>(const {impl Consume for *mut u32}::{vtable_drop_shim}<'0>)
+    storage_live(_4)
+    _4 = cast<{impl Consume for *mut u32}::consume::{vtable_method}, fn(*mut (dyn Consume + '2)) -> u32>(const {impl Consume for *mut u32}::consume::{vtable_method})
+    storage_live(_5)
+    _5 = cast<for<'_0_1> {impl Consume for *mut u32}::read::{vtable_method}<'3>, fn<'_0_1>(&'_0_1 (dyn Consume + '4)) -> u32>(const {impl Consume for *mut u32}::read::{vtable_method}<'3>)
+    storage_live(_6)
+    _6 = &core::marker::MetaSized::{vtable}<*mut u32>
+    ret = test_crate::Consume::{vtable} { size: move size, align: move align, drop: move _3, method_consume: move _4, method_read: move _5, super_trait_0: move _6 }
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::{vtable}
+static {impl Consume for *mut u32}::{vtable}: test_crate::Consume::{vtable} = {impl Consume for *mut u32}::{vtable}()
+
+// Full name: test_crate::{impl Consume for *mut u32}
+impl Consume for *mut u32 {
+    proof ImpliedClause0: (*mut u32: MetaSized) = {built_in impl MetaSized for *mut u32}
+    fn consume = {impl Consume for *mut u32}::consume
+    fn read<'_0_1> = {impl Consume for *mut u32}::read<'_0_1>
+    vtable: {impl Consume for *mut u32}::{vtable}
+}
+
+// Full name: test_crate::mk
+fn mk() -> Box<(dyn Consume + 'static)>[{built_in impl MetaSized for (dyn Consume + 'static)}, {built_in impl Sized for Global}]
+{
+    let _0: Box<(dyn Consume + '6)>[{built_in impl MetaSized for (dyn Consume + '8)}, {built_in impl Sized for Global}]; // return
+    let _1: Box<(dyn Consume + '9)>[{built_in impl MetaSized for (dyn Consume + '11)}, {built_in impl Sized for Global}]; // anonymous local
+    let _2: Box<S>[{built_in impl MetaSized for S}, {built_in impl Sized for Global}]; // anonymous local
+    let _3: S; // anonymous local
+
+    storage_live(_0)
+    storage_live(_1)
+    storage_live(_2)
+    storage_live(_3)
+    _3 = S { _0: const 42u32 }
+    _2 = new<S>[{built_in impl Sized for S}](move _3)
+    ↳⚡ unwind_continue
+    _1 = unsize_cast<Box<S>[{built_in impl MetaSized for S}, {built_in impl Sized for Global}], Box<(dyn Consume + '12)>[{built_in impl MetaSized for (dyn Consume + '14)}, {built_in impl Sized for Global}], &impl_Consume_for_S::{vtable}>(move _2)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'15, S, Global>[{built_in impl MetaSized for S}, {built_in impl Sized for Global}]] _2
+    ↳⚡ unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    _0 = unsize_cast<Box<(dyn Consume + '9)>[{built_in impl MetaSized for (dyn Consume + '11)}, {built_in impl Sized for Global}], Box<(dyn Consume + '16)>[{built_in impl MetaSized for (dyn Consume + '18)}, {built_in impl Sized for Global}],  at []>(move _1)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'33, (dyn Consume + '28), Global>[{built_in impl MetaSized for (dyn Consume + '28)}, {built_in impl Sized for Global}]] _1
+    ↳⚡ unwind_continue
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::mk_ptr
+fn mk_ptr(x: *mut u32) -> Box<(dyn Consume + 'static)>[{built_in impl MetaSized for (dyn Consume + 'static)}, {built_in impl Sized for Global}]
+{
+    let _0: Box<(dyn Consume + '6)>[{built_in impl MetaSized for (dyn Consume + '8)}, {built_in impl Sized for Global}]; // return
+    let x: *mut u32; // arg #1
+    let _2: Box<(dyn Consume + '9)>[{built_in impl MetaSized for (dyn Consume + '11)}, {built_in impl Sized for Global}]; // anonymous local
+    let _3: Box<*mut u32>[{built_in impl MetaSized for *mut u32}, {built_in impl Sized for Global}]; // anonymous local
+    let _4: *mut u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    storage_live(_3)
+    storage_live(_4)
+    _4 = copy x
+    _3 = new<*mut u32>[{built_in impl Sized for *mut u32}](move _4)
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    _2 = unsize_cast<Box<*mut u32>[{built_in impl MetaSized for *mut u32}, {built_in impl Sized for Global}], Box<(dyn Consume + '12)>[{built_in impl MetaSized for (dyn Consume + '14)}, {built_in impl Sized for Global}], &{impl Consume for *mut u32}::{vtable}>(move _3)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'15, *mut u32, Global>[{built_in impl MetaSized for *mut u32}, {built_in impl Sized for Global}]] _3
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    storage_dead(_4)
+    storage_dead(_3)
+    _0 = unsize_cast<Box<(dyn Consume + '9)>[{built_in impl MetaSized for (dyn Consume + '11)}, {built_in impl Sized for Global}], Box<(dyn Consume + '16)>[{built_in impl MetaSized for (dyn Consume + '18)}, {built_in impl Sized for Global}],  at []>(move _2)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'33, (dyn Consume + '28), Global>[{built_in impl MetaSized for (dyn Consume + '28)}, {built_in impl Sized for Global}]] _2
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(x)
+    return
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let x: Box<(dyn Consume + '6)>[{built_in impl MetaSized for (dyn Consume + '8)}, {built_in impl Sized for Global}]; // local
+    let _v_2: u32; // local
+    let _3: &'11 (dyn Consume + '12); // anonymous local
+    let n: u32; // local
+    let p: Box<(dyn Consume + '13)>[{built_in impl MetaSized for (dyn Consume + '15)}, {built_in impl Sized for Global}]; // local
+    let _6: *mut u32; // anonymous local
+    let _7: &'17 mut u32; // anonymous local
+    let _v_8: u32; // local
+    let _9: &'18 (dyn Consume + '19); // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(x)
+    x = mk()
+    ↳⚡ unwind_continue
+    fake_read(x)
+    storage_live(_v_2)
+    storage_live(_3)
+    _3 = &(*x) with_metadata(copy x.metadata)
+    _v_2 = (copy (*_3.metadata).method_read)(move _3)
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'38, (dyn Consume + '33), Global>[{built_in impl MetaSized for (dyn Consume + '33)}, {built_in impl Sized for Global}]] x
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_3)
+    fake_read(_v_2)
+    storage_live(n)
+    n = const 5u32
+    fake_read(n)
+    storage_live(p)
+    storage_live(_6)
+    storage_live(_7)
+    _7 = &mut n
+    _6 = &raw mut (*_7)
+    p = mk_ptr(move _6)
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'38, (dyn Consume + '33), Global>[{built_in impl MetaSized for (dyn Consume + '33)}, {built_in impl Sized for Global}]] x
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_6)
+    fake_read(p)
+    storage_dead(_7)
+    storage_live(_v_8)
+    storage_live(_9)
+    _9 = &(*p) with_metadata(copy p.metadata)
+    _v_8 = (copy (*_9.metadata).method_read)(move _9)
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'57, (dyn Consume + '52), Global>[{built_in impl MetaSized for (dyn Consume + '52)}, {built_in impl Sized for Global}]] p
+        ↳⚡ unwind_terminate
+        conditional_drop[impl_Destruct_for_Box::drop_glue<'38, (dyn Consume + '33), Global>[{built_in impl MetaSized for (dyn Consume + '33)}, {built_in impl Sized for Global}]] x
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_9)
+    fake_read(_v_8)
+    _0 = ()
+    storage_dead(_v_8)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'72, (dyn Consume + '67), Global>[{built_in impl MetaSized for (dyn Consume + '67)}, {built_in impl Sized for Global}]] p
+    ↳⚡ conditional_drop[impl_Destruct_for_Box::drop_glue<'38, (dyn Consume + '33), Global>[{built_in impl MetaSized for (dyn Consume + '33)}, {built_in impl Sized for Global}]] x
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(p)
+    storage_dead(n)
+    storage_dead(_v_2)
+    conditional_drop[impl_Destruct_for_Box::drop_glue<'87, (dyn Consume + '82), Global>[{built_in impl MetaSized for (dyn Consume + '82)}, {built_in impl Sized for Global}]] x
+    ↳⚡ unwind_continue
+    storage_dead(x)
+    return
+}
+
+
+

--- a/charon/tests/ui/dyn/by-value-self-vtable.rs
+++ b/charon/tests/ui/dyn/by-value-self-vtable.rs
@@ -1,0 +1,43 @@
+//! A trait method taking `self: Self` by value is still dyn-compatible; its vtable shim must
+//! take the receiver via `*mut Self` (like rustc's `ShimKind::VTable`) since a `dyn Trait`
+//! value can't be passed directly.
+trait Consume {
+    fn consume(self) -> u32;
+    fn read(&self) -> u32;
+}
+
+struct S(u32);
+impl Consume for S {
+    fn consume(self) -> u32 {
+        self.0
+    }
+    fn read(&self) -> u32 {
+        self.0
+    }
+}
+
+// `Self` being itself a pointer must not be mistaken for the `*mut Self` shim receiver.
+impl Consume for *mut u32 {
+    fn consume(self) -> u32 {
+        unsafe { *self }
+    }
+    fn read(&self) -> u32 {
+        unsafe { **self }
+    }
+}
+
+fn mk() -> Box<dyn Consume> {
+    Box::new(S(42))
+}
+
+fn mk_ptr(x: *mut u32) -> Box<dyn Consume> {
+    Box::new(x)
+}
+
+fn main() {
+    let x = mk();
+    let _v = x.read();
+    let mut n = 5u32;
+    let p = mk_ptr(&mut n);
+    let _v = p.read();
+}

--- a/charon/tests/ui/dyn/mono-by-value-self-vtable.out
+++ b/charon/tests/ui/dyn/mono-by-value-self-vtable.out
@@ -1,0 +1,524 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+fn core::marker::MetaSized::{vtable}::<S>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<S>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<S>()
+
+fn core::marker::MetaSized::{vtable}::<*mut u32>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<*mut u32>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<*mut u32>()
+
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
+// Full name: alloc::boxed::Box::<S>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<S, Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<S, Global>}::drop_glue::<S, Global>
+unsafe fn {impl Destruct for Box::<S, Global>}::drop_glue::<S, Global><'_0>(_1: &'_0 mut Box::<S, Global>)
+= <opaque>
+
+// Full name: alloc::boxed::Box::<*mut u32>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<*mut u32, Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<*mut u32, Global>}::drop_glue::<*mut u32, Global>
+unsafe fn {impl Destruct for Box::<*mut u32, Global>}::drop_glue::<*mut u32, Global><'_0>(_1: &'_0 mut Box::<*mut u32, Global>)
+= <opaque>
+
+// Full name: alloc::boxed::Box::<(dyn Consume)>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<(dyn Consume), Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global>
+unsafe fn {impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'_0>(_1: &'_0 mut Box::<(dyn Consume), Global>)
+= <opaque>
+
+// Full name: test_crate::S
+struct S {
+  _0: u32,
+}
+
+#[track_caller]
+#[diagnostic_item("box_new")]
+pub fn alloc::boxed::{Box::<S, Global>}::new::<S>(_1: S) -> Box::<S, Global>
+= <opaque>
+
+#[track_caller]
+#[diagnostic_item("box_new")]
+pub fn alloc::boxed::{Box::<*mut u32, Global>}::new::<*mut u32>(_1: *mut u32) -> Box::<*mut u32, Global>
+= <opaque>
+
+struct test_crate::Consume::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  method_consume: *const (),
+  method_read: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+// Full name: test_crate::Consume
+trait Consume<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    vtable: test_crate::Consume::{vtable}
+}
+
+// Full name: test_crate::S::{impl Destruct for S}::drop_glue
+unsafe fn impl_Destruct_for_S::drop_glue<'_0>(_1: &'_0 mut S)
+{
+    let _0: (); // return
+    let _1: &'1 mut S; // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::S::{impl Destruct for S}
+impl "impl_Destruct_for_S" Destruct for S {
+    fn drop_glue<'_0_1> = impl_Destruct_for_S::drop_glue<'_0_1>
+    non-dyn-compatible
+}
+
+// Full name: test_crate::{impl Consume for S}::read
+fn impl_Consume_for_S::read<'_0>(self: &'_0 S) -> u32
+{
+    let _0: u32; // return
+    let self: &'1 S; // arg #1
+
+    storage_live(_0)
+    _0 = copy (*self)._0
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::read::{vtable_method}
+fn impl_Consume_for_S::read::{vtable_method}<'_0>(_1: &'_0 (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_0 (dyn Consume + '0); // arg #1
+    let _2: &'_0 S; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<&'_0 (dyn Consume + '1), &'_0 S>(move _1)
+    _0 = impl_Consume_for_S::read<'_0>(move _2)
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::consume
+fn impl_Consume_for_S::consume(self: S) -> u32
+{
+    let _0: u32; // return
+    let self: S; // arg #1
+
+    storage_live(_0)
+    _0 = copy self._0
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::consume::{vtable_method}
+fn impl_Consume_for_S::consume::{vtable_method}(_1: *mut (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: *mut (dyn Consume + '0); // arg #1
+    let _2: *mut S; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<*mut (dyn Consume + '1), *mut S>(move _1)
+    _0 = impl_Consume_for_S::consume(move (*_2))
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::{vtable_drop_shim}
+unsafe fn impl_Consume_for_S::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Consume))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Consume + '0); // arg #1
+    let target_self: &'_0 mut S; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Consume + '1), &'_0 mut S>(move dyn_self)
+    drop[impl_Destruct_for_S::drop_glue<'3>] (*target_self)
+    ↳⚡ storage_dead(target_self)
+        storage_dead(dyn_self)
+        unwind_continue
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::{vtable}
+fn impl_Consume_for_S::{vtable}() -> test_crate::Consume::{vtable}
+{
+    let ret: test_crate::Consume::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn Consume + '0)); // local
+    let erased_drop: *const (); // local
+    let consume: fn(*mut (dyn Consume + '1)) -> u32; // local
+    let erased_consume: *const (); // local
+    let read: fn<'_0_1>(&'_0_1 (dyn Consume + '2)) -> u32; // local
+    let erased_read: *const (); // local
+    let _9: unsafe fn(*mut (dyn Consume + '5)); // anonymous local
+    let _10: fn(*mut (dyn Consume + '9)) -> u32; // anonymous local
+    let _11: fn<'_0_1>(&'_0_1 (dyn Consume + '14)) -> u32; // anonymous local
+    let _12: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<S>
+    storage_live(align)
+    align = align_of<S>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_9)
+    _9 = cast<impl_Consume_for_S::{vtable_drop_shim}<'4>, unsafe fn(*mut (dyn Consume + '5))>(const impl_Consume_for_S::{vtable_drop_shim}<'4>)
+    drop = move _9
+    erased_drop = cast<unsafe fn(*mut (dyn Consume + '6)), *const ()>(move drop)
+    storage_live(consume)
+    storage_live(erased_consume)
+    storage_live(_10)
+    _10 = cast<impl_Consume_for_S::consume::{vtable_method}, fn(*mut (dyn Consume + '9)) -> u32>(const impl_Consume_for_S::consume::{vtable_method})
+    consume = move _10
+    erased_consume = cast<fn(*mut (dyn Consume + '10)) -> u32, *const ()>(move consume)
+    storage_live(read)
+    storage_live(erased_read)
+    storage_live(_11)
+    _11 = cast<for<'_0_1> impl_Consume_for_S::read::{vtable_method}<'13>, fn<'_0_1>(&'_0_1 (dyn Consume + '14)) -> u32>(const impl_Consume_for_S::read::{vtable_method}<'13>)
+    read = move _11
+    erased_read = cast<fn<'_0_1>(&'_0_1 (dyn Consume + '15)) -> u32, *const ()>(move read)
+    storage_live(_12)
+    _12 = &core::marker::MetaSized::{vtable}::<S>
+    ret = test_crate::Consume::{vtable} { size: move size, align: move align, drop: move erased_drop, method_consume: move erased_consume, method_read: move erased_read, super_trait_0: move _12 }
+    return
+}
+
+// Full name: test_crate::{impl Consume for S}::{vtable}
+static impl_Consume_for_S::{vtable}: test_crate::Consume::{vtable} = impl_Consume_for_S::{vtable}()
+
+// Full name: test_crate::{impl Consume for S}
+impl "impl_Consume_for_S" Consume for S {
+    proof ImpliedClause0: (S: MetaSized) = {built_in impl MetaSized for S}
+    vtable: impl_Consume_for_S::{vtable}
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::read
+fn {impl Consume for *mut u32}::read<'_0>(self: &'_0 *mut u32) -> u32
+{
+    let _0: u32; // return
+    let self: &'1 *mut u32; // arg #1
+
+    storage_live(_0)
+    _0 = copy (*(*self))
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::read::{vtable_method}
+fn {impl Consume for *mut u32}::read::{vtable_method}<'_0>(_1: &'_0 (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: &'_0 (dyn Consume + '0); // arg #1
+    let _2: &'_0 *mut u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<&'_0 (dyn Consume + '1), &'_0 *mut u32>(move _1)
+    _0 = {impl Consume for *mut u32}::read<'_0>(move _2)
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::consume
+fn {impl Consume for *mut u32}::consume(self: *mut u32) -> u32
+{
+    let _0: u32; // return
+    let self: *mut u32; // arg #1
+
+    storage_live(_0)
+    _0 = copy (*self)
+    storage_dead(self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::consume::{vtable_method}
+fn {impl Consume for *mut u32}::consume::{vtable_method}(_1: *mut (dyn Consume)) -> u32
+{
+    let _0: u32; // return
+    let _1: *mut (dyn Consume + '0); // arg #1
+    let _2: *mut *mut u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    _2 = concretize<*mut (dyn Consume + '1), *mut *mut u32>(move _1)
+    _0 = {impl Consume for *mut u32}::consume(move (*_2))
+    ↳⚡ storage_dead(_2)
+        storage_dead(_1)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::{vtable_drop_shim}
+unsafe fn {impl Consume for *mut u32}::{vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn Consume))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn Consume + '0); // arg #1
+    let target_self: &'_0 mut *mut u32; // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn Consume + '1), &'_0 mut *mut u32>(move dyn_self)
+    storage_dead(target_self)
+    storage_dead(dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::{vtable}
+fn {impl Consume for *mut u32}::{vtable}() -> test_crate::Consume::{vtable}
+{
+    let ret: test_crate::Consume::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn Consume + '0)); // local
+    let erased_drop: *const (); // local
+    let consume: fn(*mut (dyn Consume + '1)) -> u32; // local
+    let erased_consume: *const (); // local
+    let read: fn<'_0_1>(&'_0_1 (dyn Consume + '2)) -> u32; // local
+    let erased_read: *const (); // local
+    let _9: unsafe fn(*mut (dyn Consume + '5)); // anonymous local
+    let _10: fn(*mut (dyn Consume + '9)) -> u32; // anonymous local
+    let _11: fn<'_0_1>(&'_0_1 (dyn Consume + '14)) -> u32; // anonymous local
+    let _12: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<*mut u32>
+    storage_live(align)
+    align = align_of<*mut u32>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_9)
+    _9 = cast<{impl Consume for *mut u32}::{vtable_drop_shim}<'4>, unsafe fn(*mut (dyn Consume + '5))>(const {impl Consume for *mut u32}::{vtable_drop_shim}<'4>)
+    drop = move _9
+    erased_drop = cast<unsafe fn(*mut (dyn Consume + '6)), *const ()>(move drop)
+    storage_live(consume)
+    storage_live(erased_consume)
+    storage_live(_10)
+    _10 = cast<{impl Consume for *mut u32}::consume::{vtable_method}, fn(*mut (dyn Consume + '9)) -> u32>(const {impl Consume for *mut u32}::consume::{vtable_method})
+    consume = move _10
+    erased_consume = cast<fn(*mut (dyn Consume + '10)) -> u32, *const ()>(move consume)
+    storage_live(read)
+    storage_live(erased_read)
+    storage_live(_11)
+    _11 = cast<for<'_0_1> {impl Consume for *mut u32}::read::{vtable_method}<'13>, fn<'_0_1>(&'_0_1 (dyn Consume + '14)) -> u32>(const {impl Consume for *mut u32}::read::{vtable_method}<'13>)
+    read = move _11
+    erased_read = cast<fn<'_0_1>(&'_0_1 (dyn Consume + '15)) -> u32, *const ()>(move read)
+    storage_live(_12)
+    _12 = &core::marker::MetaSized::{vtable}::<*mut u32>
+    ret = test_crate::Consume::{vtable} { size: move size, align: move align, drop: move erased_drop, method_consume: move erased_consume, method_read: move erased_read, super_trait_0: move _12 }
+    return
+}
+
+// Full name: test_crate::{impl Consume for *mut u32}::{vtable}
+static {impl Consume for *mut u32}::{vtable}: test_crate::Consume::{vtable} = {impl Consume for *mut u32}::{vtable}()
+
+// Full name: test_crate::{impl Consume for *mut u32}
+impl Consume for *mut u32 {
+    proof ImpliedClause0: (*mut u32: MetaSized) = {built_in impl MetaSized for *mut u32}
+    vtable: {impl Consume for *mut u32}::{vtable}
+}
+
+// Full name: test_crate::mk
+fn mk() -> Box::<(dyn Consume), Global>
+{
+    let _0: Box::<(dyn Consume), Global>; // return
+    let _1: Box::<(dyn Consume), Global>; // anonymous local
+    let _2: Box::<S, Global>; // anonymous local
+    let _3: S; // anonymous local
+
+    storage_live(_0)
+    storage_live(_1)
+    storage_live(_2)
+    storage_live(_3)
+    _3 = S { _0: const 42u32 }
+    _2 = alloc::boxed::{Box::<S, Global>}::new::<S>(move _3)
+    ↳⚡ unwind_continue
+    _1 = unsize_cast<Box::<S, Global>, Box::<(dyn Consume), Global>, &impl_Consume_for_S::{vtable}>(move _2)
+    conditional_drop[{impl Destruct for Box::<S, Global>}::drop_glue::<S, Global><'0>] _2
+    ↳⚡ unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    _0 = unsize_cast<Box::<(dyn Consume), Global>, Box::<(dyn Consume), Global>,  at []>(move _1)
+    conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'1>] _1
+    ↳⚡ unwind_continue
+    storage_dead(_1)
+    return
+}
+
+// Full name: test_crate::mk_ptr
+fn mk_ptr(x: *mut u32) -> Box::<(dyn Consume), Global>
+{
+    let _0: Box::<(dyn Consume), Global>; // return
+    let x: *mut u32; // arg #1
+    let _2: Box::<(dyn Consume), Global>; // anonymous local
+    let _3: Box::<*mut u32, Global>; // anonymous local
+    let _4: *mut u32; // anonymous local
+
+    storage_live(_0)
+    storage_live(_2)
+    storage_live(_3)
+    storage_live(_4)
+    _4 = copy x
+    _3 = alloc::boxed::{Box::<*mut u32, Global>}::new::<*mut u32>(move _4)
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    _2 = unsize_cast<Box::<*mut u32, Global>, Box::<(dyn Consume), Global>, &{impl Consume for *mut u32}::{vtable}>(move _3)
+    conditional_drop[{impl Destruct for Box::<*mut u32, Global>}::drop_glue::<*mut u32, Global><'0>] _3
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    storage_dead(_4)
+    storage_dead(_3)
+    _0 = unsize_cast<Box::<(dyn Consume), Global>, Box::<(dyn Consume), Global>,  at []>(move _2)
+    conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'1>] _2
+    ↳⚡ storage_dead(x)
+        unwind_continue
+    storage_dead(_2)
+    storage_dead(x)
+    return
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let x: Box::<(dyn Consume), Global>; // local
+    let _v_2: u32; // local
+    let _3: &'3 (dyn Consume + '4); // anonymous local
+    let n: u32; // local
+    let p: Box::<(dyn Consume), Global>; // local
+    let _6: *mut u32; // anonymous local
+    let _7: &'6 mut u32; // anonymous local
+    let _v_8: u32; // local
+    let _9: &'7 (dyn Consume + '8); // anonymous local
+    let _10: unsafe fn(&'3 (dyn Consume + '4)) -> u32; // anonymous local
+    let _11: unsafe fn(&'7 (dyn Consume + '8)) -> u32; // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(x)
+    x = mk()
+    ↳⚡ unwind_continue
+    fake_read(x)
+    storage_live(_v_2)
+    storage_live(_3)
+    _3 = &(*x) with_metadata(copy x.metadata)
+    storage_live(_10)
+    _10 = cast<*const (), unsafe fn(&'3 (dyn Consume + '4)) -> u32>(copy (*_3.metadata).method_read)
+    _v_2 = (copy _10)(move _3)
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'13>] x
+        ↳⚡ storage_dead(_11)
+            storage_dead(_10)
+            unwind_terminate
+        unwind_continue
+    storage_dead(_3)
+    fake_read(_v_2)
+    storage_live(n)
+    n = const 5u32
+    fake_read(n)
+    storage_live(p)
+    storage_live(_6)
+    storage_live(_7)
+    _7 = &mut n
+    _6 = &raw mut (*_7)
+    p = mk_ptr(move _6)
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'13>] x
+        ↳⚡ storage_dead(_11)
+            storage_dead(_10)
+            unwind_terminate
+        unwind_continue
+    storage_dead(_6)
+    fake_read(p)
+    storage_dead(_7)
+    storage_live(_v_8)
+    storage_live(_9)
+    _9 = &(*p) with_metadata(copy p.metadata)
+    storage_live(_11)
+    _11 = cast<*const (), unsafe fn(&'7 (dyn Consume + '8)) -> u32>(copy (*_9.metadata).method_read)
+    _v_8 = (copy _11)(move _9)
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'18>] p
+        ↳⚡ storage_dead(_11)
+            storage_dead(_10)
+            unwind_terminate
+        conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'13>] x
+        ↳⚡ storage_dead(_11)
+            storage_dead(_10)
+            unwind_terminate
+        unwind_continue
+    storage_dead(_9)
+    fake_read(_v_8)
+    _0 = ()
+    storage_dead(_v_8)
+    conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'19>] p
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'13>] x
+        ↳⚡ storage_dead(_11)
+            storage_dead(_10)
+            unwind_terminate
+        unwind_continue
+    storage_dead(p)
+    storage_dead(n)
+    storage_dead(_v_2)
+    conditional_drop[{impl Destruct for Box::<(dyn Consume), Global>}::drop_glue::<(dyn Consume), Global><'20>] x
+    ↳⚡ unwind_continue
+    storage_dead(x)
+    storage_dead(_11)
+    storage_dead(_10)
+    return
+}
+
+
+

--- a/charon/tests/ui/dyn/mono-by-value-self-vtable.rs
+++ b/charon/tests/ui/dyn/mono-by-value-self-vtable.rs
@@ -1,0 +1,42 @@
+//@ charon-args=--monomorphize
+//! Monomorphized variant of `by-value-self-vtable.rs`.
+trait Consume {
+    fn consume(self) -> u32;
+    fn read(&self) -> u32;
+}
+
+struct S(u32);
+impl Consume for S {
+    fn consume(self) -> u32 {
+        self.0
+    }
+    fn read(&self) -> u32 {
+        self.0
+    }
+}
+
+// `Self` being itself a pointer must not be mistaken for the `*mut Self` shim receiver.
+impl Consume for *mut u32 {
+    fn consume(self) -> u32 {
+        unsafe { *self }
+    }
+    fn read(&self) -> u32 {
+        unsafe { **self }
+    }
+}
+
+fn mk() -> Box<dyn Consume> {
+    Box::new(S(42))
+}
+
+fn mk_ptr(x: *mut u32) -> Box<dyn Consume> {
+    Box::new(x)
+}
+
+fn main() {
+    let x = mk();
+    let _v = x.read();
+    let mut n = 5u32;
+    let p = mk_ptr(&mut n);
+    let _v = p.read();
+}

--- a/charon/tests/ui/dyn/mono-dyn-call-by-value.out
+++ b/charon/tests/ui/dyn/mono-dyn-call-by-value.out
@@ -12,15 +12,41 @@ fn core::marker::MetaSized::{vtable}::<()>() -> core::marker::MetaSized::{vtable
 
 static core::marker::MetaSized::{vtable}::<()>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<()>()
 
+struct () {}
+
+// Full name: core::marker::Destruct
+#[lang_item(Destruct)]
+pub trait Destruct<Self>
+{
+    fn drop_glue<'_0_1>;
+    non-dyn-compatible
+}
+
 // Full name: alloc::boxed::Box::<(), Global>
 #[fundamental]
 #[lang_item(OwnedBox)]
 pub opaque type Box::<(), Global>
 
-struct () {}
-
 // Full name: alloc::boxed::Box::{impl Destruct for Box::<(), Global>}::drop_glue::<(), Global>
 unsafe fn {impl Destruct for Box::<(), Global>}::drop_glue::<(), Global><'_0>(_1: &'_0 mut Box::<(), Global>)
+= <opaque>
+
+// Full name: alloc::boxed::Box::<Foo::<(dyn T)>, Global>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<Foo::<(dyn T)>, Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<Foo::<(dyn T)>, Global>}::drop_glue::<Foo::<(dyn T)>, Global>
+unsafe fn {impl Destruct for Box::<Foo::<(dyn T)>, Global>}::drop_glue::<Foo::<(dyn T)>, Global><'_0>(_1: &'_0 mut Box::<Foo::<(dyn T)>, Global>)
+= <opaque>
+
+// Full name: alloc::boxed::Box::<Foo::<()>, Global>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<Foo::<()>, Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<Foo::<()>, Global>}::drop_glue::<Foo::<()>, Global>
+unsafe fn {impl Destruct for Box::<Foo::<()>, Global>}::drop_glue::<Foo::<()>, Global><'_0>(_1: &'_0 mut Box::<Foo::<()>, Global>)
 = <opaque>
 
 // Full name: alloc::boxed::Box::<(dyn T), Global>
@@ -32,10 +58,19 @@ pub opaque type Box::<(dyn T), Global>
 unsafe fn {impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'_0>(_1: &'_0 mut Box::<(dyn T), Global>)
 = <opaque>
 
-// Full name: alloc::boxed::{Box::<(), Global>}::new::<()>
 #[track_caller]
 #[diagnostic_item("box_new")]
-pub fn new::<()>(_1: ()) -> Box::<(), Global>
+pub fn alloc::boxed::{Box::<(), Global>}::new::<()>(_1: ()) -> Box::<(), Global>
+= <opaque>
+
+// Full name: test_crate::Foo::<()>
+struct Foo::<()> {
+  _0: (),
+}
+
+#[track_caller]
+#[diagnostic_item("box_new")]
+pub fn alloc::boxed::{Box::<Foo::<()>, Global>}::new::<Foo::<()>>(_1: Foo::<()>) -> Box::<Foo::<()>, Global>
 = <opaque>
 
 struct test_crate::T::{vtable} {
@@ -179,6 +214,11 @@ impl "impl_T_for_unit" T for () {
     vtable: impl_T_for_unit::{vtable}
 }
 
+// Full name: test_crate::Foo::<(dyn T)>
+struct Foo::<(dyn T)> {
+  _0: (dyn T),
+}
+
 // Full name: test_crate::main
 fn main()
 {
@@ -190,8 +230,20 @@ fn main()
     let _5: &'3 (dyn T + '4); // anonymous local
     let _6: (); // anonymous local
     let _7: Box::<(dyn T), Global>; // anonymous local
-    let _8: unsafe fn(&'3 (dyn T + '4)); // anonymous local
-    let _9: unsafe fn((dyn T + '13)); // anonymous local
+    let f: Box::<Foo::<(dyn T)>, Global>; // local
+    let _9: Box::<Foo::<()>, Global>; // anonymous local
+    let _10: Foo::<()>; // anonymous local
+    let _11: (); // anonymous local
+    let _12: (); // anonymous local
+    let _13: &'5 (dyn T + '6); // anonymous local
+    let _14: (); // anonymous local
+    let _15: (dyn T + '7); // anonymous local
+    let _16: unsafe fn(&'3 (dyn T + '4)); // anonymous local
+    let _17: *mut (dyn T + '16); // anonymous local
+    let _18: unsafe fn(*mut (dyn T + '16)); // anonymous local
+    let _19: unsafe fn(&'5 (dyn T + '6)); // anonymous local
+    let _20: *mut (dyn T + '25); // anonymous local
+    let _21: unsafe fn(*mut (dyn T + '25)); // anonymous local
 
     storage_live(_0)
     _0 = ()
@@ -199,10 +251,10 @@ fn main()
     storage_live(_2)
     storage_live(_3)
     _3 = ()
-    _2 = new::<()>(move _3)
+    _2 = alloc::boxed::{Box::<(), Global>}::new::<()>(move _3)
     ↳⚡ unwind_continue
     b = unsize_cast<Box::<(), Global>, Box::<(dyn T), Global>, &impl_T_for_unit::{vtable}>(move _2)
-    conditional_drop[{impl Destruct for Box::<(), Global>}::drop_glue::<(), Global><'5>] _2
+    conditional_drop[{impl Destruct for Box::<(), Global>}::drop_glue::<(), Global><'8>] _2
     ↳⚡ unwind_continue
     storage_dead(_3)
     storage_dead(_2)
@@ -211,10 +263,10 @@ fn main()
     storage_live(_4)
     storage_live(_5)
     _5 = &(*b) with_metadata(copy b.metadata)
-    storage_live(_8)
-    _8 = cast<*const (), unsafe fn(&'3 (dyn T + '4))>(copy (*_5.metadata).method_by_ref)
-    _4 = (copy _8)(move _5)
-    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'10>] b
+    storage_live(_16)
+    _16 = cast<*const (), unsafe fn(&'3 (dyn T + '4))>(copy (*_5.metadata).method_by_ref)
+    _4 = (copy _16)(move _5)
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'13>] b
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_5)
@@ -222,22 +274,78 @@ fn main()
     storage_live(_6)
     storage_live(_7)
     _7 = move b
-    storage_live(_9)
-    _9 = cast<*const (), unsafe fn((dyn T + '13))>(copy (*_7.metadata).method_by_val)
-    _6 = (copy _9)(move (*_7))
-    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'14>] _7
+    storage_live(_17)
+    _17 = &raw mut (*_7) with_metadata(copy _7.metadata)
+    storage_live(_18)
+    _18 = cast<*const (), unsafe fn(*mut (dyn T + '16))>(copy (*_17.metadata).method_by_val)
+    _6 = (copy _18)(move _17)
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'17>] _7
         ↳⚡ unwind_terminate
-        conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'10>] b
+        conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'13>] b
         ↳⚡ unwind_terminate
         unwind_continue
-    conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'15>] _7
-    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'10>] b
+    conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'18>] _7
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'13>] b
         ↳⚡ unwind_terminate
         unwind_continue
     storage_dead(_7)
     storage_dead(_6)
+    storage_live(f)
+    storage_live(_9)
+    storage_live(_10)
+    storage_live(_11)
+    _11 = ()
+    _10 = Foo::<()> { _0: move _11 }
+    storage_dead(_11)
+    _9 = alloc::boxed::{Box::<Foo::<()>, Global>}::new::<Foo::<()>>(move _10)
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'13>] b
+        ↳⚡ unwind_terminate
+        unwind_continue
+    f = unsize_cast<Box::<Foo::<()>, Global>, Box::<Foo::<(dyn T)>, Global>, &impl_T_for_unit::{vtable}>(move _9)
+    conditional_drop[{impl Destruct for Box::<Foo::<()>, Global>}::drop_glue::<Foo::<()>, Global><'19>] _9
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'13>] b
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_10)
+    storage_dead(_9)
+    fake_read(f)
+    set_type(typeof(f) == Box::<Foo::<(dyn T)>, Global>)
+    storage_live(_12)
+    storage_live(_13)
+    _13 = &(*f)._0 with_metadata(copy f.metadata)
+    storage_live(_19)
+    _19 = cast<*const (), unsafe fn(&'5 (dyn T + '6))>(copy (*_13.metadata).method_by_ref)
+    _12 = (copy _19)(move _13)
+    ↳⚡ conditional_drop[{impl Destruct for Box::<Foo::<(dyn T)>, Global>}::drop_glue::<Foo::<(dyn T)>, Global><'24>] f
+        ↳⚡ unwind_terminate
+        conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'13>] b
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_13)
+    storage_dead(_12)
+    storage_live(_14)
+    storage_live(_15)
+    storage_live(_20)
+    _20 = &raw mut (*f)._0 with_metadata(copy f.metadata)
+    storage_live(_21)
+    _21 = cast<*const (), unsafe fn(*mut (dyn T + '25))>(copy (*_20.metadata).method_by_val)
+    _14 = (copy _21)(move _20)
+    ↳⚡ conditional_drop[{built_in impl Destruct for (dyn T + '29)}::drop_glue<'30>] _15
+        ↳⚡ unwind_terminate
+        conditional_drop[{impl Destruct for Box::<Foo::<(dyn T)>, Global>}::drop_glue::<Foo::<(dyn T)>, Global><'24>] f
+        ↳⚡ unwind_terminate
+        conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'13>] b
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_15)
+    storage_dead(_14)
     _0 = ()
-    conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'16>] b
+    conditional_drop[{impl Destruct for Box::<Foo::<(dyn T)>, Global>}::drop_glue::<Foo::<(dyn T)>, Global><'31>] f
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'13>] b
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(f)
+    conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'32>] b
     ↳⚡ unwind_continue
     storage_dead(b)
     return

--- a/charon/tests/ui/dyn/mono-dyn-call-by-value.out
+++ b/charon/tests/ui/dyn/mono-dyn-call-by-value.out
@@ -1,0 +1,247 @@
+# Final LLBC before serialization:
+
+opaque type core::marker::MetaSized::{vtable}
+
+// Full name: core::marker::MetaSized
+#[fundamental]
+#[lang_item(MetaSized)]
+pub trait MetaSized<Self>
+
+fn core::marker::MetaSized::{vtable}::<()>() -> core::marker::MetaSized::{vtable}
+= <opaque>
+
+static core::marker::MetaSized::{vtable}::<()>: core::marker::MetaSized::{vtable} = core::marker::MetaSized::{vtable}::<()>()
+
+// Full name: alloc::boxed::Box::<(), Global>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<(), Global>
+
+struct () {}
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<(), Global>}::drop_glue::<(), Global>
+unsafe fn {impl Destruct for Box::<(), Global>}::drop_glue::<(), Global><'_0>(_1: &'_0 mut Box::<(), Global>)
+= <opaque>
+
+// Full name: alloc::boxed::Box::<(dyn T), Global>
+#[fundamental]
+#[lang_item(OwnedBox)]
+pub opaque type Box::<(dyn T), Global>
+
+// Full name: alloc::boxed::Box::{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global>
+unsafe fn {impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'_0>(_1: &'_0 mut Box::<(dyn T), Global>)
+= <opaque>
+
+// Full name: alloc::boxed::{Box::<(), Global>}::new::<()>
+#[track_caller]
+#[diagnostic_item("box_new")]
+pub fn new::<()>(_1: ()) -> Box::<(), Global>
+= <opaque>
+
+struct test_crate::T::{vtable} {
+  size: usize,
+  align: usize,
+  drop: *const (),
+  method_by_ref: *const (),
+  method_by_val: *const (),
+  super_trait_0: &'static core::marker::MetaSized::{vtable},
+}
+
+// Full name: test_crate::T
+trait T<Self>
+{
+    proof ImpliedClause0: (Self: MetaSized)
+    vtable: test_crate::T::{vtable}
+}
+
+// Full name: test_crate::{impl T for ()}::by_val
+fn by_val(self: ())
+{
+    let _0: (); // return
+    let self: (); // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::{impl T for ()}::by_val::{vtable_method}
+fn impl_T_for_unit::by_val::{vtable_method}(_1: *mut (dyn T))
+{
+    let _0: (); // return
+    let _1: *mut (dyn T + '0); // arg #1
+    let _2: *mut (); // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(_2)
+    _2 = concretize<*mut (dyn T + '1), *mut ()>(move _1)
+    _0 = by_val(move (*_2))
+    ↳⚡ unwind_continue
+    return
+}
+
+// Full name: test_crate::{impl T for ()}::by_ref
+fn by_ref<'_0>(self: &'_0 ())
+{
+    let _0: (); // return
+    let self: &'1 (); // arg #1
+
+    storage_live(_0)
+    _0 = ()
+    _0 = ()
+    return
+}
+
+// Full name: test_crate::{impl T for ()}::by_ref::{vtable_method}
+fn impl_T_for_unit::by_ref::{vtable_method}<'_0>(_1: &'_0 (dyn T))
+{
+    let _0: (); // return
+    let _1: &'_0 (dyn T + '0); // arg #1
+    let _2: &'_0 (); // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(_2)
+    _2 = concretize<&'_0 (dyn T + '1), &'_0 ()>(move _1)
+    _0 = by_ref<'_0>(move _2)
+    ↳⚡ unwind_continue
+    return
+}
+
+// Full name: test_crate::{impl T for ()}::{vtable_drop_shim}
+unsafe fn {vtable_drop_shim}<'_0>(dyn_self: &'_0 mut (dyn T))
+{
+    let ret: (); // return
+    let dyn_self: &'_0 mut (dyn T + '0); // arg #1
+    let target_self: &'_0 mut (); // local
+
+    storage_live(ret)
+    ret = ()
+    storage_live(target_self)
+    target_self = concretize<&'_0 mut (dyn T + '1), &'_0 mut ()>(move dyn_self)
+    return
+}
+
+// Full name: test_crate::{impl T for ()}::{vtable}
+fn impl_T_for_unit::{vtable}() -> test_crate::T::{vtable}
+{
+    let ret: test_crate::T::{vtable}; // return
+    let size: usize; // local
+    let align: usize; // local
+    let drop: unsafe fn(*mut (dyn T + '0)); // local
+    let erased_drop: *const (); // local
+    let by_ref: fn<'_0_1>(&'_0_1 (dyn T + '1)); // local
+    let erased_by_ref: *const (); // local
+    let by_val: fn(*mut (dyn T + '2)); // local
+    let erased_by_val: *const (); // local
+    let _9: unsafe fn(*mut (dyn T + '5)); // anonymous local
+    let _10: fn<'_0_1>(&'_0_1 (dyn T + '10)); // anonymous local
+    let _11: fn(*mut (dyn T + '14)); // anonymous local
+    let _12: &'static core::marker::MetaSized::{vtable}; // anonymous local
+
+    storage_live(ret)
+    storage_live(size)
+    size = size_of<()>
+    storage_live(align)
+    align = align_of<()>
+    storage_live(drop)
+    storage_live(erased_drop)
+    storage_live(_9)
+    _9 = cast<{vtable_drop_shim}<'4>, unsafe fn(*mut (dyn T + '5))>(const {vtable_drop_shim}<'4>)
+    drop = move _9
+    erased_drop = cast<unsafe fn(*mut (dyn T + '6)), *const ()>(move drop)
+    storage_live(by_ref)
+    storage_live(erased_by_ref)
+    storage_live(_10)
+    _10 = cast<for<'_0_1> impl_T_for_unit::by_ref::{vtable_method}<'9>, fn<'_0_1>(&'_0_1 (dyn T + '10))>(const impl_T_for_unit::by_ref::{vtable_method}<'9>)
+    by_ref = move _10
+    erased_by_ref = cast<fn<'_0_1>(&'_0_1 (dyn T + '11)), *const ()>(move by_ref)
+    storage_live(by_val)
+    storage_live(erased_by_val)
+    storage_live(_11)
+    _11 = cast<impl_T_for_unit::by_val::{vtable_method}, fn(*mut (dyn T + '14))>(const impl_T_for_unit::by_val::{vtable_method})
+    by_val = move _11
+    erased_by_val = cast<fn(*mut (dyn T + '15)), *const ()>(move by_val)
+    storage_live(_12)
+    _12 = &core::marker::MetaSized::{vtable}::<()>
+    ret = test_crate::T::{vtable} { size: move size, align: move align, drop: move erased_drop, method_by_ref: move erased_by_ref, method_by_val: move erased_by_val, super_trait_0: move _12 }
+    return
+}
+
+// Full name: test_crate::{impl T for ()}::{vtable}
+static impl_T_for_unit::{vtable}: test_crate::T::{vtable} = impl_T_for_unit::{vtable}()
+
+// Full name: test_crate::{impl T for ()}
+impl "impl_T_for_unit" T for () {
+    proof ImpliedClause0: ((): MetaSized) = {built_in impl MetaSized for ()}
+    vtable: impl_T_for_unit::{vtable}
+}
+
+// Full name: test_crate::main
+fn main()
+{
+    let _0: (); // return
+    let b: Box::<(dyn T), Global>; // local
+    let _2: Box::<(), Global>; // anonymous local
+    let _3: (); // anonymous local
+    let _4: (); // anonymous local
+    let _5: &'3 (dyn T + '4); // anonymous local
+    let _6: (); // anonymous local
+    let _7: Box::<(dyn T), Global>; // anonymous local
+    let _8: unsafe fn(&'3 (dyn T + '4)); // anonymous local
+    let _9: unsafe fn((dyn T + '13)); // anonymous local
+
+    storage_live(_0)
+    _0 = ()
+    storage_live(b)
+    storage_live(_2)
+    storage_live(_3)
+    _3 = ()
+    _2 = new::<()>(move _3)
+    ↳⚡ unwind_continue
+    b = unsize_cast<Box::<(), Global>, Box::<(dyn T), Global>, &impl_T_for_unit::{vtable}>(move _2)
+    conditional_drop[{impl Destruct for Box::<(), Global>}::drop_glue::<(), Global><'5>] _2
+    ↳⚡ unwind_continue
+    storage_dead(_3)
+    storage_dead(_2)
+    fake_read(b)
+    set_type(typeof(b) == Box::<(dyn T), Global>)
+    storage_live(_4)
+    storage_live(_5)
+    _5 = &(*b) with_metadata(copy b.metadata)
+    storage_live(_8)
+    _8 = cast<*const (), unsafe fn(&'3 (dyn T + '4))>(copy (*_5.metadata).method_by_ref)
+    _4 = (copy _8)(move _5)
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'10>] b
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_5)
+    storage_dead(_4)
+    storage_live(_6)
+    storage_live(_7)
+    _7 = move b
+    storage_live(_9)
+    _9 = cast<*const (), unsafe fn((dyn T + '13))>(copy (*_7.metadata).method_by_val)
+    _6 = (copy _9)(move (*_7))
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'14>] _7
+        ↳⚡ unwind_terminate
+        conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'10>] b
+        ↳⚡ unwind_terminate
+        unwind_continue
+    conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'15>] _7
+    ↳⚡ conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'10>] b
+        ↳⚡ unwind_terminate
+        unwind_continue
+    storage_dead(_7)
+    storage_dead(_6)
+    _0 = ()
+    conditional_drop[{impl Destruct for Box::<(dyn T), Global>}::drop_glue::<(dyn T), Global><'16>] b
+    ↳⚡ unwind_continue
+    storage_dead(b)
+    return
+}
+
+
+

--- a/charon/tests/ui/dyn/mono-dyn-call-by-value.rs
+++ b/charon/tests/ui/dyn/mono-dyn-call-by-value.rs
@@ -1,0 +1,20 @@
+//@ no-default-options
+//@ charon-args=--monomorphize
+
+// this could be Box<dyn FnOnce> but it would make the output a pain
+// to read, so we re-do it by hand instead.
+
+#![feature(unsized_fn_params)]
+trait T {
+    fn by_ref(&self);
+    fn by_val(self);
+}
+impl T for () {
+    fn by_ref(&self) {}
+    fn by_val(self) {}
+}
+fn main() {
+    let b: Box<dyn T> = Box::new(());
+    b.by_ref();
+    (*b).by_val();
+}

--- a/charon/tests/ui/dyn/mono-dyn-call-by-value.rs
+++ b/charon/tests/ui/dyn/mono-dyn-call-by-value.rs
@@ -13,8 +13,15 @@ impl T for () {
     fn by_ref(&self) {}
     fn by_val(self) {}
 }
+
+struct Foo<T: ?Sized>(T);
+
 fn main() {
     let b: Box<dyn T> = Box::new(());
     b.by_ref();
     (*b).by_val();
+
+    let f: Box<Foo<dyn T>> = Box::new(Foo(()));
+    f.0.by_ref();
+    ((*f).0).by_val();
 }


### PR DESCRIPTION
Based on top of #1427 

This is a bit weird, but is what rustc does and avoid gnarly unsized locals.

While the caller of a trait object that takes `self` by values sees the signature `fn(Self, ...Args)`, on the callee side the signature is actually `fn(*mut Self, ...Args)`, which morally is `fn(&own Self, ...Args)`.  This is how rustc chooses to handle unsized function arguments, and for now it seems like an Okay way of doing, so that consumers can at least support it in some homogeneous way.

I would not be opposed to improve the representation in the future to more explicitly describe these cases, though I'm not sure how atm.


rustc source: https://github.com/rust-lang/rust/blob/70222712809cd5cc1718ed8995914a1cbacb6b92/compiler/rustc_middle/src/ty/instance.rs#L101-L106

soteria rust support (for the curious): https://github.com/soteria-tools/soteria/blob/main/soteria-rust/lib/interp.ml#L1125-L1147


