### PR TITLE
Fix crash in layout guarantees for uninhabited enums

### DIFF
--- a/charon/src/transform/add_missing_info/compute_layout_guarantees.rs
+++ b/charon/src/transform/add_missing_info/compute_layout_guarantees.rs
@@ -31,7 +31,7 @@ impl TransformPass for Transform {
                 {
                     fields.iter().map(|field| field.ty.clone()).collect()
                 }
-                TypeDeclKind::Enum(variants) => variants
+                TypeDeclKind::Enum(variants) if !layout.uninhabited => variants
                     .iter_enumerated()
                     .filter(|(id, _)| {
                         layout.variant_layouts[*id]


### PR DESCRIPTION
you forgot a check :3

```rs
//@ charon-args=--monomorphize
pub enum E { A(std::convert::Infallible) }
fn main() {}
// thread 'main' (47206691) panicked at /Users/opale/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/index_vec-0.1.4/src/indexing.rs:37:10:
// index out of bounds: the len is 0 but the index is 0
// note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

